### PR TITLE
cleaned up cache code

### DIFF
--- a/worker/src/db/DBWrapper.ts
+++ b/worker/src/db/DBWrapper.ts
@@ -1,9 +1,9 @@
 import { SupabaseClient, createClient } from "@supabase/supabase-js";
-import { Database, Json } from "../../supabase/database.types";
 import { Env, hash } from "..";
+import { Database } from "../../supabase/database.types";
 import { AuthParams } from "../lib/dbLogger/DBLoggable";
+import { SecureCacheEnv, getAndStoreInCache } from "../lib/secureCache";
 import { Result, err, ok } from "../results";
-import { SecureCacheEnv, getFromCache, storeInCache } from "../lib/secureCache";
 import { RateLimiter } from "./RateLimiter";
 
 async function getHeliconeApiKeyRow(
@@ -169,6 +169,29 @@ export class DBWrapper {
     return ok(this.rateLimiter);
   }
 
+  private async _getAuthParams(): Promise<Result<AuthParams, string>> {
+    switch (this.auth._type) {
+      case "jwt":
+        if (!this.auth.orgId) {
+          return err(
+            "Helicone organization id is required for JWT authentication."
+          );
+        }
+        return getHeliconeJwtAuthParams(
+          this.supabaseClient,
+          this.auth.orgId,
+          this.auth.token
+        );
+
+      case "bearer":
+        return this.auth._bearerType === "heliconeProxyKey"
+          ? getHeliconeProxyKeyRow(this.supabaseClient, this.auth.token)
+          : getHeliconeApiKeyRow(this.supabaseClient, this.auth.token);
+      default:
+        return err("Invalid authentication.");
+    }
+  }
+
   async getAuthParams(): Promise<Result<AuthParams, string>> {
     if (this.authParams !== undefined) {
       return {
@@ -177,56 +200,17 @@ export class DBWrapper {
       };
     }
     const cacheKey = (await hash(JSON.stringify(this.auth))).substring(0, 32);
-    const cachedAuthParams = await getFromCache(cacheKey, this.secureCacheEnv);
-    if (cachedAuthParams !== null) {
-      return {
-        data: JSON.parse(cachedAuthParams),
-        error: null,
-      };
-    }
-
-    let authParams: Result<AuthParams, string> | undefined;
-    switch (this.auth._type) {
-      case "jwt":
-        if (!this.auth.orgId) {
-          return {
-            data: null,
-            error:
-              "Helicone organization id is required for JWT authentication.",
-          };
-        }
-        authParams = await getHeliconeJwtAuthParams(
-          this.supabaseClient,
-          this.auth.orgId,
-          this.auth.token
-        );
-        break;
-
-      case "bearer":
-        authParams =
-          this.auth._bearerType === "heliconeProxyKey"
-            ? await getHeliconeProxyKeyRow(this.supabaseClient, this.auth.token)
-            : await getHeliconeApiKeyRow(this.supabaseClient, this.auth.token);
-        break;
-
-      default:
-        return { data: null, error: "Invalid authentication." };
-    }
+    const authParams = await getAndStoreInCache(
+      cacheKey,
+      this.secureCacheEnv,
+      async () => this._getAuthParams()
+    );
 
     if (!authParams || authParams.error || !authParams.data) {
-      return {
-        data: null,
-        error: authParams?.error || "Invalid authentication.",
-      };
+      return err(authParams?.error || "Invalid authentication.");
     }
 
-    await storeInCache(
-      cacheKey,
-      JSON.stringify(authParams.data),
-      this.secureCacheEnv
-    );
     this.authParams = authParams.data;
-
     return authParams;
   }
 
@@ -238,32 +222,27 @@ export class DBWrapper {
     if (authParams.error !== null) {
       return err(authParams.error);
     }
-    const cachedTier = await getFromCache(
+
+    const tier = await getAndStoreInCache<string>(
       `tier-${authParams.data.organizationId}`,
-      this.secureCacheEnv
+      this.secureCacheEnv,
+      async () => {
+        const { data, error } = await this.supabaseClient
+          .from("organization")
+          .select("*")
+          .eq("id", authParams.data.organizationId)
+          .single();
+
+        if (error !== null) {
+          return err(error.message);
+        }
+        return ok(data?.tier ?? "free");
+      }
     );
-
-    if (cachedTier !== null) {
-      this.tier = cachedTier;
-      return ok(this.tier);
+    if (tier.error !== null) {
+      return err(tier.error);
     }
-
-    const { data, error } = await this.supabaseClient
-      .from("organization")
-      .select("*")
-      .eq("id", authParams.data.organizationId)
-      .single();
-
-    if (error !== null) {
-      return err(error.message);
-    }
-    this.tier = data?.tier ?? "free";
-
-    await storeInCache(
-      `tier-${authParams.data.organizationId}`,
-      this.tier,
-      this.secureCacheEnv
-    );
+    this.tier = tier.data;
 
     return ok(this.tier);
   }

--- a/worker/src/lib/RequestWrapper.ts
+++ b/worker/src/lib/RequestWrapper.ts
@@ -7,7 +7,7 @@ import { SupabaseClient, createClient } from "@supabase/supabase-js";
 import { Env, hash } from "..";
 import { Database } from "../../supabase/database.types";
 import { HeliconeAuth } from "../db/DBWrapper";
-import { Result } from "../results";
+import { Result, err } from "../results";
 import { HeliconeHeaders } from "./HeliconeHeaders";
 import { checkLimits } from "./limits/check";
 import { getAndStoreInCache } from "./secureCache";
@@ -263,10 +263,7 @@ export class RequestWrapper {
         async () => await this.getProviderKeyFromProxy(authKey, env)
       );
       if (error || !data || !data.providerKey || !data.proxyKeyId) {
-        return {
-          data: null,
-          error: `Proxy key not found. Error: ${error}`,
-        };
+        return err(`Proxy key not found. Error: ${error}`);
       }
       const providerKeyRow = data;
 

--- a/worker/src/lib/secureCache.ts
+++ b/worker/src/lib/secureCache.ts
@@ -86,11 +86,11 @@ export async function getFromCache(
   return decrypt(JSON.parse(encrypted), env);
 }
 
-export async function getAndStoreInCache<T>(
+export async function getAndStoreInCache<T, K>(
   key: string,
   env: SecureCacheEnv,
-  fn: () => Promise<Result<T, string>>
-): Promise<Result<T, string>> {
+  fn: () => Promise<Result<T, K>>
+): Promise<Result<T, K>> {
   const cached = await getFromCache(key, env);
   if (cached !== null) {
     return ok(JSON.parse(cached) as T);

--- a/worker/src/lib/secureCache.ts
+++ b/worker/src/lib/secureCache.ts
@@ -93,7 +93,6 @@ export async function getAndStoreInCache<T>(
 ): Promise<Result<T, string>> {
   const cached = await getFromCache(key, env);
   if (cached !== null) {
-    console.log("Using cached value");
     return ok(JSON.parse(cached) as T);
   }
   const value = await fn();

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -80,6 +80,7 @@ routes = [
 	{ pattern = "api_staging.hconeai.com", custom_domain = true, zone_name = "hconeai.com" },
 	{ pattern = "gateway_staging.hconeai.com", custom_domain = true, zone_name = "hconeai.com" },
 	{ pattern = "2yfv_staging.hconeai.com", custom_domain = true, zone_name = "hconeai.com" },
+	{ pattern = "2yfv_staging2.hconeai.com", custom_domain = true, zone_name = "hconeai.com" },
 ]
 
 kv_namespaces = [

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -42,6 +42,7 @@ routes = [
 	{ pattern = "anthropic.hconeai.com", custom_domain = true, zone_name = "hconeai.com" },
 	{ pattern = "api.hconeai.com", custom_domain = true, zone_name = "hconeai.com" },
 	{ pattern = "gateway.hconeai.com", custom_domain = true, zone_name = "hconeai.com" },
+	{ pattern = "2yfv.hconeai.com", custom_domain = true, zone_name = "hconeai.com" },
 ]
 
 durable_objects.bindings = [
@@ -78,6 +79,7 @@ routes = [
 	{ pattern = "anthropic_staging.hconeai.com", custom_domain = true, zone_name = "hconeai.com" },
 	{ pattern = "api_staging.hconeai.com", custom_domain = true, zone_name = "hconeai.com" },
 	{ pattern = "gateway_staging.hconeai.com", custom_domain = true, zone_name = "hconeai.com" },
+	{ pattern = "2yfv_staging.hconeai.com", custom_domain = true, zone_name = "hconeai.com" },
 ]
 
 kv_namespaces = [


### PR DESCRIPTION
I created a function that allows us to easily wrap any call with our secure cache so that we can secure store stuff in cache quickly without a lot of code

```ts
export async function getAndStoreInCache<T, K>(
  key: string,
  env: SecureCacheEnv,
  fn: () => Promise<Result<T, K>>
): Promise<Result<T, K>> {
  const cached = await getFromCache(key, env);
  if (cached !== null) {
    return ok(JSON.parse(cached) as T);
  }
  const value = await fn();
  if (value.error !== null) {
    return value;
  }

  await storeInCache(key, JSON.stringify(value.data), env);
  return value;
}

```

to use it just do this 
```ts
    const { data, error } = await getAndStoreInCache(
        `getProviderKeyFromProxy-${authKey}`,
        env,
        async () => await this.getProviderKeyFromProxy(authKey, env)
      );
```

This will execute the function passed in and if it fails or returns an error it does not cache. But just return the error. It also allows us to VERY easily wrap any call into our cache