### PR TITLE
Fix Azure baseURL field in docs

### DIFF
--- a/docs/getting-started/integration-method/azure.mdx
+++ b/docs/getting-started/integration-method/azure.mdx
@@ -43,13 +43,13 @@ openai.ChatCompletion.create(
   <Accordion title="OpenAI v4+">
     ```typescript
     const openai = new OpenAI({
-      baseURL: "https://oai.hconeai.com/openai/deployments/DEPLOYMENTNAME/chat/completions",
+      baseURL: "https://oai.hconeai.com/openai/deployments/[DEPLOYMENTNAME]",
       defaultHeaders: {
         "Helicone-Auth": `Bearer [HELICONE_API_KEY]`,
         "Helicone-OpenAI-API-Base": "https://[AZURE_DOMAIN].openai.azure.com",
         "api-key": "[AZURE_API_KEY]",
       },
-      defaultQuery: { "api-version": "2023-03-15-preview" },
+      defaultQuery: { "api-version": "[API_VERSION]" },
     });
     ```
   </Accordion>


### PR DESCRIPTION
Helicone seems to be adding the `/chat/completions` part automatically.  Request is failing if we include it in the URL.