### PR TITLE
Support azure custom REST endpoints 

### DIFF
--- a/worker/src/lib/HeliconeProxyRequest/mapper.ts
+++ b/worker/src/lib/HeliconeProxyRequest/mapper.ts
@@ -5,6 +5,13 @@ import { Result } from "../../results";
 import { IHeliconeHeaders } from "../HeliconeHeaders";
 import { RequestWrapper } from "../RequestWrapper";
 import {
+  anthropicPattern,
+  azurePattern,
+  heliconeProxyPattern,
+  localProxyPattern,
+  openAiPattern,
+} from "../consts/Providers";
+import {
   ChatPrompt,
   FormattedPrompt,
   Prompt,
@@ -182,13 +189,6 @@ export class HeliconeProxyRequestMapper {
   }
 
   private validateApiConfiguration(api_base: string | undefined): boolean {
-    const openAiPattern = /^https:\/\/api\.openai\.com\/v\d+\/?$/;
-    const anthropicPattern = /^https:\/\/api\.anthropic\.com\/v\d+\/?$/;
-    const azurePattern =
-      /^(https?:\/\/)?([^.]*\.)?(openai\.azure\.com|azure-api\.net)(\/.*)?$/;
-    const localProxyPattern = /^http:\/\/127\.0\.0\.1:\d+\/v\d+\/?$/;
-    const heliconeProxyPattern = /^https:\/\/oai\.hconeai\.com\/v\d+\/?$/;
-
     return (
       api_base === undefined ||
       openAiPattern.test(api_base) ||

--- a/worker/src/lib/consts/Providers.ts
+++ b/worker/src/lib/consts/Providers.ts
@@ -1,0 +1,14 @@
+const openAiPattern = /^https:\/\/api\.openai\.com\/v\d+\/?$/;
+const anthropicPattern = /^https:\/\/api\.anthropic\.com\/v\d+\/?$/;
+const azurePattern =
+  /^(https?:\/\/)?([^.]*\.)?(openai\.azure\.com|azure-api\.net)(\/.*)?$/;
+const localProxyPattern = /^http:\/\/127\.0\.0\.1:\d+\/v\d+\/?$/;
+const heliconeProxyPattern = /^https:\/\/oai\.hconeai\.com\/v\d+\/?$/;
+
+export {
+  openAiPattern,
+  anthropicPattern,
+  azurePattern,
+  localProxyPattern,
+  heliconeProxyPattern,
+};

--- a/worker/src/lib/providerCalls/call.ts
+++ b/worker/src/lib/providerCalls/call.ts
@@ -55,7 +55,6 @@ export async function callProvider(props: CallProps): Promise<Response> {
     setTimeout(() => controller.abort(), 1000 * 60 * 30);
     response = await fetch(new_url.href, { ...init, signal });
   } else {
-    console.log(`New: ${new_url.href}`);
     response = await fetch(new_url.href, init);
   }
 

--- a/worker/src/lib/providerCalls/call.ts
+++ b/worker/src/lib/providerCalls/call.ts
@@ -1,4 +1,5 @@
 import { HeliconeProxyRequest } from "../HeliconeProxyRequest/mapper";
+import { azurePattern } from "../consts/Providers";
 
 export interface CallProps {
   headers: Headers;
@@ -38,9 +39,11 @@ export async function callProvider(props: CallProps): Promise<Response> {
     props;
   const apiBaseUrl = new URL(apiBase.replace(/\/$/, "")); // remove trailing slash if any
 
-  const new_url = new URL(
-    `${apiBaseUrl.origin}${originalUrl.pathname}${originalUrl.search}`
-  );
+  const new_url = azurePattern.test(apiBase)
+    ? apiBaseUrl
+    : new URL(
+        `${apiBaseUrl.origin}${originalUrl.pathname}${originalUrl.search}`
+      );
 
   const baseInit = { method, headers: removeHeliconeHeaders(headers) };
   const init = method === "GET" ? { ...baseInit } : { ...baseInit, body };
@@ -52,6 +55,7 @@ export async function callProvider(props: CallProps): Promise<Response> {
     setTimeout(() => controller.abort(), 1000 * 60 * 30);
     response = await fetch(new_url.href, { ...init, signal });
   } else {
+    console.log(`New: ${new_url.href}`);
     response = await fetch(new_url.href, init);
   }
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/ai-services/openai/reference

The endpoints look like:  https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME/completions?api-version=2023-05-15

But our current logic strips the entire ending and forces it to be:
https://YOUR_RESOURCE_NAME.openai.azure.com/v1/chat/completions

This causes a 404. The azure endpoints require the url structure. The model is not even in the body. Luckily with Scotts recently change, the model name will be retrieved from the response first. 
