### PR TITLE
Add anthropic tokenizer in worker

### DIFF
--- a/worker/package.json
+++ b/worker/package.json
@@ -24,6 +24,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@anthropic-ai/tokenizer": "^0.0.4",
     "@clickhouse/client-common": "^0.2.1",
     "@clickhouse/client-web": "^0.2.2",
     "@supabase/supabase-js": "^2.1.1",
@@ -39,6 +40,7 @@
     "events": "^3.3.0",
     "gpt3-tokenizer": "^1.1.5",
     "itty-router": "^4.0.13",
+    "js-tiktoken": "^1.0.7",
     "pg": "^8.11.2",
     "prettier": "^2.8.7",
     "yarn": "^1.22.19"

--- a/worker/src/lib/dbLogger/tokenCounter.ts
+++ b/worker/src/lib/dbLogger/tokenCounter.ts
@@ -1,40 +1,34 @@
 import { Provider } from "../..";
+import claudeRanks from "@anthropic-ai/tokenizer/claude.json";
 import GPT3Tokenizer from "gpt3-tokenizer";
+import { Tiktoken } from "js-tiktoken";
+
+// Moved all the tokenizer here so it won't be loaded for every request
+const openAITokenizer = new GPT3Tokenizer({ type: "gpt3" });
+// Anthropic tokenizer is loaded by js-tiktoken as the library only supports WASM
+// https://github.com/anthropics/anthropic-tokenizer-typescript/issues/6
+const anthropicTokenizer = new Tiktoken({
+  bpe_ranks: claudeRanks.bpe_ranks,
+  special_tokens: claudeRanks.special_tokens,
+  pat_str: claudeRanks.pat_str,
+});
 
 export async function getTokenCount(
   inputText: string,
   provider: Provider,
-  tokenCalcUrl: string
+  _tokenCalcUrl: string
 ): Promise<number> {
+  if (!inputText) return 0;
+
   if (provider === "OPENAI") {
     if (!inputText) return 0;
-    const tokenizer = new GPT3Tokenizer({ type: "gpt3" }); // or 'codex'
     const encoded: { bpe: number[]; text: string[] } =
-      tokenizer.encode(inputText);
+      openAITokenizer.encode(inputText);
     return encoded.bpe.length;
   } else if (provider === "ANTHROPIC") {
-    try {
-      return fetch(tokenCalcUrl, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          text: inputText,
-        }),
-      })
-        .then((res) =>
-          res.json<{
-            count: number;
-          }>()
-        )
-        .then((res) => {
-          return res.count;
-        });
-    } catch (e) {
-      console.error(e);
-      return 0;
-    }
+    // Normalize the potentially unicode input to Anthropic standard of normalization
+    // https://github.com/anthropics/anthropic-tokenizer-typescript/blob/bd241051066ea37120f2898419e3fc8662fab280/index.ts#L7C19-L7C19
+    return anthropicTokenizer.encode(inputText.normalize("NFKC"), "all").length;
   } else {
     throw new Error(`Invalid provider: ${provider}`);
   }

--- a/worker/yarn.lock
+++ b/worker/yarn.lock
@@ -15,6 +15,14 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@anthropic-ai/tokenizer@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/tokenizer/-/tokenizer-0.0.4.tgz#d1f5dab07bbf9289414dad1f7c57b812b27bb857"
+  integrity sha512-EHRKbxlxlc8W4KCBEseByJ7YwyYCmgu9OyN59H9+IYIGPoKv8tXyQXinkeGDI+cI8Tiuz9wk2jZb/kK7AyvL7g==
+  dependencies:
+    "@types/node" "^18.11.18"
+    tiktoken "^1.0.10"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.13":
   version "7.22.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
@@ -967,6 +975,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.6.0.tgz#9d7daa855d33d4efec8aea88cd66db1c2f0ebe16"
   integrity sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==
 
+"@types/node@^18.11.18":
+  version "18.18.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.5.tgz#afc0fd975df946d6e1add5bbf98264225b212244"
+  integrity sha512-4slmbtwV59ZxitY4ixUZdy1uRLf9eSIvBWPQxNjhHYWEtn0FryfKpyS2cvADYXTayWdKEIsJengncrVvkI4I6A==
+
 "@types/phoenix@^1.5.4":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@types/phoenix/-/phoenix-1.6.1.tgz#9551cd77a8f4c70c5d81db899f2af762066aabde"
@@ -1357,7 +1370,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.3.1:
+base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -3150,6 +3163,13 @@ jest@^29.5.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
+js-tiktoken@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/js-tiktoken/-/js-tiktoken-1.0.7.tgz#56933fcd2093e8304060dfde3071bda91812e6f5"
+  integrity sha512-biba8u/clw7iesNEWLOLwrNGoBP2lA+hTaBLs/D45pJdUPFXyxD6nhcDVtADChghv4GgyAiMKYMiRx7x6h7Biw==
+  dependencies:
+    base64-js "^1.5.1"
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4253,6 +4273,11 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
+
+tiktoken@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/tiktoken/-/tiktoken-1.0.10.tgz#d5ade07bc19f4424c404646b606e64674b0df5ef"
+  integrity sha512-gF8ndTCNu7WcRFbl1UUWaFIB4CTXmHzS3tRYdyUYF7x3C6YR6Evoao4zhKDmWIwv2PzNbzoQMV8Pxt+17lEDbA==
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
This PR will add anthropic tokenizer to worker, such that it does not need another service running just to tokenize anthropic models.

As always if there's any question, or changes I need to make, please do tell me!

p.s. Seems like wrangler now supports WASM, and that could (maybe) make the perf slightly better? [tiktoken npm library already supports it](https://github.com/dqbd/tiktoken#cloudflare-workers)