### PR TITLE
Updated hprompt to accept config args

### DIFF
--- a/docs/features/prompts/intro.mdx
+++ b/docs/features/prompts/intro.mdx
@@ -10,7 +10,7 @@ Helicone's prompt management provides a seamless way for users to track the prom
 ```tsx
 const location = "space";
 const scene = "two brothers";
-const promptInput = hprompt`
+const promptInput = hprompt()`
 Compose a movie scene involving ${{ scene }}, set in ${{ location }}
 `;
 ```

--- a/docs/features/prompts/quick-start.mdx
+++ b/docs/features/prompts/quick-start.mdx
@@ -59,7 +59,7 @@ You must be using Helicone via Proxy. If you are not, please refer to our [Quick
           {
             role: "user",
             // 2: Add hprompt to any string, and nest any variable in additional brackets `{}`
-            content: hprompt`Write a story about ${{ scene }}`,
+            content: hprompt()`Write a story about ${{ scene }}`,
           },
         ],
         model: "gpt-3.5-turbo",
@@ -85,20 +85,20 @@ You must be using Helicone via Proxy. If you are not, please refer to our [Quick
       </Step>
       <Step title="Replace any text input">
 
-      Using the backtick string formatter in JavaScript, add `hprompt` in front of your backtick to automatically format your text so that Helicone can determine where your variables are.
+      Using the backtick string formatter in JavaScript, add `hprompt()` in front of your backtick to automatically format your text so that Helicone can determine where your variables are.
 
       Also, nest your inputted variable so that it is within another bracket `{}`, this is essentially
       making it so that we can determine the `input key` for Helicone.
 
       ```tsx
-      content: hprompt`Write a story about ${{ scene }}`,
+      content: hprompt()`Write a story about ${{ scene }}`,
       ```
 
       <Accordion title="Change Input Name">
         If you want to rename your input or have a custom input, you can change the key-value pair in the passed dictionary to the string formatter function. Like this:
 
         ```tsx
-        content: hprompt`Write a story about ${{ "my_magical_input": scene  }}`,
+        content: hprompt()`Write a story about ${{ "my_magical_input": scene  }}`,
         ```
       </Accordion>
       </Step>
@@ -124,8 +124,8 @@ You must be using Helicone via Proxy. If you are not, please refer to our [Quick
   </Tab>
   <Tab title="Packageless (curl)">
   Let's say we have an app that generates a short story with an inputted scene.
-  
-  For example: "Write a story about a secret agent"
+
+For example: "Write a story about a secret agent"
 
   <Steps>
     <Step title="Determine your input variables">
@@ -164,7 +164,7 @@ You must be using Helicone via Proxy. If you are not, please refer to our [Quick
     </Step>
 
   </Steps>
-  
+
   </Tab>
   <Tab title="Other">
     Currently, we only support packages for TypeScript and JavaScript for easy integration. For now, we recommend manually implementing input variables like this:

--- a/helicone-node/core/HeliconePromptFormat.ts
+++ b/helicone-node/core/HeliconePromptFormat.ts
@@ -38,23 +38,40 @@ export function prompt(
   return { heliconeTemplate, inputs, builtString };
 }
 
-export function hprompt(
-  strings: TemplateStringsArray,
-  ...values: any[]
-): string {
-  // TODO handle the case where you just have `${input}` as a string and not `{{input}}`
-  return strings.reduce((acc, string, i) => {
-    const val = values[i];
-    if (val != null) {
-      const key = Object.keys(val)[0];
-      const value = Object.values(val)[0];
-      return (
-        acc +
-        string +
-        `<helicone-prompt-input key="${key}" >${value}</helicone-prompt-input>`
-      );
-    } else {
-      return acc + string;
-    }
-  }, "");
+interface HPromptConfig {
+  dedent?: (strings: TemplateStringsArray, ...values: unknown[]) => string;
+  format: "raw" | "template";
 }
+
+const hpromptTag = "helicone-prompt-input";
+
+/**
+ * Generates a prompt with annotated variables.
+ * @param dedent - Dedent is the name of the most commonly used tagged template literal function for postprocessing, though any similar function may be provided.
+ * @param format - The format of the prompt. If 'raw', the prompt will be returned as a string with the variables replaced. If 'template', the prompt will be returned as a string with the variables replaced with helicone-prompt-input tags.
+ */
+export const hprompt =
+  (config?: HPromptConfig) =>
+  (strings: TemplateStringsArray, ...values: any[]): string => {
+    const { dedent, format = "template" } = config ?? {};
+    const parts: string[] = strings.reduce(
+      (acc: string[], str: string, i: number) => {
+        acc.push(str);
+        if (values[i] != null) {
+          const isObject = typeof values[i] === "object";
+          const value = isObject ? Object.values(values[i])[0] : values[i];
+          acc.push(
+            format === "template" && isObject
+              ? `<${hpromptTag} key="${
+                  Object.keys(values[i])[0]
+                }">${value}</${hpromptTag}>`
+              : value
+          );
+        }
+        return acc;
+      },
+      []
+    );
+    const output = parts.join("");
+    return dedent != null ? dedent`${output}` : output;
+  };

