### PR TITLE
Add Github authentication support

### DIFF
--- a/web/components/templates/auth/authForm.tsx
+++ b/web/components/templates/auth/authForm.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import { BsGoogle } from "react-icons/bs";
+import { BsGoogle, BsGithub } from "react-icons/bs";
 import Image from "next/image";
 import { FormEvent, useState } from "react";
 import { useSupabaseClient } from "@supabase/auth-helpers-react";
@@ -11,11 +11,17 @@ import { ArrowPathIcon } from "@heroicons/react/24/outline";
 interface AuthFormProps {
   handleEmailSubmit: (email: string, password: string) => void;
   handleGoogleSubmit?: () => void;
+  handleGithubSubmit?: () => void;
   authFormType: "signin" | "signup" | "reset" | "reset-password";
 }
 
 const AuthForm = (props: AuthFormProps) => {
-  const { handleEmailSubmit, handleGoogleSubmit, authFormType } = props;
+  const {
+    handleEmailSubmit,
+    handleGoogleSubmit,
+    handleGithubSubmit,
+    authFormType,
+  } = props;
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -265,6 +271,21 @@ const AuthForm = (props: AuthFormProps) => {
                       <BsGoogle />
                       <span className="text-sm lg:text-md font-semibold leading-6">
                         Google
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              )}
+              {handleGithubSubmit && (
+                <div className="mt-6">
+                  <div className="grid grid-cols-1 gap-4">
+                    <button
+                      onClick={() => handleGithubSubmit()}
+                      className="flex w-full items-center justify-center gap-2 rounded-md border border-gray-300 bg-white hover:bg-gray-200 px-3 py-1.5 text-black focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
+                    >
+                      <BsGithub />
+                      <span className="text-sm lg:text-md font-semibold leading-6">
+                        Github
                       </span>
                     </button>
                   </div>

--- a/web/components/templates/auth/authForm.tsx
+++ b/web/components/templates/auth/authForm.tsx
@@ -285,7 +285,7 @@ const AuthForm = (props: AuthFormProps) => {
                     >
                       <BsGithub />
                       <span className="text-sm lg:text-md font-semibold leading-6">
-                        Github
+                        GitHub
                       </span>
                     </button>
                   </div>

--- a/web/pages/signin.tsx
+++ b/web/pages/signin.tsx
@@ -39,6 +39,17 @@ const SignIn = (props: SignInProps) => {
         }
         setNotification("Successfully signed in.", "success");
       }}
+      handleGithubSubmit={async () => {
+        const { error } = await supabase.auth.signInWithOAuth({
+          provider: "github",
+        });
+        if (error) {
+          setNotification("Error logging in. Please try again.", "error");
+          console.error(error);
+          return;
+        }
+        setNotification("Successfully signed in.", "success");
+      }}
       authFormType={"signin"}
     />
   );

--- a/web/pages/signup.tsx
+++ b/web/pages/signup.tsx
@@ -61,6 +61,19 @@ const SignUp = (props: SignUpProps) => {
             return;
           }
         }}
+        handleGithubSubmit={async () => {
+          const { error } = await supabase.auth.signInWithOAuth({
+            provider: "github",
+          });
+          if (error) {
+            setNotification(
+              "Error creating your account. Please try again.",
+              "error"
+            );
+            console.error(error);
+            return;
+          }
+        }}
         authFormType={"signup"}
       />
       <ThemedModal


### PR DESCRIPTION
Connect GitHub auth as a secondary auth options.

- Create a GitHub OAuth in Helicone Org
- Activate it on Supabase
- Edit login page and add Github Auth button 
- End-To-End test it