### PR TITLE
Docs: Fixed typescript config for Langchain

### DIFF
--- a/docs/features/advanced-usage/caching.mdx
+++ b/docs/features/advanced-usage/caching.mdx
@@ -63,10 +63,8 @@ import { Configuration, OpenAIApi } from "openai";
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,
   basePath: "https://oai.hconeai.com/v1",
-  baseOptions: {
-    headers: {
-      "Helicone-Cache-Enabled": "true",
-    },
+  defaultHeaders: {
+    "Helicone-Cache-Enabled": "true",
   },
 });
 const openai = new OpenAIApi(configuration);
@@ -135,11 +133,9 @@ import { Configuration, OpenAIApi } from "openai";
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,
   basePath: "https://oai.hconeai.com/v1",
-  baseOptions: {
-    headers: {
-      "Helicone-Cache-Enabled": "true",
-      "Helicone-Cache-Bucket-Max-Size": "5",
-    },
+  defaultHeaders: {
+    "Helicone-Cache-Enabled": "true",
+    "Helicone-Cache-Bucket-Max-Size": "5",
   },
 });
 const openai = new OpenAIApi(configuration);

--- a/docs/features/advanced-usage/custom-properties.mdx
+++ b/docs/features/advanced-usage/custom-properties.mdx
@@ -59,13 +59,11 @@ import { Configuration, OpenAIApi } from "openai";
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,
   basePath: "https://oai.hconeai.com/v1",
-  baseOptions: {
-    headers: {
-      "Helicone-Auth": "Bearer HELICONE_API_KEY"
-      "Helicone-Property-Session": "24",
-      "Helicone-Property-Conversation": "support_issue_2",
-      "Helicone-Property-App": "mobile",
-    },
+  defaultHeaders: {
+    "Helicone-Auth": "Bearer HELICONE_API_KEY"
+    "Helicone-Property-Session": "24",
+    "Helicone-Property-Conversation": "support_issue_2",
+    "Helicone-Property-App": "mobile",
   },
 });
 const openai = new OpenAIApi(configuration);
@@ -75,7 +73,7 @@ const openai = new OpenAIApi(configuration);
 llm = ChatOpenAI(
     openai_api_key="<OPENAI_API_KEY>",
     openai_api_base="https://oai.hconeai.com/v1",
-    headers={
+    default_headers={
         "Helicone-Auth": "Bearer <HELICONE_API_KEY>"
         "Helicone-Property-Type": "Course Outline"
     }

--- a/docs/features/advanced-usage/custom-rate-limits.mdx
+++ b/docs/features/advanced-usage/custom-rate-limits.mdx
@@ -53,11 +53,9 @@ import { Configuration, OpenAIApi } from "openai";
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,
   basePath: "https://oai.hconeai.com/v1",
-  baseOptions: {
-    headers: {
-      "Helicone-Property-IP": "111.1.1.1",
-      "Helicone-RateLimit-Policy": "1000;w=60;s=ip",
-    },
+  defaultHeaders: {
+    "Helicone-Property-IP": "111.1.1.1",
+    "Helicone-RateLimit-Policy": "1000;w=60;s=ip",
   },
 });
 const openai = new OpenAIApi(configuration);
@@ -68,7 +66,8 @@ const openai = new OpenAIApi(configuration);
 <Info>
   {" "}
   Fun fact: this policy format is an [IETF standard](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/)
-  for specifying rate limits! Except for the segment field, that's a Helicone special twist 🍬{" "}
+  for specifying rate limits! Except for the segment field, that's a Helicone special
+  twist 🍬{" "}
 </Info>
 
 ### Filtering by segments
@@ -81,8 +80,8 @@ You can rate limit for all of your requests made with the API key, by user, or b
 
 <Info>
   {" "}
-  The minimum value for the time window is 60. The only unit for the time window field is seconds, so for example, use 60
-  * 60 * 24 = 86400 for a single day.{" "}
+  The minimum value for the time window is 60. The only unit for the time window
+  field is seconds, so for example, use 60 * 60 * 24 = 86400 for a single day.{" "}
 </Info>
 
 ### Examples
@@ -147,6 +146,6 @@ These headers are only returned if a rate limit policy is active.
 
 <Info>
   {" "}
-  Test out your rate limit policy in a local environment before deploying to production. Contact `help@helicone.ai` if you
-  have any questions.{" "}
+  Test out your rate limit policy in a local environment before deploying to production.
+  Contact `help@helicone.ai` if you have any questions.{" "}
 </Info>

--- a/docs/features/advanced-usage/omit-logs.mdx
+++ b/docs/features/advanced-usage/omit-logs.mdx
@@ -41,11 +41,9 @@ import { Configuration, OpenAIApi } from "openai";
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,
   basePath: "https://oai.hconeai.com/v1",
-  baseOptions: {
-    headers: {
-      "Helicone-Omit-Request": "true",
-      "Helicone-Omit-Response": "true",
-    },
+  defaultHeaders: {
+    "Helicone-Omit-Request": "true",
+    "Helicone-Omit-Response": "true",
   },
 });
 const openai = new OpenAIApi(configuration);

