### PR TITLE
Update TS openai code sample to v4

### DIFF
--- a/web/components/templates/home/codeSnippet.tsx
+++ b/web/components/templates/home/codeSnippet.tsx
@@ -25,21 +25,13 @@ const CODE_CONVERTS = {
   }'
   `,
   typescript: (key: string) => `
-  import { Configuration, OpenAIApi } from "openai";
-  
-  const configuration = new Configuration({
-    apiKey: process.env.OPENAI_API_KEY,
-    // Add a basePath to the Configuration
-    basePath: "${BASE_PATH}",
-    baseOptions: {
-      headers: {
-        // Add your Helicone API Key
-        "Helicone-Auth": "Bearer ${key}",
-      },
-    }
-  });
-  
-  const openai = new OpenAIApi(configuration);`,
+  import OpenAI from "openai";
+  const openai = new OpenAI({
+    baseURL: 'https://oai.hconeai.com/v1',
+    defaultHeaders: {
+      'Helicone-Auth': \`Bearer ${process.env.HELICONE_API_KEY}\`,
+    });
+    `,
 
   python: (key: string) => `
   openai.api_base = "${BASE_PATH}"

--- a/web/components/templates/home/codeSnippet.tsx
+++ b/web/components/templates/home/codeSnippet.tsx
@@ -29,7 +29,7 @@ const CODE_CONVERTS = {
   const openai = new OpenAI({
     baseURL: 'https://oai.hconeai.com/v1',
     defaultHeaders: {
-      'Helicone-Auth': \`Bearer ${process.env.HELICONE_API_KEY}\`,
+      'Helicone-Auth': 'Bearer ' + process.env.HELICONE_API_KEY,
     });
     `,
 


### PR DESCRIPTION
Update the code snippet in Helicone's Onboarding to reflect openai's npm package v4 configuration from v3.

https://github.com/openai/openai-node/discussions/217

Prev:
<img width="875" alt="Screenshot 2023-10-09 at 1 07 44 PM" src="https://github.com/Helicone/helicone/assets/83605543/924bd10e-35ab-4a7a-a9e2-590f11b19fec">
