### PR TITLE
download more ram

### DIFF
--- a/valhalla/packages/helicone-shared-ts/src/db/valhalla.ts
+++ b/valhalla/packages/helicone-shared-ts/src/db/valhalla.ts
@@ -70,7 +70,7 @@ class ValhallaDB implements IValhallaDB {
       user: username,
       password: password,
       database: auroraDb,
-      max: 3_000,
+      max: 10_000,
       idleTimeoutMillis: 1000, // close idle clients after 1 second
       connectionTimeoutMillis: 1000, // return an error after 1 second if connection could not be established
       maxUses: 500,

--- a/valhalla/packages/jawn/src/index.ts
+++ b/valhalla/packages/jawn/src/index.ts
@@ -204,7 +204,7 @@ app.patch(
 );
 
 app.get(
-  "/healthcheck-db",
+  "/healthcheck",
   withDB(async ({ db, request, res }) => {
     const now = await db.now();
     if (now.error) {
@@ -234,12 +234,6 @@ app.get(
     });
   })
 );
-
-app.get("/healthcheck", (request, res) => {
-  res.json({
-    status: "healthy :)",
-  });
-});
 
 app.listen(parseInt(process.env.PORT ?? "8585"), "0.0.0.0", () => {
   console.log(`Server is running on http://localhost:8585`);


### PR DESCRIPTION
We had a huge spike in requests. Which caused our node to fail

<img width="226" alt="image" src="https://github.com/Helicone/helicone/assets/26822232/4ad58a4b-411f-47a1-9ce6-4198569ac65b">


So I am adding more requests... I am also going to make the min number of nodes 2, and making sure our health check actually checks the db