--- a/helicone-node/package-lock.json
+++ b/helicone-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helicone/helicone",
-  "version": "2.1.6",
+  "version": "2.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helicone/helicone",
-      "version": "2.1.6",
+      "version": "2.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/uuid": "^9.0.1",

--- a/helicone-node/tests/hprompt.test.ts
+++ b/helicone-node/tests/hprompt.test.ts
@@ -1,0 +1,60 @@
+import { hprompt } from "../core/HeliconePromptFormat";
+
+describe("hprompt", () => {
+  it("should handle 1 string variable", () => {
+    const firstName = "Bob";
+    const raw = hprompt({ format: "raw" })`Hello ${{ firstName }}`;
+    const template = hprompt()`Hello ${{ firstName }}`;
+    expect(raw).toBe("Hello Bob");
+    expect(template).toBe(
+      'Hello <helicone-prompt-input key="firstName">Bob</helicone-prompt-input>'
+    );
+  });
+
+  it("should handle 1 number variable", () => {
+    const count = 10;
+    const raw = hprompt({ format: "raw" })`You're #${{ count }}!`;
+    const template = hprompt()`You're #${{ count }}!`;
+    expect(raw).toBe(`You're #10!`);
+    expect(template).toBe(
+      `You're #<helicone-prompt-input key="count">10</helicone-prompt-input>!`
+    );
+  });
+
+  it("should handle 1 boolean variable", () => {
+    const isTrue = true;
+    const raw = hprompt({ format: "raw" })`Is it ${{ isTrue }}?`;
+    const template = hprompt()`Is it ${{ isTrue }}?`;
+    expect(raw).toBe(`Is it true?`);
+    expect(template).toBe(
+      `Is it <helicone-prompt-input key="isTrue">true</helicone-prompt-input>?`
+    );
+  });
+
+  it("should handle a mix of multiple variables", () => {
+    const firstName = "Bob";
+    const count = 10;
+    const isTrue = true;
+    const raw = hprompt({ format: "raw" })`Hello ${{ firstName }}, you're #${{
+      count,
+    }}!
+Is it ${{ isTrue }}?`;
+    const template = hprompt()`Hello ${{
+      firstName,
+    }}, you're #${{ count }}!
+Is it ${{ isTrue }}?`;
+    expect(raw).toBe(`Hello Bob, you're #10!\nIs it true?`);
+    expect(template).toBe(
+      `Hello <helicone-prompt-input key="firstName">Bob</helicone-prompt-input>, you're #<helicone-prompt-input key="count">10</helicone-prompt-input>!
+Is it <helicone-prompt-input key="isTrue">true</helicone-prompt-input>?`
+    );
+  });
+
+  it("should handle non-object variables", () => {
+    const firstName = "Bob";
+    const raw = hprompt({ format: "raw" })`Hello ${firstName}`;
+    const template = hprompt()`Hello ${firstName}`;
+    expect(raw).toBe("Hello Bob");
+    expect(template).toBe("Hello Bob");
+  });
+});


### PR DESCRIPTION
`hprompt` now accepts configuration params to customize the following:
  1. toggle the `format` between "template" and "raw", to make it easier to migrate a prompt to the Helicone format 
  2. chain a tagged template literal functions, to make it easier to integrate with existing functions, like [dedent](https://github.com/dmnd/dedent)