### PR TITLE
fix curly brackets

### DIFF
--- a/docs/getting-started/integration-method/openai.mdx
+++ b/docs/getting-started/integration-method/openai.mdx
@@ -162,7 +162,7 @@ POST https://api.hconeai.com/oai/v1/log
 
 | Name          | Value            |
 | ------------- | ---------------- |
-| Authorization | Bearer {API_KEY} |
+| Authorization | Bearer `{API_KEY}` |
 
 Replace `{API_KEY}` with your actual API Key.
 


### PR DESCRIPTION
We don't support curly brackets well and may cause the page to go down. Before we put in a fix, we suggest to escape either with backticks or `/`