--- a/docs/features/advanced-usage/retries.mdx
+++ b/docs/features/advanced-usage/retries.mdx
@@ -42,11 +42,9 @@ import { Configuration, OpenAIApi } from "openai";
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,
   basePath: "https://oai.hconeai.com/v1",
-  baseOptions: {
-    headers: {
-      "Helicone-Auth": "Bearer HELICONE_API_KEY",
-      "Helicone-Retry-Enabled": "true",
-    },
+  defaultHeaders: {
+    "Helicone-Auth": "Bearer HELICONE_API_KEY",
+    "Helicone-Retry-Enabled": "true",
   },
 });
 const openai = new OpenAIApi(configuration);
@@ -65,4 +63,7 @@ You can customize the behavior of the retries feature by setting additional head
 | `helicone-retry-min-timeout` | Minimum timeout (in milliseconds) between retries |
 | `helicone-retry-max-timeout` | Maximum timeout (in milliseconds) between retries |
 
-<Info> Header values have to be strings, for example `"helicone-retry-num": "3"` </Info>
+<Info>
+  {" "}
+  Header values have to be strings, for example `"helicone-retry-num": "3"`{" "}
+</Info>

--- a/docs/features/advanced-usage/user-metrics.mdx
+++ b/docs/features/advanced-usage/user-metrics.mdx
@@ -37,10 +37,8 @@ import { Configuration, OpenAIApi } from "openai";
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,
   basePath: "https://oai.hconeai.com/v1",
-  baseOptions: {
-    headers: {
+  defaultHeaders: {
       Helicone-User-Id: "alicebob@gmail.com",
-    },
   },
 });
 const openai = new OpenAIApi(configuration);

