### PR TITLE
Fix relative link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ response = openai.Completion.create(
 )
 ```
 
-👉 Then view your logs at [Helicone](www.helicone.ai).
+👉 Then view your logs at [Helicone](https://www.helicone.ai).
 
 ## More resources
 


### PR DESCRIPTION
If you use `www.helicone.ai` instead of `https://www.helicone.ai` it doesn't work correctly and links to a 404 on github.com.

