### PR TITLE
Property Value Speed Improvements - move property value query to response_with_property table

### DIFF
--- a/clickhouse/migrations/schema_15_update_order_by_properties.sql
+++ b/clickhouse/migrations/schema_15_update_order_by_properties.sql
@@ -1,0 +1,5 @@
+ALTER TABLE default.properties_copy_v2 ADD COLUMN value_2 Int32, MODIFY ORDER BY (organization_id, key, value, created_at, id)
+
+
+ALTER TABLE default.properties_copy_v2
+   MODIFY ORDER BY (id, organization_id, key, value, created_at);

--- a/clickhouse/migrations/schema_15_update_order_by_properties.sql
+++ b/clickhouse/migrations/schema_15_update_order_by_properties.sql
@@ -1,5 +1,0 @@
-ALTER TABLE default.properties_copy_v2 ADD COLUMN value_2 Int32, MODIFY ORDER BY (organization_id, key, value, created_at, id)
-
-
-ALTER TABLE default.properties_copy_v2
-   MODIFY ORDER BY (id, organization_id, key, value, created_at);

--- a/web/lib/api/properties/propertyParams.ts
+++ b/web/lib/api/properties/propertyParams.ts
@@ -2,9 +2,12 @@ import {
   FilterLeaf,
   FilterNode,
 } from "../../../services/lib/filters/filterDefs";
-import { buildFilterWithAuthClickHouseProperties } from "../../../services/lib/filters/filters";
+import {
+  buildFilterWithAuthClickHousePropResponse,
+  buildFilterWithAuthClickHouseProperties,
+} from "../../../services/lib/filters/filters";
 import { Result } from "../../result";
-import { dbQueryClickhouse } from "../db/dbExecute";
+import { dbQueryClickhouse, printRunnableQuery } from "../db/dbExecute";
 
 export interface PropertyParam {
   property_param: string;
@@ -16,8 +19,8 @@ function getFilterSearchFilterNode(
   search: string
 ): FilterNode {
   const propertyFilter: FilterLeaf = {
-    properties_copy_v2: {
-      key: {
+    property_with_response_v1: {
+      property_key: {
         equals: property,
       },
     },
@@ -26,8 +29,8 @@ function getFilterSearchFilterNode(
     return propertyFilter;
   }
   const searchFilter: FilterLeaf = {
-    properties_copy_v2: {
-      value: {
+    property_with_response_v1: {
+      property_value: {
         contains: search,
       },
     },
@@ -44,15 +47,15 @@ export async function getPropertyParams(
   property: string,
   search: string
 ): Promise<Result<PropertyParam[], string>> {
-  const builtFilter = await buildFilterWithAuthClickHouseProperties({
+  const builtFilter = await buildFilterWithAuthClickHousePropResponse({
     org_id,
     filter: getFilterSearchFilterNode(property, search),
     argsAcc: [],
   });
 
   const query = `
-  SELECT distinct key as property_key, value as property_param
-  from properties_copy_v2
+  SELECT distinct property_key, property_value as property_param
+  from property_with_response_v1
   where (
     ${builtFilter.filter}
   )

--- a/web/lib/api/properties/propertyParams.ts
+++ b/web/lib/api/properties/propertyParams.ts
@@ -2,12 +2,9 @@ import {
   FilterLeaf,
   FilterNode,
 } from "../../../services/lib/filters/filterDefs";
-import {
-  buildFilterWithAuthClickHousePropResponse,
-  buildFilterWithAuthClickHouseProperties,
-} from "../../../services/lib/filters/filters";
+import { buildFilterWithAuthClickHousePropResponse } from "../../../services/lib/filters/filters";
 import { Result } from "../../result";
-import { dbQueryClickhouse, printRunnableQuery } from "../db/dbExecute";
+import { dbQueryClickhouse } from "../db/dbExecute";
 
 export interface PropertyParam {
   property_param: string;


### PR DESCRIPTION
This is a quick fix that is faster...

The real fix is to get rid of  `properties_copy_v2`

and replace it with 
```sql
CREATE TABLE IF NOT EXISTS default.properties_v3
(
   `id` Int64,
   `created_at` DateTime64,
   `request_id` UUID,
   `key` String,
   `value` String,
   `organization_id` UUID,
)
ENGINE = MergeTree
PRIMARY KEY (organization_id, key, value, id)
ORDER BY (organization_id, key, value);
```

This was before we knew how to properly use clickhouse... 