### PR TITLE
remove openapi and add endpoints from new spec

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -1,6 +1,5 @@
 {
   "name": "Helicone",
-
   "logo": {
     "light": "/logo/light.png",
     "dark": "/logo/dark.svg"
@@ -32,7 +31,6 @@
     "suggestEdit": true,
     "raiseIssue": true
   },
-  "openapi": ["/swagger.json"],
   "navigation": [
     {
       "group": "Welcome",
@@ -159,7 +157,16 @@
     },
     {
       "group": "Request",
-      "pages": ["rest/request/post-v1requestquery"]
+      "pages": [
+        "rest/request/request/post-v1requestquery"
+      ]
+    },
+    {
+      "group": "Prompt",
+      "pages": [
+        "rest/request/prompt/post-v1promptquery",
+        "rest/request/prompt/post-v1prompt-query"
+      ]
     }
   ],
   "topbarLinks": [

--- a/docs/rest/request/prompt/post-v1prompt-query.mdx
+++ b/docs/rest/request/prompt/post-v1prompt-query.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/prompt/{promptId}/query
+---

--- a/docs/rest/request/prompt/post-v1promptquery.mdx
+++ b/docs/rest/request/prompt/post-v1promptquery.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/prompt/query
+---

--- a/docs/rest/request/request/post-v1requestquery.mdx
+++ b/docs/rest/request/request/post-v1requestquery.mdx
@@ -1,4 +1,3 @@
 ---
-title: "Request - Query"
 openapi: post /v1/request/query
 ---


### PR DESCRIPTION
## Summary

This PR removes the openapi section from the `mint.json` and new endpoints to the navigation. 

<img width="1405" alt="CleanShot 2024-04-15 at 16 55 10@2x" src="https://github.com/Helicone/helicone/assets/123998500/57bd73f2-4a5a-46f2-9c9d-16083e4a8bc1">

Refer to https://mintlify.com/docs/api-playground/openapi/setup for how to scrape new endpoints when the OpenAPI Spec updates. 

## Testing

Navigate to the docs folder and run `mintlify dev` to preview `API tab` locally. 