### PR TITLE
add anthropic sonnet and haiku pricing

### DIFF
--- a/costs/src/providers/anthropic/index.ts
+++ b/costs/src/providers/anthropic/index.ts
@@ -61,11 +61,31 @@ export const costs: ModelRow[] = [
   {
     model: {
       operator: "equals",
+      value: "claude-3-sonnet-20240229",
+    },
+    cost: {
+      prompt_token: 0.000003,
+      completion_token: 0.000015,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
       value: "claude-3-opus-20240229",
     },
     cost: {
       prompt_token: 0.000015,
       completion_token: 0.000075,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "claude-3-haiku-20240307",
+    },
+    cost: {
+      prompt_token: 0.00000025,
+      completion_token: 0.00000125,
     },
   },
 ];

--- a/costs/src/providers/anthropic/index.ts
+++ b/costs/src/providers/anthropic/index.ts
@@ -61,21 +61,21 @@ export const costs: ModelRow[] = [
   {
     model: {
       operator: "equals",
-      value: "claude-3-sonnet-20240229",
-    },
-    cost: {
-      prompt_token: 0.000003,
-      completion_token: 0.000015,
-    },
-  },
-  {
-    model: {
-      operator: "equals",
       value: "claude-3-opus-20240229",
     },
     cost: {
       prompt_token: 0.000015,
       completion_token: 0.000075,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "claude-3-sonnet-20240229",
+    },
+    cost: {
+      prompt_token: 0.000003,
+      completion_token: 0.000015,
     },
   },
   {

--- a/web/packages/cost/providers/anthropic/index.ts
+++ b/web/packages/cost/providers/anthropic/index.ts
@@ -68,4 +68,24 @@ export const costs: ModelRow[] = [
       completion_token: 0.000075,
     },
   },
+  {
+    model: {
+      operator: "equals",
+      value: "claude-3-sonnet-20240229",
+    },
+    cost: {
+      prompt_token: 0.000003,
+      completion_token: 0.000015,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "claude-3-haiku-20240307",
+    },
+    cost: {
+      prompt_token: 0.00000025,
+      completion_token: 0.00000125,
+    },
+  },
 ];

--- a/worker/src/packages/cost/providers/anthropic/index.ts
+++ b/worker/src/packages/cost/providers/anthropic/index.ts
@@ -68,4 +68,24 @@ export const costs: ModelRow[] = [
       completion_token: 0.000075,
     },
   },
+  {
+    model: {
+      operator: "equals",
+      value: "claude-3-sonnet-20240229",
+    },
+    cost: {
+      prompt_token: 0.000003,
+      completion_token: 0.000015,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "claude-3-haiku-20240307",
+    },
+    cost: {
+      prompt_token: 0.00000025,
+      completion_token: 0.00000125,
+    },
+  },
 ];


### PR DESCRIPTION
This PR adds the pricings for both the sonnet and haiku models from anthropic.