### PR TITLE
Add claude pricing & fix anthropic docs

### DIFF
--- a/docs/getting-started/integration-method/anthropic.mdx
+++ b/docs/getting-started/integration-method/anthropic.mdx
@@ -33,7 +33,7 @@ title: "Anthropic"
     Change the api base and add a Helicone-Auth header
     ```typescript
   const anthropic = new Anthropic({
-    baseURL: "https://anthropic.hconeai.com/v1",
+    baseURL: "https://anthropic.hconeai.com/",
     apiKey: "my api key",
     defaultHeaders: {
       "Helicone-Auth": "Bearer <HELICONE_API_KEY>",

--- a/docs/getting-started/integration-method/anthropic.mdx
+++ b/docs/getting-started/integration-method/anthropic.mdx
@@ -9,7 +9,7 @@ title: "Anthropic"
     import anthropic
     client = anthropic.Client(
         api_key="<Anthropic API Key>",
-        api_url="https://anthropic.hconeai.com/v1"
+        base_url="https://anthropic.hconeai.com/v1"
     )
     res = client._request_as_json(
         "post",

--- a/web/lib/api/metrics/costCalc.ts
+++ b/web/lib/api/metrics/costCalc.ts
@@ -1,6 +1,7 @@
 import { Database } from "../../../supabase/database.types";
 import { ModelMetrics } from "./modelMetrics";
 
+// Note: all pricing is per 1k tokens, make sure to divide Anthropic pricing by 1000 as it is per 1M tokens
 const COSTS_PROMPT = {
   ada: 0.0004,
   babbage: 0.0005,
@@ -13,9 +14,14 @@ const COSTS_PROMPT = {
   "gpt-3.5-turbo-0613": 0.0015,
   "gpt-3.5-turbo-16k-0613": 0.003,
   "text-embedding-ada-002-v2": 0.0001,
-  //TODO add clauden https://console.anthropic.com/account/pricing
+  // Latest anthropic pricing from July 2023 (https://www-files.anthropic.com/production/images/model_pricing_july2023.pdf)
+  "claude-instant-1	": 0.00163,
+  "claude-instant-1.2": 0.00163,
+  "claude-2": 0.01102,
+  "claude-2.0": 0.01102,
 };
 
+// Note: all pricing is per 1k tokens, make sure to divide Anthropic pricing by 1000 as it is per 1M tokens
 const COSTS_COMPLETIONS = {
   ada: 0.0004,
   babbage: 0.0005,
@@ -27,7 +33,11 @@ const COSTS_COMPLETIONS = {
   "gpt-4-32k-0613": 0.12,
   "gpt-3.5-turbo-0613": 0.002,
   "gpt-3.5-turbo-16k-0613": 0.004,
-  //TODO add claude https://console.anthropic.com/account/pricing
+  // Latest anthropic pricing from July 2023 (https://www-files.anthropic.com/production/images/model_pricing_july2023.pdf)
+  "claude-instant-1	": 0.00551,
+  "claude-instant-1.2": 0.00551,
+  "claude-2": 0.03268,
+  "claude-2.0": 0.03268,
 };
 
 const OPENAI_FINETUNE_COSTS_PROMPT = {

--- a/web/lib/sql/constants.ts
+++ b/web/lib/sql/constants.ts
@@ -20,6 +20,10 @@ sum(
     WHEN (${table}.model LIKE '%gpt-4%') THEN 0.03 * ${table}.prompt_tokens + 0.06 * ${table}.completion_tokens
     WHEN (${table}.model LIKE '%claude-v1%') THEN 0.0163 * ${table}.prompt_tokens + 0.0551 * ${table}.completion_tokens
     WHEN (${table}.model LIKE '%claude-instant-v1%') THEN 0.01102 * ${table}.prompt_tokens + 0.03268 * ${table}.completion_tokens
+    WHEN (${table}.model LIKE '%claude-2%') THEN 0.01102 * ${table}.prompt_tokens + 0.03268 * ${table}.completion_tokens
+    WHEN (${table}.model LIKE '%claude-instant-1%') THEN 0.00163 * ${table}.prompt_tokens + 0.00551 * ${table}.completion_tokens
+    WHEN (${table}.model LIKE '%claude-2.0%') THEN 0.01102 * ${table}.prompt_tokens + 0.03268 * ${table}.completion_tokens
+    WHEN (${table}.model LIKE '%claude-instant-1.2%') THEN 0.00163 * ${table}.prompt_tokens + 0.00551 * ${table}.completion_tokens
     ELSE 0
   END
   ) / 1000

--- a/worker/src/lib/limits/check.ts
+++ b/worker/src/lib/limits/check.ts
@@ -24,6 +24,10 @@ sum(
     WHEN (${table}.model LIKE '%gpt-4%') THEN 0.03 * ${table}.prompt_tokens + 0.06 * ${table}.completion_tokens
     WHEN (${table}.model LIKE '%claude-v1%') THEN 0.0163 * ${table}.prompt_tokens + 0.0551 * ${table}.completion_tokens
     WHEN (${table}.model LIKE '%claude-instant-v1%') THEN 0.01102 * ${table}.prompt_tokens + 0.03268 * ${table}.completion_tokens
+    WHEN (${table}.model LIKE '%claude-2%') THEN 0.01102 * ${table}.prompt_tokens + 0.03268 * ${table}.completion_tokens
+    WHEN (${table}.model LIKE '%claude-instant-1%') THEN 0.00163 * ${table}.prompt_tokens + 0.00551 * ${table}.completion_tokens
+    WHEN (${table}.model LIKE '%claude-2.0%') THEN 0.01102 * ${table}.prompt_tokens + 0.03268 * ${table}.completion_tokens
+    WHEN (${table}.model LIKE '%claude-instant-1.2%') THEN 0.00163 * ${table}.prompt_tokens + 0.00551 * ${table}.completion_tokens
     ELSE 0
   END
   ) / 1000


### PR DESCRIPTION
This PR will add claude pricing to wherever file I found have anything related to cost. This should close #909. I've also fix some docs problem related to integrating Helicone with Anthropic client in both Python and Node (TS), this should close #883.

If any of my implementation is not up to your standard, or need something to change please let me know!

p.s. I think you can change your `getTokenCount` function in worker folder to use [anthropic typescript tokenizer](https://github.com/anthropics/anthropic-tokenizer-typescript) instead of running it with Python on another instances.