--- a/docs/getting-started/integration-method/gateway.mdx
+++ b/docs/getting-started/integration-method/gateway.mdx
@@ -109,12 +109,10 @@ const model = new ChatOpenAI({
   azureOpenAIBasePath: "https://gateway.hconeai.com",
   configuration: {
     organization: "[organization]",
-    baseOptions: {
-      headers: {
-        "Helicone-Auth": `Bearer ${heliconeApiKey}`,
-        "Helicone-Target-Url": "https://api.lemonfox.ai",
-        "Helicone-Target-Provider": "LemonFox",
-      },
+    defaultHeaders: {
+      "Helicone-Auth": `Bearer ${heliconeApiKey}`,
+      "Helicone-Target-Url": "https://api.lemonfox.ai",
+      "Helicone-Target-Provider": "LemonFox",
     },
   },
 });

--- a/docs/getting-started/integration-method/openai-proxy.mdx
+++ b/docs/getting-started/integration-method/openai-proxy.mdx
@@ -12,29 +12,31 @@ title: "OpenAI"
   export HELICONE_API_KEY=<your API key>
   ```
 
-  Initialize OpenAI client. Can also be done via global client.
-  ```python
-  client = OpenAI(
-    api_key="your-api-key-here",  # Replace with your OpenAI API key
-    base_url="http://oai.hconeai.com/v1",  # Set the API endpoint
-    default_headers= {  # Optionally set default headers or set per request (see below)
-      "Helicone-Auth": "Bearer HELICONE_API_KEY" 
-    }
-  )
-  ```
+Initialize OpenAI client. Can also be done via global client.
 
-  Send request and attach extra headers
-  ```python
-  chat_completion = client.chat.completions.create(
-    model="gpt-4-vision-preview",
-    messages=[
-        {"role": "user", "content": "Hello world!"}
-    ],
-    extra_headers={ # Can also attach headers per request
-        "Helicone-Auth": "Bearer HELICONE_API_KEY"
-    },
-  )
-  ```
+```python
+client = OpenAI(
+  api_key="your-api-key-here",  # Replace with your OpenAI API key
+  base_url="http://oai.hconeai.com/v1",  # Set the API endpoint
+  default_headers= {  # Optionally set default headers or set per request (see below)
+    "Helicone-Auth": "Bearer HELICONE_API_KEY"
+  }
+)
+```
+
+Send request and attach extra headers
+
+```python
+chat_completion = client.chat.completions.create(
+  model="gpt-4-vision-preview",
+  messages=[
+      {"role": "user", "content": "Hello world!"}
+  ],
+  extra_headers={ # Can also attach headers per request
+      "Helicone-Auth": "Bearer HELICONE_API_KEY"
+  },
+)
+```
 
     That's it! Your OpenAI requests now log results to Helicone.
 
@@ -47,6 +49,7 @@ title: "OpenAI"
   ```
 
 Change the api base and add a Helicone-Auth header
+
 ```python
 import openai
 
@@ -63,7 +66,6 @@ openai.Completion.create(
 
   </Accordion>
 </AccordionGroup>
-
 
   </Tab>
   <Tab title="Python (w/ package)">
@@ -282,12 +284,10 @@ Here is an example cURL command:
       modelName: "gpt-3.5-turbo",
       configuration: {
         basePath: "https://oai.hconeai.com/v1",
-        baseOptions: {
-          headers: {
-            "Helicone-Auth": `Bearer HELICONE_API_KEY`,
-            }
-          }
-        }
+        defaultHeaders: {
+          "Helicone-Auth": `Bearer HELICONE_API_KEY`,
+          },
+        },
       });
     ```
 

--- a/docs/helicone-headers/intro.mdx
+++ b/docs/helicone-headers/intro.mdx
@@ -69,11 +69,9 @@ const model = new ChatOpenAI({
   azureOpenAIBasePath: "https://oai.hconeai.com",
   configuration: {
     organization: "[organization]",
-    baseOptions: {
-      headers: {
-        "Helicone-Auth": `Bearer ${heliconeApiKey}`,
-        "Helicone-<Header>": "<Value>",
-      },
+    defaultHeaders: {
+      "Helicone-Auth": `Bearer ${heliconeApiKey}`,
+      "Helicone-<Header>": "<Value>",
     },
   },
 });

--- a/web/components/templates/home/codeSnippet.tsx
+++ b/web/components/templates/home/codeSnippet.tsx
@@ -62,10 +62,8 @@ const model = new OpenAI(
   {},
   {
     basePath: "${BASE_PATH}",
-    baseOptions: {
-      headers: {
-        "Helicone-Auth": "Bearer ${key}"
-      },
+    defaultHeaders: {
+      "Helicone-Auth": "Bearer ${key}"
     },
   }
 );


### PR DESCRIPTION
Langchain has deprecated the baseOptions, so I have updated the documentation to reflect this change.

```ts
    /** @deprecated Use defaultHeaders and defaultQuery instead */
    baseOptions?: {
        headers?: Record<string, string>;
        params?: Record<string, string>;
    };
```