### PR TITLE
Streaming support

### DIFF
--- a/web/pages/api/hello.ts
+++ b/web/pages/api/hello.ts
@@ -10,4 +10,27 @@ export default async function handler(
   res: NextApiResponse<Data>
 ) {
   res.status(200).json({ name: "John Doe" });
+  var es = await fetch("http://127.0.0.1:8787/v1/engines/davinci/completions", {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + "<API KEY>",
+    },
+    method: "POST",
+    body: JSON.stringify({
+      prompt: "HELLO write me a book",
+      temperature: 0.75,
+      top_p: 0.95,
+      max_tokens: 10,
+      stream: true,
+      stop: ["\n\n"],
+    }),
+  });
+
+  const reader = es.body?.pipeThrough(new TextDecoderStream()).getReader();
+
+  while (true) {
+    const res = await reader?.read();
+    if (res?.done) break;
+    console.log("Received", res?.value);
+  }
 }

--- a/worker/src/cache.ts
+++ b/worker/src/cache.ts
@@ -58,8 +58,24 @@ function getCacheState(headers: Headers): CacheHeaders {
 }
 
 export function getCacheSettings(
-  headers: Headers
+  headers: Headers,
+  isStream: boolean
 ): Result<CacheSettings, string> {
+  // streams cannot be cached
+  if (isStream) {
+    return {
+      data: {
+        shouldReadFromCache: false,
+        shouldSaveToCache: false,
+        cacheControl: "no-cache",
+        bucketSettings: {
+          maxSize: 1,
+        },
+      },
+      error: null,
+    };
+  }
+
   try {
     const cacheHeaders = getCacheState(headers);
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -180,23 +180,6 @@ async function logRequest({
   }
 }
 
-async function logResponse(
-  dbClient: SupabaseClient,
-  requestId: string,
-  body: any
-): Promise<void> {
-  console.log(requestId);
-  const { data, error } = await dbClient
-    .from("response")
-    .insert([{ request: requestId, body: body }])
-    .select("id");
-  if (error !== null) {
-    console.error(error, "saf");
-  } else {
-    console.log(data);
-  }
-}
-
 function heliconeHeaders(
   requestResult: Result<string, string>
 ): Record<string, string> {
@@ -281,7 +264,6 @@ async function readResponse(
   }
   try {
     if (!requestSettings.stream) {
-      console.log("NO STREAM", JSON.parse(result));
       return {
         data: JSON.parse(result),
         error: null,
@@ -312,8 +294,15 @@ async function readAndLogResponse(
   dbClient: SupabaseClient
 ): Promise<void> {
   const responseResult = await readResponse(requestSettings, readable);
-  console.log("responseREsult,", responseResult);
-  return logResponse(dbClient, requestId, responseResult);
+  const { data, error } = await dbClient
+    .from("response")
+    .insert([{ request: requestId, body: responseResult }])
+    .select("id");
+  if (error !== null) {
+    console.error(error);
+  } else {
+    console.log(data);
+  }
 }
 
 async function forwardAndLog(

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -338,16 +338,16 @@ async function forwardAndLog(
     undefined,
     undefined,
   ];
-  console.log("result", requestResult);
 
   ctx.waitUntil(
-    readableLog &&
-      readAndLogResponse(
-        requestSettings,
-        readableLog,
-        requestResult.data,
-        dbClient
-      )
+    readableLog && requestResult.data !== null
+      ? readAndLogResponse(
+          requestSettings,
+          readableLog,
+          requestResult.data,
+          dbClient
+        )
+      : Promise.resolve()
   );
 
   return new Response(readable, {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -350,12 +350,13 @@ async function forwardAndLog(
       : Promise.resolve()
   );
 
+  const responseHeaders = new Headers(response.headers);
+  for (const [key, value] of Object.entries(heliconeHeaders(requestResult))) {
+    responseHeaders.set(key, value);
+  }
   return new Response(readable, {
     ...response,
-    headers: {
-      ...heliconeHeaders(requestResult),
-      ...response.headers,
-    },
+    headers: responseHeaders,
   });
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,7 +1,9 @@
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { getCacheSettings } from "./cache";
 import { extractPrompt, Prompt } from "./prompt";
+import { PassThrough } from "stream";
 // import bcrypt from "bcrypt";
+
 export interface Env {
   SUPABASE_SERVICE_ROLE_KEY: string;
   SUPABASE_URL: string;
@@ -181,14 +183,17 @@ async function logRequest({
 async function logResponse(
   dbClient: SupabaseClient,
   requestId: string,
-  body: string
+  body: any
 ): Promise<void> {
+  console.log(requestId);
   const { data, error } = await dbClient
     .from("response")
-    .insert([{ request: requestId, body: JSON.parse(body) }])
+    .insert([{ request: requestId, body: body }])
     .select("id");
   if (error !== null) {
-    console.error(error);
+    console.error(error, "saf");
+  } else {
+    console.log(data);
   }
 }
 
@@ -254,7 +259,65 @@ function removeHeliconeHeaders(request: Headers): Headers {
   return newHeaders;
 }
 
+async function readResponse(
+  requestSettings: RequestSettings,
+  readable: ReadableStream<any>
+): Promise<Result<any, string>> {
+  const reader = await readable?.getReader();
+  let result = "";
+  const MAX_LOOPS = 10_000;
+  let i = 0;
+  while (true) {
+    if (reader === undefined) break;
+    const res = await reader?.read();
+    if (res?.done) break;
+    if (typeof res?.value === "string") {
+      result += res?.value;
+    } else if (res?.value instanceof Uint8Array) {
+      result += new TextDecoder().decode(res?.value);
+    }
+    i++;
+    if (i > MAX_LOOPS) break;
+  }
+  try {
+    if (!requestSettings.stream) {
+      console.log("NO STREAM", JSON.parse(result));
+      return {
+        data: JSON.parse(result),
+        error: null,
+      };
+    }
+    const lines = result.split("\n").filter((line) => line !== "");
+    const data = lines.map((line, i) => {
+      if (i === lines.length - 1) return {};
+
+      return JSON.parse(line.replace("data:", ""));
+    });
+    return {
+      data: data,
+      error: null,
+    };
+  } catch (e) {
+    return {
+      data: null,
+      error: "error parsing response, " + e + ", " + result,
+    };
+  }
+}
+
+async function readAndLogResponse(
+  requestSettings: RequestSettings,
+  readable: ReadableStream<any>,
+  requestId: string,
+  dbClient: SupabaseClient
+): Promise<void> {
+  const responseResult = await readResponse(requestSettings, readable);
+  console.log("responseREsult,", responseResult);
+  return logResponse(dbClient, requestId, responseResult);
+}
+
 async function forwardAndLog(
+  requestSettings: RequestSettings,
   body: string,
   request: Request,
   env: Env,
@@ -282,14 +345,23 @@ async function forwardAndLog(
       ...getHeliconeHeaders(request.headers),
     }),
   ]);
-  const responseBody = await response.text();
-  if (requestResult.data !== null) {
-    ctx.waitUntil(logResponse(dbClient, requestResult.data, responseBody));
-  } else {
-    console.error(requestResult.error);
-  }
+  const [readable, readableLog] = response.body?.tee() ?? [
+    undefined,
+    undefined,
+  ];
+  console.log("result", requestResult);
 
-  return new Response(responseBody, {
+  ctx.waitUntil(
+    readableLog &&
+      readAndLogResponse(
+        requestSettings,
+        readableLog,
+        requestResult.data,
+        dbClient
+      )
+  );
+
+  return new Response(readable, {
     ...response,
     headers: {
       ...heliconeHeaders(requestResult),
@@ -301,12 +373,20 @@ async function forwardAndLog(
 async function uncachedRequest(
   request: Request,
   env: Env,
-  ctx: ExecutionContext
+  ctx: ExecutionContext,
+  requestSettings: RequestSettings
 ): Promise<Response> {
   const result = await extractPrompt(request);
   if (result.data !== null) {
     const { request: formattedRequest, body: body, prompt } = result.data;
-    return await forwardAndLog(body, formattedRequest, env, ctx, prompt);
+    return await forwardAndLog(
+      requestSettings,
+      body,
+      formattedRequest,
+      env,
+      ctx,
+      prompt
+    );
   } else {
     return new Response(result.error, { status: 400 });
   }
@@ -434,15 +514,26 @@ async function recordCacheHit(headers: Headers, env: Env): Promise<void> {
   }
 }
 
+interface RequestSettings {
+  stream: boolean;
+}
+
 export default {
   async fetch(
     request: Request,
     env: Env,
     ctx: ExecutionContext
   ): Promise<Response> {
+    const requestBody = await request.clone().json<{ stream?: boolean }>();
+    const requestSettings = {
+      stream: requestBody.stream ?? false,
+    };
+
     const { data: cacheSettings, error: cacheError } = getCacheSettings(
-      request.headers
+      request.headers,
+      requestBody.stream ?? false
     );
+
     if (cacheError !== null) {
       return new Response(cacheError, { status: 400 });
     }
@@ -460,7 +551,7 @@ export default {
 
     let requestClone = cacheSettings.shouldSaveToCache ? request.clone() : null;
 
-    const response = await uncachedRequest(request, env, ctx);
+    const response = await uncachedRequest(request, env, ctx, requestSettings);
 
     if (cacheSettings.shouldSaveToCache && requestClone) {
       ctx.waitUntil(

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -15,11 +15,11 @@ routes = [
 [env.production.vars]
 SUPABASE_URL = "https://bolqqmqbrciybnypvklh.supabase.co"
 
-[env.devdev]
-name = "helicone-worker-devdev"
+[env.preview]
+name = "helicone-worker-preview"
 routes = [
-	{ pattern = "devdev-oai.hconeai.com", custom_domain = true, zone_name = "hconeai.com" }
+	{ pattern = "preview-oai.hconeai.com", custom_domain = true, zone_name = "hconeai.com" }
 ]
 
-[env.devdev.vars]
+[env.preview.vars]
 SUPABASE_URL = "https://wldkumawyhruufmucrrc.supabase.co"

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -22,4 +22,4 @@ routes = [
 ]
 
 [env.devdev.vars]
-SUPABASE_URL = "https://bolqqmqbrciybnypvklh.supabase.co"
+SUPABASE_URL = "https://wldkumawyhruufmucrrc.supabase.co"

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -14,3 +14,12 @@ routes = [
 
 [env.production.vars]
 SUPABASE_URL = "https://bolqqmqbrciybnypvklh.supabase.co"
+
+[env.devdev]
+name = "helicone-worker-devdev"
+routes = [
+	{ pattern = "devdev-oai.hconeai.com", custom_domain = true, zone_name = "hconeai.com" }
+]
+
+[env.devdev.vars]
+SUPABASE_URL = "https://bolqqmqbrciybnypvklh.supabase.co"


### PR DESCRIPTION
Migrated the response body to fork so that we can in parallel log the response at the same time that it is being sent back to the user. 

Look for this code: 
```typescript
const [readable, readableLog] = response.body?.tee()
```

This is where it all changes.

The current preview branch is now using `https://preview-oai.hconeai.com/v1/chat/completions`

You can test this endpoint with this piece of code (I just threw it in an endpoint and tested it)

```typescript
  var es = await fetch("http://127.0.0.1:8787/v1/engines/davinci/completions", {
    headers: {
      "Content-Type": "application/json",
      Authorization: "Bearer " + "<API KEY>",
    },
    method: "POST",
    body: JSON.stringify({
      prompt: "HELLO write me a book",
      temperature: 0.75,
      top_p: 0.95,
      max_tokens: 10,
      stream: true,
      stop: ["\n\n"],
    }),
  });

  const reader = es.body?.pipeThrough(new TextDecoderStream()).getReader();

  while (true) {
    const res = await reader?.read();
    if (res?.done) break;
    console.log("Received", res?.value);
  }
```

# Frontend
We can view the response if you click on JSON view

![Screenshot 2023-03-13 at 11 43 57 PM](https://user-images.githubusercontent.com/26822232/224917441-b51a37be-2561-4c6f-8c11-98772f2a687c.png)

otherwise it just shows `n/a`

![Screenshot 2023-03-13 at 11 44 26 PM](https://user-images.githubusercontent.com/26822232/224917536-e956939a-c4ca-4fd6-9298-63ca363acda1.png)

Right now there are no front end changes, I will do this in a follow up PR.

But a few things I want to discuss.

1. We need to make it clear that pricing is not being tracked from streaming completions. 
2. Maybe we should add a warning on the dashboard "unknown priced requests - 193" then maybe add a little info icon that shows maybe something like "we dont do pricing for streamed requests" or something like this.