### PR TITLE
Change image syntax

### DIFF
--- a/docs/features/jobs/quick-start.mdx
+++ b/docs/features/jobs/quick-start.mdx
@@ -76,15 +76,15 @@ curl --request POST \
 # Viewing Jobs
 
 By navigating to [helicone.ai/jobs](https://www.helicone.ai/job), you can view all your jobs along with their current status.
-![](images/jobs/table.png)
+![](/images/jobs/table.png)
 
 Clicking on a specific job will redirect you to the job page where you can observe the nodes and their respective status.
 
 This can be viewed in both a list format
-![](images/jobs/list.png)
+![](/images/jobs/list.png)
 
 and a graphical representation
-![](images/jobs/graph.png)
+![](/images/jobs/graph.png)
 
 # Roadmap
 


### PR DESCRIPTION
For images, syntax for images include a `/` before the relative path. For example, 
```
![](/images/IMAGENAME.png)
```
instead of 
```
![](images/IMAGENAME.png)
```