### PR TITLE
Remove columns from get requests

### DIFF
--- a/web/components/templates/requests/requestsPage.tsx
+++ b/web/components/templates/requests/requestsPage.tsx
@@ -285,17 +285,6 @@ const RequestsPage = (props: RequestsPageProps) => {
       format: (value: string) => value,
     },
     {
-      key: "cacheCount",
-      active: false,
-      sortBy: "desc",
-      toSortLeaf: (direction) => ({
-        is_cached: direction,
-      }),
-      label: "Cache hits",
-      minWidth: 170,
-      format: (value: number) => value.toFixed(0),
-    },
-    {
       key: "logProbs",
       active: false,
       label: "Log Prob",

--- a/web/components/templates/requests/useRequestsPage.tsx
+++ b/web/components/templates/requests/useRequestsPage.tsx
@@ -25,7 +25,6 @@ import { Message } from "./requestsPage";
 import { useOrg } from "../../shared/layout/organizationContext";
 
 export type RequestWrapper = {
-  cacheCount: number;
   promptName: string;
   promptRegex: string;
   requestCreatedAt: string;
@@ -41,11 +40,7 @@ export type RequestWrapper = {
   userId: string;
   responseCreatedAt: string;
   responseId: string;
-  userApiKeyHash: string;
   keyName: string;
-  userApiKeyPreview: string;
-  userApiKeyUserId: string;
-
   // these next columns need to be double-defined because of the way the table is built
   error:
     | {
@@ -148,7 +143,6 @@ export const convertRequest = (request: HeliconeRequest, values: string[]) => {
   const obj: RequestWrapper = {
     requestBody: request.request_body,
     responseBody: request.response_body,
-    cacheCount: +request.cache_count,
     promptName: request.prompt_name || "",
     promptRegex: request.prompt_regex || "",
     requestCreatedAt: request.request_created_at,
@@ -161,10 +155,6 @@ export const convertRequest = (request: HeliconeRequest, values: string[]) => {
     responseCreatedAt: request.response_created_at,
     responseId: request.response_id,
     keyName: request.key_name,
-    userApiKeyHash: request.user_api_key_hash,
-    userApiKeyPreview: request.user_api_key_preview,
-    userApiKeyUserId: request.user_api_key_user_id,
-
     // More information about the request
     api: getRequestAndResponse(request),
     error: request.response_body?.error || undefined,

--- a/web/lib/api/graphql/query/heliconeRequest.ts
+++ b/web/lib/api/graphql/query/heliconeRequest.ts
@@ -113,7 +113,6 @@ export async function heliconeRequest(
           id: r.request_user_id,
         }
       : null,
-    cacheHits: r.cache_count,
     properties: r.request_properties
       ? Object.entries(r.request_properties).map(([k, v]) => ({
           name: k,

--- a/web/lib/api/request/request.ts
+++ b/web/lib/api/request/request.ts
@@ -29,13 +29,9 @@ export interface HeliconeRequest {
     [key: string]: Json;
   } | null;
   helicone_user: string | null;
-  user_api_key_preview: string;
-  user_api_key_user_id: string;
-  user_api_key_hash: string;
   prompt_name: string | null;
   prompt_regex: string | null;
   key_name: string;
-  cache_count: number;
   request_prompt: string | null;
   response_prompt: string | null;
   delay_ms: number | null;
@@ -72,18 +68,12 @@ export async function getRequests(
     request.prompt_values as request_prompt_values,
     request.helicone_user as helicone_user,
     response.delay_ms as delay_ms,
-    user_api_keys.api_key_preview as user_api_key_preview,
-    user_api_keys.user_id as user_api_key_user_id,
-    user_api_keys.api_key_hash as user_api_key_hash,
-    user_api_keys.key_name as key_name,
     prompt.name AS prompt_name,
     prompt.prompt AS prompt_regex,
-    (select count(*) from cache_hits ch where ch.request_id = request.id) as cache_count,
     (coalesce(request.body ->>'prompt', request.body ->'messages'->0->>'content'))::text as request_prompt,
     (coalesce(response.body ->'choices'->0->>'text', response.body ->'choices'->0->>'message'))::text as response_prompt
   FROM request
     left join response on request.id = response.request
-    left join user_api_keys on user_api_keys.api_key_hash = request.auth_hash
     left join prompt on request.formatted_prompt_id = prompt.id
   WHERE (
     (${builtFilter.filter})

--- a/web/services/hooks/requests.tsx
+++ b/web/services/hooks/requests.tsx
@@ -26,7 +26,6 @@ const useGetRequests = (
         const currentPageSize = query.queryKey[2] as number;
         const advancedFilter = query.queryKey[3];
         const sortLeaf = query.queryKey[4];
-
         return await fetch("/api/request", {
           method: "POST",
           headers: {

--- a/web/services/lib/filters/frontendFilterDefs.ts
+++ b/web/services/lib/filters/frontendFilterDefs.ts
@@ -105,7 +105,6 @@ export const requestTableFilters: [
   SingleFilterDef<"response">,
   SingleFilterDef<"request">,
   SingleFilterDef<"response">,
-  SingleFilterDef<"user_api_keys">,
   SingleFilterDef<"response">
 ] = [
   {
@@ -141,13 +140,6 @@ export const requestTableFilters: [
     operators: textOperators,
     table: "response",
     column: "body_model",
-    category: "request",
-  },
-  {
-    label: "Key Name",
-    operators: textOperators,
-    table: "user_api_keys",
-    column: "api_key_name",
     category: "request",
   },
   {


### PR DESCRIPTION
This increases speed and fixes the bug where if users had multiple users log with API keys it would show up twice.