### PR TITLE
Add preview models to the Playground page

### DIFF
--- a/web/components/templates/playground/playgroundPage.tsx
+++ b/web/components/templates/playground/playgroundPage.tsx
@@ -129,9 +129,12 @@ const PlaygroundPage = (props: PlaygroundPageProps) => {
                           "gpt-3.5-turbo",
                           "gpt-3.5-turbo-0613",
                           "gpt-3.5-turbo-16k",
+                          "gpt-3.5-turbo-1106",
                           "gpt-4",
                           "gpt-4-0613",
                           "gpt-4-32k",
+                          "gpt-4-1106-preview",
+                          "gpt-4-vision-preview",
                         ].map((model, idx) => (
                           <MultiSelectItem
                             value={model}


### PR DESCRIPTION
Hey!

Was playing with your playground page and could not find vision and new turbo models in the models dropdown.

This PR will add the models.