### PR TITLE
More precise FilterNode object

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1291,294 +1291,6 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"Partial_UserMetricsToOperators_": {
-				"properties": {
-					"user_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"last_active": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"total_requests": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_UserApiKeysTableToOperators_": {
-				"properties": {
-					"api_key_hash": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"api_key_name": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_PropertiesTableToOperators_": {
-				"properties": {
-					"auth_hash": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"key": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"value": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_TimestampOperatorsTyped_": {
-				"properties": {
-					"gte": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"lte": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"lt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"gt": {
-						"type": "string",
-						"format": "date-time"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_RequestResponseLogToOperators_": {
-				"properties": {
-					"latency": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"status": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"request_created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperatorsTyped_"
-					},
-					"response_created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperatorsTyped_"
-					},
-					"auth_hash": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"model": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"user_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"organization_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"node_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"job_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"threat": {
-						"$ref": "#/components/schemas/Partial_BooleanOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_UserViewToOperators_": {
-				"properties": {
-					"user_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"active_for": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"first_active": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"last_active": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"total_requests": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"average_requests_per_day_active": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"average_tokens_per_request": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"total_completion_tokens": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"total_prompt_token": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"cost": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_PropertiesCopyV2ToOperators_": {
-				"properties": {
-					"key": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"value": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"organization_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_PropertyWithResponseV1ToOperators_": {
-				"properties": {
-					"property_key": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"property_value": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"request_created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperatorsTyped_"
-					},
-					"organization_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"threat": {
-						"$ref": "#/components/schemas/Partial_BooleanOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_JobToOperators_": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"name": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"description": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"status": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"updated_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"timeout_seconds": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"custom_properties": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/Partial_TextOperators_"
-						},
-						"type": "object"
-					},
-					"org_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_NodesToOperators_": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"name": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"description": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"job_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"status": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"updated_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"timeout_seconds": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"custom_properties": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/Partial_TextOperators_"
-						},
-						"type": "object"
-					},
-					"org_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_CacheHitsTableToOperators_": {
-				"properties": {
-					"organization_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"request_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"latency": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"completion_tokens": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"prompt_tokens": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperatorsTyped_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_RateLimitTableToOperators_": {
-				"properties": {
-					"organization_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperatorsTyped_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
 			"Partial_PromptVersionsToOperators_": {
 				"properties": {
 					"minor_version": {
@@ -1597,87 +1309,28 @@
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Partial_TablesAndViews_": {
+			"Pick_FilterLeaf.request-or-prompts_versions_": {
 				"properties": {
-					"user_metrics": {
-						"$ref": "#/components/schemas/Partial_UserMetricsToOperators_"
-					},
-					"user_api_keys": {
-						"$ref": "#/components/schemas/Partial_UserApiKeysTableToOperators_"
-					},
-					"response": {
-						"$ref": "#/components/schemas/Partial_ResponseTableToOperators_"
-					},
 					"request": {
 						"$ref": "#/components/schemas/Partial_RequestTableToOperators_"
-					},
-					"feedback": {
-						"$ref": "#/components/schemas/Partial_FeedbackTableToOperators_"
-					},
-					"properties_table": {
-						"$ref": "#/components/schemas/Partial_PropertiesTableToOperators_"
-					},
-					"request_response_log": {
-						"$ref": "#/components/schemas/Partial_RequestResponseLogToOperators_"
-					},
-					"users_view": {
-						"$ref": "#/components/schemas/Partial_UserViewToOperators_"
-					},
-					"properties_v3": {
-						"$ref": "#/components/schemas/Partial_PropertiesCopyV2ToOperators_"
-					},
-					"property_with_response_v1": {
-						"$ref": "#/components/schemas/Partial_PropertyWithResponseV1ToOperators_"
-					},
-					"job": {
-						"$ref": "#/components/schemas/Partial_JobToOperators_"
-					},
-					"job_node": {
-						"$ref": "#/components/schemas/Partial_NodesToOperators_"
-					},
-					"cache_hits": {
-						"$ref": "#/components/schemas/Partial_CacheHitsTableToOperators_"
-					},
-					"rate_limit_log": {
-						"$ref": "#/components/schemas/Partial_RateLimitTableToOperators_"
-					},
-					"properties": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/Partial_TextOperators_"
-						},
-						"type": "object"
-					},
-					"values": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/Partial_TextOperators_"
-						},
-						"type": "object"
-					},
-					"prompt_v2": {
-						"$ref": "#/components/schemas/Partial_PromptToOperators_"
 					},
 					"prompts_versions": {
 						"$ref": "#/components/schemas/Partial_PromptVersionsToOperators_"
 					}
 				},
 				"type": "object",
-				"description": "Make all properties in T optional"
+				"description": "From T, pick a set of properties whose keys are in the union K"
 			},
-			"SingleKey_TablesAndViews_": {
-				"$ref": "#/components/schemas/Partial_TablesAndViews_"
+			"FilterLeafSubset_request-or-prompts_versions_": {
+				"$ref": "#/components/schemas/Pick_FilterLeaf.request-or-prompts_versions_"
 			},
-			"FilterLeaf": {
-				"$ref": "#/components/schemas/SingleKey_TablesAndViews_"
-			},
-			"FilterNode": {
+			"DatasetFilterNode": {
 				"anyOf": [
 					{
-						"$ref": "#/components/schemas/FilterLeaf"
+						"$ref": "#/components/schemas/FilterLeafSubset_request-or-prompts_versions_"
 					},
 					{
-						"$ref": "#/components/schemas/FilterBranch"
+						"$ref": "#/components/schemas/DatasetFilterBranch"
 					},
 					{
 						"type": "string",
@@ -1687,10 +1340,10 @@
 					}
 				]
 			},
-			"FilterBranch": {
+			"DatasetFilterBranch": {
 				"properties": {
-					"left": {
-						"$ref": "#/components/schemas/FilterNode"
+					"right": {
+						"$ref": "#/components/schemas/DatasetFilterNode"
 					},
 					"operator": {
 						"type": "string",
@@ -1699,17 +1352,16 @@
 							"and"
 						]
 					},
-					"right": {
-						"$ref": "#/components/schemas/FilterNode"
+					"left": {
+						"$ref": "#/components/schemas/DatasetFilterNode"
 					}
 				},
 				"required": [
-					"left",
+					"right",
 					"operator",
-					"right"
+					"left"
 				],
-				"type": "object",
-				"additionalProperties": false
+				"type": "object"
 			},
 			"RandomDatasetParams": {
 				"properties": {
@@ -1717,7 +1369,7 @@
 						"type": "string"
 					},
 					"filter": {
-						"$ref": "#/components/schemas/FilterNode"
+						"$ref": "#/components/schemas/DatasetFilterNode"
 					},
 					"offset": {
 						"type": "number",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -583,48 +583,6 @@
 					}
 				]
 			},
-			"Partial_TextOperators_": {
-				"properties": {
-					"not-equals": {
-						"type": "string"
-					},
-					"equals": {
-						"type": "string"
-					},
-					"like": {
-						"type": "string"
-					},
-					"ilike": {
-						"type": "string"
-					},
-					"contains": {
-						"type": "string"
-					},
-					"not-contains": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_TimestampOperators_": {
-				"properties": {
-					"gte": {
-						"type": "string"
-					},
-					"lte": {
-						"type": "string"
-					},
-					"lt": {
-						"type": "string"
-					},
-					"gt": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
 			"Partial_NumberOperators_": {
 				"properties": {
 					"not-equals": {
@@ -655,48 +613,69 @@
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Partial_UserMetricsToOperators_": {
+			"Partial_TimestampOperators_": {
 				"properties": {
-					"user_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
+					"gte": {
+						"type": "string"
 					},
-					"last_active": {
+					"lte": {
+						"type": "string"
+					},
+					"lt": {
+						"type": "string"
+					},
+					"gt": {
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"description": "Make all properties in T optional"
+			},
+			"Partial_BooleanOperators_": {
+				"properties": {
+					"equals": {
+						"type": "boolean"
+					}
+				},
+				"type": "object",
+				"description": "Make all properties in T optional"
+			},
+			"Partial_TextOperators_": {
+				"properties": {
+					"not-equals": {
+						"type": "string"
+					},
+					"equals": {
+						"type": "string"
+					},
+					"like": {
+						"type": "string"
+					},
+					"ilike": {
+						"type": "string"
+					},
+					"contains": {
+						"type": "string"
+					},
+					"not-contains": {
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"description": "Make all properties in T optional"
+			},
+			"Partial_FeedbackTableToOperators_": {
+				"properties": {
+					"id": {
+						"$ref": "#/components/schemas/Partial_NumberOperators_"
+					},
+					"created_at": {
 						"$ref": "#/components/schemas/Partial_TimestampOperators_"
 					},
-					"total_requests": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_UserApiKeysTableToOperators_": {
-				"properties": {
-					"api_key_hash": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
+					"rating": {
+						"$ref": "#/components/schemas/Partial_BooleanOperators_"
 					},
-					"api_key_name": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_ResponseTableToOperators_": {
-				"properties": {
-					"body_tokens": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"body_model": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"body_completion": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"status": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"model": {
+					"response_id": {
 						"$ref": "#/components/schemas/Partial_TextOperators_"
 					}
 				},
@@ -739,27 +718,608 @@
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Partial_BooleanOperators_": {
+			"Partial_ResponseTableToOperators_": {
 				"properties": {
-					"equals": {
-						"type": "boolean"
+					"body_tokens": {
+						"$ref": "#/components/schemas/Partial_NumberOperators_"
+					},
+					"body_model": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
+					},
+					"body_completion": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
+					},
+					"status": {
+						"$ref": "#/components/schemas/Partial_NumberOperators_"
+					},
+					"model": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
 					}
 				},
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Partial_FeedbackTableToOperators_": {
+			"Pick_TablesAndViews.feedback-or-request-or-response_": {
+				"properties": {
+					"feedback": {
+						"$ref": "#/components/schemas/Partial_FeedbackTableToOperators_"
+					},
+					"request": {
+						"$ref": "#/components/schemas/Partial_RequestTableToOperators_"
+					},
+					"response": {
+						"$ref": "#/components/schemas/Partial_ResponseTableToOperators_"
+					}
+				},
+				"required": [
+					"feedback",
+					"request",
+					"response"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"FilterLeafSubset_feedback-or-request-or-response_": {
+				"$ref": "#/components/schemas/Pick_TablesAndViews.feedback-or-request-or-response_"
+			},
+			"RequestFilterNode": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/FilterLeafSubset_feedback-or-request-or-response_"
+					},
+					{
+						"$ref": "#/components/schemas/RequestFilterBranch"
+					},
+					{
+						"type": "string",
+						"enum": [
+							"all"
+						]
+					}
+				]
+			},
+			"RequestFilterBranch": {
+				"properties": {
+					"right": {
+						"$ref": "#/components/schemas/RequestFilterNode"
+					},
+					"operator": {
+						"type": "string",
+						"enum": [
+							"or",
+							"and"
+						]
+					},
+					"left": {
+						"$ref": "#/components/schemas/RequestFilterNode"
+					}
+				},
+				"required": [
+					"right",
+					"operator",
+					"left"
+				],
+				"type": "object"
+			},
+			"SortDirection": {
+				"type": "string",
+				"enum": [
+					"asc",
+					"desc"
+				]
+			},
+			"SortLeafRequest": {
+				"properties": {
+					"created_at": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"cache_created_at": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"latency": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"last_active": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"total_tokens": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"completion_tokens": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"prompt_tokens": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"user_id": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"body_model": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"is_cached": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"request_prompt": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"response_text": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"properties": {
+						"properties": {},
+						"additionalProperties": {
+							"$ref": "#/components/schemas/SortDirection"
+						},
+						"type": "object"
+					},
+					"values": {
+						"properties": {},
+						"additionalProperties": {
+							"$ref": "#/components/schemas/SortDirection"
+						},
+						"type": "object"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RequestQueryParams": {
+				"properties": {
+					"filter": {
+						"$ref": "#/components/schemas/RequestFilterNode"
+					},
+					"offset": {
+						"type": "number",
+						"format": "double"
+					},
+					"limit": {
+						"type": "number",
+						"format": "double"
+					},
+					"sort": {
+						"$ref": "#/components/schemas/SortLeafRequest"
+					},
+					"isCached": {
+						"type": "boolean"
+					},
+					"includeInputs": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"filter"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ResultSuccess_null_": {
+				"properties": {
+					"data": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result_null.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_null_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
+			"PromptsResult": {
 				"properties": {
 					"id": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
+						"type": "string"
+					},
+					"user_defined_id": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"pretty_name": {
+						"type": "string"
+					},
+					"major_version": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"id",
+					"user_defined_id",
+					"description",
+					"pretty_name",
+					"major_version"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ResultSuccess_PromptsResult-Array_": {
+				"properties": {
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/PromptsResult"
+						},
+						"type": "array"
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result_PromptsResult-Array.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_PromptsResult-Array_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
+			"Partial_PromptToOperators_": {
+				"properties": {
+					"id": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
+					},
+					"user_defined_id": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
+					}
+				},
+				"type": "object",
+				"description": "Make all properties in T optional"
+			},
+			"Pick_TablesAndViews.prompt_v2_": {
+				"properties": {
+					"prompt_v2": {
+						"$ref": "#/components/schemas/Partial_PromptToOperators_"
+					}
+				},
+				"required": [
+					"prompt_v2"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"FilterLeafSubset_prompt_v2_": {
+				"$ref": "#/components/schemas/Pick_TablesAndViews.prompt_v2_"
+			},
+			"PromptsFilterNode": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/FilterLeafSubset_prompt_v2_"
+					},
+					{
+						"$ref": "#/components/schemas/PromptsFilterBranch"
+					},
+					{
+						"type": "string",
+						"enum": [
+							"all"
+						]
+					}
+				]
+			},
+			"PromptsFilterBranch": {
+				"properties": {
+					"right": {
+						"$ref": "#/components/schemas/PromptsFilterNode"
+					},
+					"operator": {
+						"type": "string",
+						"enum": [
+							"or",
+							"and"
+						]
+					},
+					"left": {
+						"$ref": "#/components/schemas/PromptsFilterNode"
+					}
+				},
+				"required": [
+					"right",
+					"operator",
+					"left"
+				],
+				"type": "object"
+			},
+			"PromptsQueryParams": {
+				"properties": {
+					"filter": {
+						"$ref": "#/components/schemas/PromptsFilterNode"
+					}
+				},
+				"required": [
+					"filter"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"PromptResult": {
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"user_defined_id": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"pretty_name": {
+						"type": "string"
+					},
+					"major_version": {
+						"type": "number",
+						"format": "double"
+					},
+					"latest_version_id": {
+						"type": "string"
+					},
+					"latest_model_used": {
+						"type": "string"
 					},
 					"created_at": {
+						"type": "string"
+					},
+					"last_used": {
+						"type": "string"
+					},
+					"versions": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"id",
+					"user_defined_id",
+					"description",
+					"pretty_name",
+					"major_version",
+					"latest_version_id",
+					"latest_model_used",
+					"created_at",
+					"last_used",
+					"versions"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ResultSuccess_PromptResult_": {
+				"properties": {
+					"data": {
+						"$ref": "#/components/schemas/PromptResult"
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result_PromptResult.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_PromptResult_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
+			"PromptQueryParams": {
+				"properties": {
+					"timeFilter": {
+						"properties": {
+							"end": {
+								"type": "string"
+							},
+							"start": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"end",
+							"start"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"timeFilter"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"PromptVersionResult": {
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"minor_version": {
+						"type": "number",
+						"format": "double"
+					},
+					"major_version": {
+						"type": "number",
+						"format": "double"
+					},
+					"helicone_template": {
+						"type": "string"
+					},
+					"prompt_v2": {
+						"type": "string"
+					},
+					"model": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"id",
+					"minor_version",
+					"major_version",
+					"helicone_template",
+					"prompt_v2",
+					"model"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ResultSuccess_PromptVersionResult_": {
+				"properties": {
+					"data": {
+						"$ref": "#/components/schemas/PromptVersionResult"
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result_PromptVersionResult.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_PromptVersionResult_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
+			"PromptCreateSubversionParams": {
+				"properties": {
+					"newHeliconeTemplate": {}
+				},
+				"required": [
+					"newHeliconeTemplate"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ResultSuccess_PromptVersionResult-Array_": {
+				"properties": {
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/PromptVersionResult"
+						},
+						"type": "array"
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result_PromptVersionResult-Array.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_PromptVersionResult-Array_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
+			"NewDatasetParams": {
+				"properties": {
+					"datasetName": {
+						"type": "string"
+					},
+					"requestIds": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"datasetName",
+					"requestIds"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Partial_UserMetricsToOperators_": {
+				"properties": {
+					"user_id": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
+					},
+					"last_active": {
 						"$ref": "#/components/schemas/Partial_TimestampOperators_"
 					},
-					"rating": {
-						"$ref": "#/components/schemas/Partial_BooleanOperators_"
+					"total_requests": {
+						"$ref": "#/components/schemas/Partial_NumberOperators_"
+					}
+				},
+				"type": "object",
+				"description": "Make all properties in T optional"
+			},
+			"Partial_UserApiKeysTableToOperators_": {
+				"properties": {
+					"api_key_hash": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
 					},
-					"response_id": {
+					"api_key_name": {
 						"$ref": "#/components/schemas/Partial_TextOperators_"
 					}
 				},
@@ -1027,18 +1587,6 @@
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Partial_PromptToOperators_": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"user_defined_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
 			"Partial_PromptVersionsToOperators_": {
 				"properties": {
 					"minor_version": {
@@ -1167,438 +1715,6 @@
 					"left",
 					"operator",
 					"right"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"SortDirection": {
-				"type": "string",
-				"enum": [
-					"asc",
-					"desc"
-				]
-			},
-			"SortLeafRequest": {
-				"properties": {
-					"created_at": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"cache_created_at": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"latency": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"last_active": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"total_tokens": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"completion_tokens": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"prompt_tokens": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"user_id": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"body_model": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"is_cached": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"request_prompt": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"response_text": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"properties": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/SortDirection"
-						},
-						"type": "object"
-					},
-					"values": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/SortDirection"
-						},
-						"type": "object"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"RequestQueryParams": {
-				"properties": {
-					"filter": {
-						"$ref": "#/components/schemas/FilterNode"
-					},
-					"offset": {
-						"type": "number",
-						"format": "double"
-					},
-					"limit": {
-						"type": "number",
-						"format": "double"
-					},
-					"sort": {
-						"$ref": "#/components/schemas/SortLeafRequest"
-					},
-					"isCached": {
-						"type": "boolean"
-					},
-					"includeInputs": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"filter"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ResultSuccess_null_": {
-				"properties": {
-					"data": {
-						"type": "number",
-						"enum": [
-							null
-						],
-						"nullable": true
-					},
-					"error": {
-						"type": "number",
-						"enum": [
-							null
-						],
-						"nullable": true
-					}
-				},
-				"required": [
-					"data",
-					"error"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Result_null.string_": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ResultSuccess_null_"
-					},
-					{
-						"$ref": "#/components/schemas/ResultError_string_"
-					}
-				]
-			},
-			"PromptsResult": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"user_defined_id": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"pretty_name": {
-						"type": "string"
-					},
-					"major_version": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"id",
-					"user_defined_id",
-					"description",
-					"pretty_name",
-					"major_version"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ResultSuccess_PromptsResult-Array_": {
-				"properties": {
-					"data": {
-						"items": {
-							"$ref": "#/components/schemas/PromptsResult"
-						},
-						"type": "array"
-					},
-					"error": {
-						"type": "number",
-						"enum": [
-							null
-						],
-						"nullable": true
-					}
-				},
-				"required": [
-					"data",
-					"error"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Result_PromptsResult-Array.string_": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ResultSuccess_PromptsResult-Array_"
-					},
-					{
-						"$ref": "#/components/schemas/ResultError_string_"
-					}
-				]
-			},
-			"PromptsQueryParams": {
-				"properties": {
-					"filter": {
-						"$ref": "#/components/schemas/FilterNode"
-					}
-				},
-				"required": [
-					"filter"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"PromptResult": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"user_defined_id": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"pretty_name": {
-						"type": "string"
-					},
-					"major_version": {
-						"type": "number",
-						"format": "double"
-					},
-					"latest_version_id": {
-						"type": "string"
-					},
-					"latest_model_used": {
-						"type": "string"
-					},
-					"created_at": {
-						"type": "string"
-					},
-					"last_used": {
-						"type": "string"
-					},
-					"versions": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"id",
-					"user_defined_id",
-					"description",
-					"pretty_name",
-					"major_version",
-					"latest_version_id",
-					"latest_model_used",
-					"created_at",
-					"last_used",
-					"versions"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ResultSuccess_PromptResult_": {
-				"properties": {
-					"data": {
-						"$ref": "#/components/schemas/PromptResult"
-					},
-					"error": {
-						"type": "number",
-						"enum": [
-							null
-						],
-						"nullable": true
-					}
-				},
-				"required": [
-					"data",
-					"error"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Result_PromptResult.string_": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ResultSuccess_PromptResult_"
-					},
-					{
-						"$ref": "#/components/schemas/ResultError_string_"
-					}
-				]
-			},
-			"PromptQueryParams": {
-				"properties": {
-					"timeFilter": {
-						"properties": {
-							"end": {
-								"type": "string"
-							},
-							"start": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"end",
-							"start"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"timeFilter"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"PromptVersionResult": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"minor_version": {
-						"type": "number",
-						"format": "double"
-					},
-					"major_version": {
-						"type": "number",
-						"format": "double"
-					},
-					"helicone_template": {
-						"type": "string"
-					},
-					"prompt_v2": {
-						"type": "string"
-					},
-					"model": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"id",
-					"minor_version",
-					"major_version",
-					"helicone_template",
-					"prompt_v2",
-					"model"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ResultSuccess_PromptVersionResult_": {
-				"properties": {
-					"data": {
-						"$ref": "#/components/schemas/PromptVersionResult"
-					},
-					"error": {
-						"type": "number",
-						"enum": [
-							null
-						],
-						"nullable": true
-					}
-				},
-				"required": [
-					"data",
-					"error"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Result_PromptVersionResult.string_": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ResultSuccess_PromptVersionResult_"
-					},
-					{
-						"$ref": "#/components/schemas/ResultError_string_"
-					}
-				]
-			},
-			"PromptCreateSubversionParams": {
-				"properties": {
-					"newHeliconeTemplate": {}
-				},
-				"required": [
-					"newHeliconeTemplate"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ResultSuccess_PromptVersionResult-Array_": {
-				"properties": {
-					"data": {
-						"items": {
-							"$ref": "#/components/schemas/PromptVersionResult"
-						},
-						"type": "array"
-					},
-					"error": {
-						"type": "number",
-						"enum": [
-							null
-						],
-						"nullable": true
-					}
-				},
-				"required": [
-					"data",
-					"error"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Result_PromptVersionResult-Array.string_": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ResultSuccess_PromptVersionResult-Array_"
-					},
-					{
-						"$ref": "#/components/schemas/ResultError_string_"
-					}
-				]
-			},
-			"NewDatasetParams": {
-				"properties": {
-					"datasetName": {
-						"type": "string"
-					},
-					"requestIds": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"datasetName",
-					"requestIds"
 				],
 				"type": "object",
 				"additionalProperties": false

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -739,7 +739,7 @@
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Pick_TablesAndViews.feedback-or-request-or-response_": {
+			"Pick_FilterLeaf.feedback-or-request-or-response_": {
 				"properties": {
 					"feedback": {
 						"$ref": "#/components/schemas/Partial_FeedbackTableToOperators_"
@@ -751,16 +751,11 @@
 						"$ref": "#/components/schemas/Partial_ResponseTableToOperators_"
 					}
 				},
-				"required": [
-					"feedback",
-					"request",
-					"response"
-				],
 				"type": "object",
 				"description": "From T, pick a set of properties whose keys are in the union K"
 			},
 			"FilterLeafSubset_feedback-or-request-or-response_": {
-				"$ref": "#/components/schemas/Pick_TablesAndViews.feedback-or-request-or-response_"
+				"$ref": "#/components/schemas/Pick_FilterLeaf.feedback-or-request-or-response_"
 			},
 			"RequestFilterNode": {
 				"anyOf": [
@@ -1001,20 +996,17 @@
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Pick_TablesAndViews.prompt_v2_": {
+			"Pick_FilterLeaf.prompt_v2_": {
 				"properties": {
 					"prompt_v2": {
 						"$ref": "#/components/schemas/Partial_PromptToOperators_"
 					}
 				},
-				"required": [
-					"prompt_v2"
-				],
 				"type": "object",
 				"description": "From T, pick a set of properties whose keys are in the union K"
 			},
 			"FilterLeafSubset_prompt_v2_": {
-				"$ref": "#/components/schemas/Pick_TablesAndViews.prompt_v2_"
+				"$ref": "#/components/schemas/Pick_FilterLeaf.prompt_v2_"
 			},
 			"PromptsFilterNode": {
 				"anyOf": [

--- a/valhalla/jawn/src/controllers/public/experimentController.ts
+++ b/valhalla/jawn/src/controllers/public/experimentController.ts
@@ -1,24 +1,8 @@
 // src/users/usersController.ts
-import {
-  Body,
-  Controller,
-  Example,
-  Path,
-  Post,
-  Request,
-  Route,
-  Security,
-  Tags,
-} from "tsoa";
-import { Result, err, ok } from "../../lib/shared/result";
-import { FilterNode } from "../../lib/shared/filters/filterDefs";
-import { SortLeafRequest } from "../../lib/shared/sorts/requests/sorts";
-import { HeliconeRequest } from "../../lib/stores/request/request";
-import { RequestManager } from "../../managers/request/RequestManager";
-import { JawnAuthenticatedRequest } from "../../types/request";
-import { PromptManager } from "../../managers/prompt/PromptManager";
-import { DatasetManager } from "../../managers/dataset/DatasetManager";
+import { Body, Controller, Post, Request, Route, Security, Tags } from "tsoa";
+import { Result, err } from "../../lib/shared/result";
 import { ExperimentManager } from "../../managers/experiment/ExperimentManager";
+import { JawnAuthenticatedRequest } from "../../types/request";
 
 export interface NewExperimentParams {
   datasetId: string;

--- a/valhalla/jawn/src/controllers/public/experimentDatasetController.ts
+++ b/valhalla/jawn/src/controllers/public/experimentDatasetController.ts
@@ -25,7 +25,7 @@ export interface NewDatasetParams {
 
 export interface RandomDatasetParams {
   datasetName: string;
-  filter: FilterNode;
+  filter: DatasetFilterNode;
   offset?: number;
   limit?: number;
 }

--- a/valhalla/jawn/src/controllers/public/experimentDatasetController.ts
+++ b/valhalla/jawn/src/controllers/public/experimentDatasetController.ts
@@ -1,9 +1,22 @@
 // src/users/usersController.ts
 import { Body, Controller, Post, Request, Route, Security, Tags } from "tsoa";
 import { Result, err, ok } from "../../lib/shared/result";
-import { FilterNode } from "../../lib/shared/filters/filterDefs";
+import {
+  FilterLeafSubset,
+  FilterNode,
+} from "../../lib/shared/filters/filterDefs";
 import { DatasetManager } from "../../managers/dataset/DatasetManager";
 import { JawnAuthenticatedRequest } from "../../types/request";
+
+export type DatasetFilterBranch = {
+  left: DatasetFilterNode;
+  operator: "or" | "and";
+  right: DatasetFilterNode;
+};
+type DatasetFilterNode =
+  | FilterLeafSubset<"request" | "prompts_versions">
+  | DatasetFilterBranch
+  | "all";
 
 export interface NewDatasetParams {
   datasetName: string;

--- a/valhalla/jawn/src/controllers/public/promptController.ts
+++ b/valhalla/jawn/src/controllers/public/promptController.ts
@@ -10,12 +10,25 @@ import {
   Tags,
 } from "tsoa";
 import { Result } from "../../lib/shared/result";
-import { FilterNode } from "../../lib/shared/filters/filterDefs";
+import {
+  FilterLeafSubset,
+  FilterNode,
+} from "../../lib/shared/filters/filterDefs";
 import { PromptManager } from "../../managers/prompt/PromptManager";
 import { JawnAuthenticatedRequest } from "../../types/request";
 
+export type PromptsFilterBranch = {
+  left: PromptsFilterNode;
+  operator: "or" | "and";
+  right: PromptsFilterNode;
+};
+type PromptsFilterNode =
+  | FilterLeafSubset<"prompt_v2">
+  | PromptsFilterBranch
+  | "all";
+
 export interface PromptsQueryParams {
-  filter: FilterNode;
+  filter: PromptsFilterNode;
 }
 
 export interface PromptsResult {

--- a/valhalla/jawn/src/controllers/public/requestController.ts
+++ b/valhalla/jawn/src/controllers/public/requestController.ts
@@ -11,15 +11,25 @@ import {
   Security,
   Tags,
 } from "tsoa";
+import { FilterLeafSubset } from "../../lib/shared/filters/filterDefs";
 import { Result } from "../../lib/shared/result";
-import { FilterNode } from "../../lib/shared/filters/filterDefs";
 import { SortLeafRequest } from "../../lib/shared/sorts/requests/sorts";
 import { HeliconeRequest } from "../../lib/stores/request/request";
 import { RequestManager } from "../../managers/request/RequestManager";
 import { JawnAuthenticatedRequest } from "../../types/request";
 
+export type RequestFilterBranch = {
+  left: RequestFilterNode;
+  operator: "or" | "and";
+  right: RequestFilterNode;
+};
+type RequestFilterNode =
+  | FilterLeafSubset<"feedback" | "request" | "response">
+  | RequestFilterBranch
+  | "all";
+
 export interface RequestQueryParams {
-  filter: FilterNode;
+  filter: RequestFilterNode;
   offset?: number;
   limit?: number;
   sort?: SortLeafRequest;

--- a/valhalla/jawn/src/lib/shared/filters/filterDefs.ts
+++ b/valhalla/jawn/src/lib/shared/filters/filterDefs.ts
@@ -284,6 +284,26 @@ export interface FilterBranch {
 
 export type FilterNode = FilterLeaf | FilterBranch | "all";
 
+export type FilterLeafSubset<T extends keyof TablesAndViews> = Pick<
+  TablesAndViews,
+  T
+>;
+
+// I am keeping this here just incase anyone in the future tries to do this... we know it has been done before.
+// Basically this would be awesome instead of having to create types like RequestFilterNode, but tsoa is not
+// sophisticated enough to handle this.
+//
+// export type FilterBranchSubset<T extends TableAndViewKeys> = {
+//   left: FilterNodeSubset<T>;
+//   operator: "or" | "and";
+//   right: FilterNodeSubset<T>;
+// };
+
+// export type FilterNodeSubset<T extends TableAndViewKeys> =
+//   | FilterLeafSubset<T>
+//   | FilterBranchSubset<T>
+//   | "all";
+
 export function timeFilterToFilterNode(
   filter: TimeFilter,
   table: keyof TablesAndViews

--- a/valhalla/jawn/src/lib/shared/filters/filterDefs.ts
+++ b/valhalla/jawn/src/lib/shared/filters/filterDefs.ts
@@ -285,7 +285,7 @@ export interface FilterBranch {
 export type FilterNode = FilterLeaf | FilterBranch | "all";
 
 export type FilterLeafSubset<T extends keyof TablesAndViews> = Pick<
-  TablesAndViews,
+  FilterLeaf,
   T
 >;
 

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -244,14 +244,14 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"body_tokens":{"ref":"Partial_NumberOperators_"},"body_model":{"ref":"Partial_TextOperators_"},"body_completion":{"ref":"Partial_TextOperators_"},"status":{"ref":"Partial_NumberOperators_"},"model":{"ref":"Partial_TextOperators_"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_TablesAndViews.feedback-or-request-or-response_": {
+    "Pick_FilterLeaf.feedback-or-request-or-response_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"feedback":{"ref":"Partial_FeedbackTableToOperators_","required":true},"request":{"ref":"Partial_RequestTableToOperators_","required":true},"response":{"ref":"Partial_ResponseTableToOperators_","required":true}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"feedback":{"ref":"Partial_FeedbackTableToOperators_"},"request":{"ref":"Partial_RequestTableToOperators_"},"response":{"ref":"Partial_ResponseTableToOperators_"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "FilterLeafSubset_feedback-or-request-or-response_": {
         "dataType": "refAlias",
-        "type": {"ref":"Pick_TablesAndViews.feedback-or-request-or-response_","validators":{}},
+        "type": {"ref":"Pick_FilterLeaf.feedback-or-request-or-response_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "RequestFilterNode": {
@@ -348,14 +348,14 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"ref":"Partial_TextOperators_"},"user_defined_id":{"ref":"Partial_TextOperators_"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_TablesAndViews.prompt_v2_": {
+    "Pick_FilterLeaf.prompt_v2_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"prompt_v2":{"ref":"Partial_PromptToOperators_","required":true}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"prompt_v2":{"ref":"Partial_PromptToOperators_"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "FilterLeafSubset_prompt_v2_": {
         "dataType": "refAlias",
-        "type": {"ref":"Pick_TablesAndViews.prompt_v2_","validators":{}},
+        "type": {"ref":"Pick_FilterLeaf.prompt_v2_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "PromptsFilterNode": {

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -473,106 +473,36 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_UserMetricsToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"user_id":{"ref":"Partial_TextOperators_"},"last_active":{"ref":"Partial_TimestampOperators_"},"total_requests":{"ref":"Partial_NumberOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_UserApiKeysTableToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"api_key_hash":{"ref":"Partial_TextOperators_"},"api_key_name":{"ref":"Partial_TextOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_PropertiesTableToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"auth_hash":{"ref":"Partial_TextOperators_"},"key":{"ref":"Partial_TextOperators_"},"value":{"ref":"Partial_TextOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_TimestampOperatorsTyped_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"gte":{"dataType":"datetime"},"lte":{"dataType":"datetime"},"lt":{"dataType":"datetime"},"gt":{"dataType":"datetime"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_RequestResponseLogToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"latency":{"ref":"Partial_NumberOperators_"},"status":{"ref":"Partial_NumberOperators_"},"request_created_at":{"ref":"Partial_TimestampOperatorsTyped_"},"response_created_at":{"ref":"Partial_TimestampOperatorsTyped_"},"auth_hash":{"ref":"Partial_TextOperators_"},"model":{"ref":"Partial_TextOperators_"},"user_id":{"ref":"Partial_TextOperators_"},"organization_id":{"ref":"Partial_TextOperators_"},"node_id":{"ref":"Partial_TextOperators_"},"job_id":{"ref":"Partial_TextOperators_"},"threat":{"ref":"Partial_BooleanOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_UserViewToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"user_id":{"ref":"Partial_TextOperators_"},"active_for":{"ref":"Partial_NumberOperators_"},"first_active":{"ref":"Partial_TimestampOperators_"},"last_active":{"ref":"Partial_TimestampOperators_"},"total_requests":{"ref":"Partial_NumberOperators_"},"average_requests_per_day_active":{"ref":"Partial_NumberOperators_"},"average_tokens_per_request":{"ref":"Partial_NumberOperators_"},"total_completion_tokens":{"ref":"Partial_NumberOperators_"},"total_prompt_token":{"ref":"Partial_NumberOperators_"},"cost":{"ref":"Partial_NumberOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_PropertiesCopyV2ToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"key":{"ref":"Partial_TextOperators_"},"value":{"ref":"Partial_TextOperators_"},"organization_id":{"ref":"Partial_TextOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_PropertyWithResponseV1ToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"property_key":{"ref":"Partial_TextOperators_"},"property_value":{"ref":"Partial_TextOperators_"},"request_created_at":{"ref":"Partial_TimestampOperatorsTyped_"},"organization_id":{"ref":"Partial_TextOperators_"},"threat":{"ref":"Partial_BooleanOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_JobToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"ref":"Partial_TextOperators_"},"name":{"ref":"Partial_TextOperators_"},"description":{"ref":"Partial_TextOperators_"},"status":{"ref":"Partial_TextOperators_"},"created_at":{"ref":"Partial_TimestampOperators_"},"updated_at":{"ref":"Partial_TimestampOperators_"},"timeout_seconds":{"ref":"Partial_NumberOperators_"},"custom_properties":{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"Partial_TextOperators_"}},"org_id":{"ref":"Partial_TextOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_NodesToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"ref":"Partial_TextOperators_"},"name":{"ref":"Partial_TextOperators_"},"description":{"ref":"Partial_TextOperators_"},"job_id":{"ref":"Partial_TextOperators_"},"status":{"ref":"Partial_TextOperators_"},"created_at":{"ref":"Partial_TimestampOperators_"},"updated_at":{"ref":"Partial_TimestampOperators_"},"timeout_seconds":{"ref":"Partial_NumberOperators_"},"custom_properties":{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"Partial_TextOperators_"}},"org_id":{"ref":"Partial_TextOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_CacheHitsTableToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"organization_id":{"ref":"Partial_TextOperators_"},"request_id":{"ref":"Partial_TextOperators_"},"latency":{"ref":"Partial_NumberOperators_"},"completion_tokens":{"ref":"Partial_NumberOperators_"},"prompt_tokens":{"ref":"Partial_NumberOperators_"},"created_at":{"ref":"Partial_TimestampOperatorsTyped_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_RateLimitTableToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"organization_id":{"ref":"Partial_TextOperators_"},"created_at":{"ref":"Partial_TimestampOperatorsTyped_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Partial_PromptVersionsToOperators_": {
         "dataType": "refAlias",
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"minor_version":{"ref":"Partial_NumberOperators_"},"major_version":{"ref":"Partial_NumberOperators_"},"id":{"ref":"Partial_TextOperators_"},"prompt_v2":{"ref":"Partial_TextOperators_"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_TablesAndViews_": {
+    "Pick_FilterLeaf.request-or-prompts_versions_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"user_metrics":{"ref":"Partial_UserMetricsToOperators_"},"user_api_keys":{"ref":"Partial_UserApiKeysTableToOperators_"},"response":{"ref":"Partial_ResponseTableToOperators_"},"request":{"ref":"Partial_RequestTableToOperators_"},"feedback":{"ref":"Partial_FeedbackTableToOperators_"},"properties_table":{"ref":"Partial_PropertiesTableToOperators_"},"request_response_log":{"ref":"Partial_RequestResponseLogToOperators_"},"users_view":{"ref":"Partial_UserViewToOperators_"},"properties_v3":{"ref":"Partial_PropertiesCopyV2ToOperators_"},"property_with_response_v1":{"ref":"Partial_PropertyWithResponseV1ToOperators_"},"job":{"ref":"Partial_JobToOperators_"},"job_node":{"ref":"Partial_NodesToOperators_"},"cache_hits":{"ref":"Partial_CacheHitsTableToOperators_"},"rate_limit_log":{"ref":"Partial_RateLimitTableToOperators_"},"properties":{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"Partial_TextOperators_"}},"values":{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"Partial_TextOperators_"}},"prompt_v2":{"ref":"Partial_PromptToOperators_"},"prompts_versions":{"ref":"Partial_PromptVersionsToOperators_"}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"request":{"ref":"Partial_RequestTableToOperators_"},"prompts_versions":{"ref":"Partial_PromptVersionsToOperators_"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SingleKey_TablesAndViews_": {
+    "FilterLeafSubset_request-or-prompts_versions_": {
         "dataType": "refAlias",
-        "type": {"ref":"Partial_TablesAndViews_","validators":{}},
+        "type": {"ref":"Pick_FilterLeaf.request-or-prompts_versions_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "FilterLeaf": {
+    "DatasetFilterNode": {
         "dataType": "refAlias",
-        "type": {"ref":"SingleKey_TablesAndViews_","validators":{}},
+        "type": {"dataType":"union","subSchemas":[{"ref":"FilterLeafSubset_request-or-prompts_versions_"},{"ref":"DatasetFilterBranch"},{"dataType":"enum","enums":["all"]}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "FilterNode": {
+    "DatasetFilterBranch": {
         "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"FilterLeaf"},{"ref":"FilterBranch"},{"dataType":"enum","enums":["all"]}],"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "FilterBranch": {
-        "dataType": "refObject",
-        "properties": {
-            "left": {"ref":"FilterNode","required":true},
-            "operator": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["or"]},{"dataType":"enum","enums":["and"]}],"required":true},
-            "right": {"ref":"FilterNode","required":true},
-        },
-        "additionalProperties": false,
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"right":{"ref":"DatasetFilterNode","required":true},"operator":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["or"]},{"dataType":"enum","enums":["and"]}],"required":true},"left":{"ref":"DatasetFilterNode","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "RandomDatasetParams": {
         "dataType": "refObject",
         "properties": {
             "datasetName": {"dataType":"string","required":true},
-            "filter": {"ref":"FilterNode","required":true},
+            "filter": {"ref":"DatasetFilterNode","required":true},
             "offset": {"dataType":"double"},
             "limit": {"dataType":"double"},
         },

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -209,9 +209,9 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_HeliconeRequest-Array_"},{"ref":"ResultError_string_"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_TextOperators_": {
+    "Partial_NumberOperators_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"not-equals":{"dataType":"string"},"equals":{"dataType":"string"},"like":{"dataType":"string"},"ilike":{"dataType":"string"},"contains":{"dataType":"string"},"not-contains":{"dataType":"string"}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"not-equals":{"dataType":"double"},"equals":{"dataType":"double"},"gte":{"dataType":"double"},"lte":{"dataType":"double"},"lt":{"dataType":"double"},"gt":{"dataType":"double"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Partial_TimestampOperators_": {
@@ -219,34 +219,14 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"gte":{"dataType":"string"},"lte":{"dataType":"string"},"lt":{"dataType":"string"},"gt":{"dataType":"string"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_NumberOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"not-equals":{"dataType":"double"},"equals":{"dataType":"double"},"gte":{"dataType":"double"},"lte":{"dataType":"double"},"lt":{"dataType":"double"},"gt":{"dataType":"double"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_UserMetricsToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"user_id":{"ref":"Partial_TextOperators_"},"last_active":{"ref":"Partial_TimestampOperators_"},"total_requests":{"ref":"Partial_NumberOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_UserApiKeysTableToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"api_key_hash":{"ref":"Partial_TextOperators_"},"api_key_name":{"ref":"Partial_TextOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_ResponseTableToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"body_tokens":{"ref":"Partial_NumberOperators_"},"body_model":{"ref":"Partial_TextOperators_"},"body_completion":{"ref":"Partial_TextOperators_"},"status":{"ref":"Partial_NumberOperators_"},"model":{"ref":"Partial_TextOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_RequestTableToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"prompt":{"ref":"Partial_TextOperators_"},"created_at":{"ref":"Partial_TimestampOperators_"},"user_id":{"ref":"Partial_TextOperators_"},"auth_hash":{"ref":"Partial_TextOperators_"},"org_id":{"ref":"Partial_TextOperators_"},"id":{"ref":"Partial_TextOperators_"},"node_id":{"ref":"Partial_TextOperators_"},"model":{"ref":"Partial_TextOperators_"},"modelOverride":{"ref":"Partial_TextOperators_"},"path":{"ref":"Partial_TextOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Partial_BooleanOperators_": {
         "dataType": "refAlias",
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"equals":{"dataType":"boolean"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_TextOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"not-equals":{"dataType":"string"},"equals":{"dataType":"string"},"like":{"dataType":"string"},"ilike":{"dataType":"string"},"contains":{"dataType":"string"},"not-contains":{"dataType":"string"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Partial_FeedbackTableToOperators_": {
@@ -254,94 +234,34 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"ref":"Partial_NumberOperators_"},"created_at":{"ref":"Partial_TimestampOperators_"},"rating":{"ref":"Partial_BooleanOperators_"},"response_id":{"ref":"Partial_TextOperators_"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_PropertiesTableToOperators_": {
+    "Partial_RequestTableToOperators_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"auth_hash":{"ref":"Partial_TextOperators_"},"key":{"ref":"Partial_TextOperators_"},"value":{"ref":"Partial_TextOperators_"}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"prompt":{"ref":"Partial_TextOperators_"},"created_at":{"ref":"Partial_TimestampOperators_"},"user_id":{"ref":"Partial_TextOperators_"},"auth_hash":{"ref":"Partial_TextOperators_"},"org_id":{"ref":"Partial_TextOperators_"},"id":{"ref":"Partial_TextOperators_"},"node_id":{"ref":"Partial_TextOperators_"},"model":{"ref":"Partial_TextOperators_"},"modelOverride":{"ref":"Partial_TextOperators_"},"path":{"ref":"Partial_TextOperators_"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_TimestampOperatorsTyped_": {
+    "Partial_ResponseTableToOperators_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"gte":{"dataType":"datetime"},"lte":{"dataType":"datetime"},"lt":{"dataType":"datetime"},"gt":{"dataType":"datetime"}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"body_tokens":{"ref":"Partial_NumberOperators_"},"body_model":{"ref":"Partial_TextOperators_"},"body_completion":{"ref":"Partial_TextOperators_"},"status":{"ref":"Partial_NumberOperators_"},"model":{"ref":"Partial_TextOperators_"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_RequestResponseLogToOperators_": {
+    "Pick_TablesAndViews.feedback-or-request-or-response_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"latency":{"ref":"Partial_NumberOperators_"},"status":{"ref":"Partial_NumberOperators_"},"request_created_at":{"ref":"Partial_TimestampOperatorsTyped_"},"response_created_at":{"ref":"Partial_TimestampOperatorsTyped_"},"auth_hash":{"ref":"Partial_TextOperators_"},"model":{"ref":"Partial_TextOperators_"},"user_id":{"ref":"Partial_TextOperators_"},"organization_id":{"ref":"Partial_TextOperators_"},"node_id":{"ref":"Partial_TextOperators_"},"job_id":{"ref":"Partial_TextOperators_"},"threat":{"ref":"Partial_BooleanOperators_"}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"feedback":{"ref":"Partial_FeedbackTableToOperators_","required":true},"request":{"ref":"Partial_RequestTableToOperators_","required":true},"response":{"ref":"Partial_ResponseTableToOperators_","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_UserViewToOperators_": {
+    "FilterLeafSubset_feedback-or-request-or-response_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"user_id":{"ref":"Partial_TextOperators_"},"active_for":{"ref":"Partial_NumberOperators_"},"first_active":{"ref":"Partial_TimestampOperators_"},"last_active":{"ref":"Partial_TimestampOperators_"},"total_requests":{"ref":"Partial_NumberOperators_"},"average_requests_per_day_active":{"ref":"Partial_NumberOperators_"},"average_tokens_per_request":{"ref":"Partial_NumberOperators_"},"total_completion_tokens":{"ref":"Partial_NumberOperators_"},"total_prompt_token":{"ref":"Partial_NumberOperators_"},"cost":{"ref":"Partial_NumberOperators_"}},"validators":{}},
+        "type": {"ref":"Pick_TablesAndViews.feedback-or-request-or-response_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_PropertiesCopyV2ToOperators_": {
+    "RequestFilterNode": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"key":{"ref":"Partial_TextOperators_"},"value":{"ref":"Partial_TextOperators_"},"organization_id":{"ref":"Partial_TextOperators_"}},"validators":{}},
+        "type": {"dataType":"union","subSchemas":[{"ref":"FilterLeafSubset_feedback-or-request-or-response_"},{"ref":"RequestFilterBranch"},{"dataType":"enum","enums":["all"]}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_PropertyWithResponseV1ToOperators_": {
+    "RequestFilterBranch": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"property_key":{"ref":"Partial_TextOperators_"},"property_value":{"ref":"Partial_TextOperators_"},"request_created_at":{"ref":"Partial_TimestampOperatorsTyped_"},"organization_id":{"ref":"Partial_TextOperators_"},"threat":{"ref":"Partial_BooleanOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_JobToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"ref":"Partial_TextOperators_"},"name":{"ref":"Partial_TextOperators_"},"description":{"ref":"Partial_TextOperators_"},"status":{"ref":"Partial_TextOperators_"},"created_at":{"ref":"Partial_TimestampOperators_"},"updated_at":{"ref":"Partial_TimestampOperators_"},"timeout_seconds":{"ref":"Partial_NumberOperators_"},"custom_properties":{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"Partial_TextOperators_"}},"org_id":{"ref":"Partial_TextOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_NodesToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"ref":"Partial_TextOperators_"},"name":{"ref":"Partial_TextOperators_"},"description":{"ref":"Partial_TextOperators_"},"job_id":{"ref":"Partial_TextOperators_"},"status":{"ref":"Partial_TextOperators_"},"created_at":{"ref":"Partial_TimestampOperators_"},"updated_at":{"ref":"Partial_TimestampOperators_"},"timeout_seconds":{"ref":"Partial_NumberOperators_"},"custom_properties":{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"Partial_TextOperators_"}},"org_id":{"ref":"Partial_TextOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_CacheHitsTableToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"organization_id":{"ref":"Partial_TextOperators_"},"request_id":{"ref":"Partial_TextOperators_"},"latency":{"ref":"Partial_NumberOperators_"},"completion_tokens":{"ref":"Partial_NumberOperators_"},"prompt_tokens":{"ref":"Partial_NumberOperators_"},"created_at":{"ref":"Partial_TimestampOperatorsTyped_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_RateLimitTableToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"organization_id":{"ref":"Partial_TextOperators_"},"created_at":{"ref":"Partial_TimestampOperatorsTyped_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_PromptToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"ref":"Partial_TextOperators_"},"user_defined_id":{"ref":"Partial_TextOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_PromptVersionsToOperators_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"minor_version":{"ref":"Partial_NumberOperators_"},"major_version":{"ref":"Partial_NumberOperators_"},"id":{"ref":"Partial_TextOperators_"},"prompt_v2":{"ref":"Partial_TextOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Partial_TablesAndViews_": {
-        "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"user_metrics":{"ref":"Partial_UserMetricsToOperators_"},"user_api_keys":{"ref":"Partial_UserApiKeysTableToOperators_"},"response":{"ref":"Partial_ResponseTableToOperators_"},"request":{"ref":"Partial_RequestTableToOperators_"},"feedback":{"ref":"Partial_FeedbackTableToOperators_"},"properties_table":{"ref":"Partial_PropertiesTableToOperators_"},"request_response_log":{"ref":"Partial_RequestResponseLogToOperators_"},"users_view":{"ref":"Partial_UserViewToOperators_"},"properties_v3":{"ref":"Partial_PropertiesCopyV2ToOperators_"},"property_with_response_v1":{"ref":"Partial_PropertyWithResponseV1ToOperators_"},"job":{"ref":"Partial_JobToOperators_"},"job_node":{"ref":"Partial_NodesToOperators_"},"cache_hits":{"ref":"Partial_CacheHitsTableToOperators_"},"rate_limit_log":{"ref":"Partial_RateLimitTableToOperators_"},"properties":{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"Partial_TextOperators_"}},"values":{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"Partial_TextOperators_"}},"prompt_v2":{"ref":"Partial_PromptToOperators_"},"prompts_versions":{"ref":"Partial_PromptVersionsToOperators_"}},"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "SingleKey_TablesAndViews_": {
-        "dataType": "refAlias",
-        "type": {"ref":"Partial_TablesAndViews_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "FilterLeaf": {
-        "dataType": "refAlias",
-        "type": {"ref":"SingleKey_TablesAndViews_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "FilterNode": {
-        "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"FilterLeaf"},{"ref":"FilterBranch"},{"dataType":"enum","enums":["all"]}],"validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "FilterBranch": {
-        "dataType": "refObject",
-        "properties": {
-            "left": {"ref":"FilterNode","required":true},
-            "operator": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["or"]},{"dataType":"enum","enums":["and"]}],"required":true},
-            "right": {"ref":"FilterNode","required":true},
-        },
-        "additionalProperties": false,
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"right":{"ref":"RequestFilterNode","required":true},"operator":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["or"]},{"dataType":"enum","enums":["and"]}],"required":true},"left":{"ref":"RequestFilterNode","required":true}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "SortDirection": {
@@ -373,7 +293,7 @@ const models: TsoaRoute.Models = {
     "RequestQueryParams": {
         "dataType": "refObject",
         "properties": {
-            "filter": {"ref":"FilterNode","required":true},
+            "filter": {"ref":"RequestFilterNode","required":true},
             "offset": {"dataType":"double"},
             "limit": {"dataType":"double"},
             "sort": {"ref":"SortLeafRequest"},
@@ -423,10 +343,35 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_PromptsResult-Array_"},{"ref":"ResultError_string_"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_PromptToOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"ref":"Partial_TextOperators_"},"user_defined_id":{"ref":"Partial_TextOperators_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Pick_TablesAndViews.prompt_v2_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"prompt_v2":{"ref":"Partial_PromptToOperators_","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "FilterLeafSubset_prompt_v2_": {
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_TablesAndViews.prompt_v2_","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "PromptsFilterNode": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"FilterLeafSubset_prompt_v2_"},{"ref":"PromptsFilterBranch"},{"dataType":"enum","enums":["all"]}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "PromptsFilterBranch": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"right":{"ref":"PromptsFilterNode","required":true},"operator":{"dataType":"union","subSchemas":[{"dataType":"enum","enums":["or"]},{"dataType":"enum","enums":["and"]}],"required":true},"left":{"ref":"PromptsFilterNode","required":true}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "PromptsQueryParams": {
         "dataType": "refObject",
         "properties": {
-            "filter": {"ref":"FilterNode","required":true},
+            "filter": {"ref":"PromptsFilterNode","required":true},
         },
         "additionalProperties": false,
     },
@@ -524,6 +469,101 @@ const models: TsoaRoute.Models = {
         "properties": {
             "datasetName": {"dataType":"string","required":true},
             "requestIds": {"dataType":"array","array":{"dataType":"string"},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_UserMetricsToOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"user_id":{"ref":"Partial_TextOperators_"},"last_active":{"ref":"Partial_TimestampOperators_"},"total_requests":{"ref":"Partial_NumberOperators_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_UserApiKeysTableToOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"api_key_hash":{"ref":"Partial_TextOperators_"},"api_key_name":{"ref":"Partial_TextOperators_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_PropertiesTableToOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"auth_hash":{"ref":"Partial_TextOperators_"},"key":{"ref":"Partial_TextOperators_"},"value":{"ref":"Partial_TextOperators_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_TimestampOperatorsTyped_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"gte":{"dataType":"datetime"},"lte":{"dataType":"datetime"},"lt":{"dataType":"datetime"},"gt":{"dataType":"datetime"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_RequestResponseLogToOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"latency":{"ref":"Partial_NumberOperators_"},"status":{"ref":"Partial_NumberOperators_"},"request_created_at":{"ref":"Partial_TimestampOperatorsTyped_"},"response_created_at":{"ref":"Partial_TimestampOperatorsTyped_"},"auth_hash":{"ref":"Partial_TextOperators_"},"model":{"ref":"Partial_TextOperators_"},"user_id":{"ref":"Partial_TextOperators_"},"organization_id":{"ref":"Partial_TextOperators_"},"node_id":{"ref":"Partial_TextOperators_"},"job_id":{"ref":"Partial_TextOperators_"},"threat":{"ref":"Partial_BooleanOperators_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_UserViewToOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"user_id":{"ref":"Partial_TextOperators_"},"active_for":{"ref":"Partial_NumberOperators_"},"first_active":{"ref":"Partial_TimestampOperators_"},"last_active":{"ref":"Partial_TimestampOperators_"},"total_requests":{"ref":"Partial_NumberOperators_"},"average_requests_per_day_active":{"ref":"Partial_NumberOperators_"},"average_tokens_per_request":{"ref":"Partial_NumberOperators_"},"total_completion_tokens":{"ref":"Partial_NumberOperators_"},"total_prompt_token":{"ref":"Partial_NumberOperators_"},"cost":{"ref":"Partial_NumberOperators_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_PropertiesCopyV2ToOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"key":{"ref":"Partial_TextOperators_"},"value":{"ref":"Partial_TextOperators_"},"organization_id":{"ref":"Partial_TextOperators_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_PropertyWithResponseV1ToOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"property_key":{"ref":"Partial_TextOperators_"},"property_value":{"ref":"Partial_TextOperators_"},"request_created_at":{"ref":"Partial_TimestampOperatorsTyped_"},"organization_id":{"ref":"Partial_TextOperators_"},"threat":{"ref":"Partial_BooleanOperators_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_JobToOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"ref":"Partial_TextOperators_"},"name":{"ref":"Partial_TextOperators_"},"description":{"ref":"Partial_TextOperators_"},"status":{"ref":"Partial_TextOperators_"},"created_at":{"ref":"Partial_TimestampOperators_"},"updated_at":{"ref":"Partial_TimestampOperators_"},"timeout_seconds":{"ref":"Partial_NumberOperators_"},"custom_properties":{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"Partial_TextOperators_"}},"org_id":{"ref":"Partial_TextOperators_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_NodesToOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"ref":"Partial_TextOperators_"},"name":{"ref":"Partial_TextOperators_"},"description":{"ref":"Partial_TextOperators_"},"job_id":{"ref":"Partial_TextOperators_"},"status":{"ref":"Partial_TextOperators_"},"created_at":{"ref":"Partial_TimestampOperators_"},"updated_at":{"ref":"Partial_TimestampOperators_"},"timeout_seconds":{"ref":"Partial_NumberOperators_"},"custom_properties":{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"Partial_TextOperators_"}},"org_id":{"ref":"Partial_TextOperators_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_CacheHitsTableToOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"organization_id":{"ref":"Partial_TextOperators_"},"request_id":{"ref":"Partial_TextOperators_"},"latency":{"ref":"Partial_NumberOperators_"},"completion_tokens":{"ref":"Partial_NumberOperators_"},"prompt_tokens":{"ref":"Partial_NumberOperators_"},"created_at":{"ref":"Partial_TimestampOperatorsTyped_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_RateLimitTableToOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"organization_id":{"ref":"Partial_TextOperators_"},"created_at":{"ref":"Partial_TimestampOperatorsTyped_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_PromptVersionsToOperators_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"minor_version":{"ref":"Partial_NumberOperators_"},"major_version":{"ref":"Partial_NumberOperators_"},"id":{"ref":"Partial_TextOperators_"},"prompt_v2":{"ref":"Partial_TextOperators_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Partial_TablesAndViews_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"user_metrics":{"ref":"Partial_UserMetricsToOperators_"},"user_api_keys":{"ref":"Partial_UserApiKeysTableToOperators_"},"response":{"ref":"Partial_ResponseTableToOperators_"},"request":{"ref":"Partial_RequestTableToOperators_"},"feedback":{"ref":"Partial_FeedbackTableToOperators_"},"properties_table":{"ref":"Partial_PropertiesTableToOperators_"},"request_response_log":{"ref":"Partial_RequestResponseLogToOperators_"},"users_view":{"ref":"Partial_UserViewToOperators_"},"properties_v3":{"ref":"Partial_PropertiesCopyV2ToOperators_"},"property_with_response_v1":{"ref":"Partial_PropertyWithResponseV1ToOperators_"},"job":{"ref":"Partial_JobToOperators_"},"job_node":{"ref":"Partial_NodesToOperators_"},"cache_hits":{"ref":"Partial_CacheHitsTableToOperators_"},"rate_limit_log":{"ref":"Partial_RateLimitTableToOperators_"},"properties":{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"Partial_TextOperators_"}},"values":{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"Partial_TextOperators_"}},"prompt_v2":{"ref":"Partial_PromptToOperators_"},"prompts_versions":{"ref":"Partial_PromptVersionsToOperators_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "SingleKey_TablesAndViews_": {
+        "dataType": "refAlias",
+        "type": {"ref":"Partial_TablesAndViews_","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "FilterLeaf": {
+        "dataType": "refAlias",
+        "type": {"ref":"SingleKey_TablesAndViews_","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "FilterNode": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"FilterLeaf"},{"ref":"FilterBranch"},{"dataType":"enum","enums":["all"]}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "FilterBranch": {
+        "dataType": "refObject",
+        "properties": {
+            "left": {"ref":"FilterNode","required":true},
+            "operator": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["or"]},{"dataType":"enum","enums":["and"]}],"required":true},
+            "right": {"ref":"FilterNode","required":true},
         },
         "additionalProperties": false,
     },

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -1291,294 +1291,6 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"Partial_UserMetricsToOperators_": {
-				"properties": {
-					"user_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"last_active": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"total_requests": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_UserApiKeysTableToOperators_": {
-				"properties": {
-					"api_key_hash": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"api_key_name": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_PropertiesTableToOperators_": {
-				"properties": {
-					"auth_hash": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"key": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"value": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_TimestampOperatorsTyped_": {
-				"properties": {
-					"gte": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"lte": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"lt": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"gt": {
-						"type": "string",
-						"format": "date-time"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_RequestResponseLogToOperators_": {
-				"properties": {
-					"latency": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"status": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"request_created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperatorsTyped_"
-					},
-					"response_created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperatorsTyped_"
-					},
-					"auth_hash": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"model": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"user_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"organization_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"node_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"job_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"threat": {
-						"$ref": "#/components/schemas/Partial_BooleanOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_UserViewToOperators_": {
-				"properties": {
-					"user_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"active_for": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"first_active": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"last_active": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"total_requests": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"average_requests_per_day_active": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"average_tokens_per_request": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"total_completion_tokens": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"total_prompt_token": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"cost": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_PropertiesCopyV2ToOperators_": {
-				"properties": {
-					"key": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"value": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"organization_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_PropertyWithResponseV1ToOperators_": {
-				"properties": {
-					"property_key": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"property_value": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"request_created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperatorsTyped_"
-					},
-					"organization_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"threat": {
-						"$ref": "#/components/schemas/Partial_BooleanOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_JobToOperators_": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"name": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"description": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"status": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"updated_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"timeout_seconds": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"custom_properties": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/Partial_TextOperators_"
-						},
-						"type": "object"
-					},
-					"org_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_NodesToOperators_": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"name": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"description": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"job_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"status": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"updated_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperators_"
-					},
-					"timeout_seconds": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"custom_properties": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/Partial_TextOperators_"
-						},
-						"type": "object"
-					},
-					"org_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_CacheHitsTableToOperators_": {
-				"properties": {
-					"organization_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"request_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"latency": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"completion_tokens": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"prompt_tokens": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperatorsTyped_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_RateLimitTableToOperators_": {
-				"properties": {
-					"organization_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"created_at": {
-						"$ref": "#/components/schemas/Partial_TimestampOperatorsTyped_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
 			"Partial_PromptVersionsToOperators_": {
 				"properties": {
 					"minor_version": {
@@ -1597,87 +1309,28 @@
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Partial_TablesAndViews_": {
+			"Pick_FilterLeaf.request-or-prompts_versions_": {
 				"properties": {
-					"user_metrics": {
-						"$ref": "#/components/schemas/Partial_UserMetricsToOperators_"
-					},
-					"user_api_keys": {
-						"$ref": "#/components/schemas/Partial_UserApiKeysTableToOperators_"
-					},
-					"response": {
-						"$ref": "#/components/schemas/Partial_ResponseTableToOperators_"
-					},
 					"request": {
 						"$ref": "#/components/schemas/Partial_RequestTableToOperators_"
-					},
-					"feedback": {
-						"$ref": "#/components/schemas/Partial_FeedbackTableToOperators_"
-					},
-					"properties_table": {
-						"$ref": "#/components/schemas/Partial_PropertiesTableToOperators_"
-					},
-					"request_response_log": {
-						"$ref": "#/components/schemas/Partial_RequestResponseLogToOperators_"
-					},
-					"users_view": {
-						"$ref": "#/components/schemas/Partial_UserViewToOperators_"
-					},
-					"properties_v3": {
-						"$ref": "#/components/schemas/Partial_PropertiesCopyV2ToOperators_"
-					},
-					"property_with_response_v1": {
-						"$ref": "#/components/schemas/Partial_PropertyWithResponseV1ToOperators_"
-					},
-					"job": {
-						"$ref": "#/components/schemas/Partial_JobToOperators_"
-					},
-					"job_node": {
-						"$ref": "#/components/schemas/Partial_NodesToOperators_"
-					},
-					"cache_hits": {
-						"$ref": "#/components/schemas/Partial_CacheHitsTableToOperators_"
-					},
-					"rate_limit_log": {
-						"$ref": "#/components/schemas/Partial_RateLimitTableToOperators_"
-					},
-					"properties": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/Partial_TextOperators_"
-						},
-						"type": "object"
-					},
-					"values": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/Partial_TextOperators_"
-						},
-						"type": "object"
-					},
-					"prompt_v2": {
-						"$ref": "#/components/schemas/Partial_PromptToOperators_"
 					},
 					"prompts_versions": {
 						"$ref": "#/components/schemas/Partial_PromptVersionsToOperators_"
 					}
 				},
 				"type": "object",
-				"description": "Make all properties in T optional"
+				"description": "From T, pick a set of properties whose keys are in the union K"
 			},
-			"SingleKey_TablesAndViews_": {
-				"$ref": "#/components/schemas/Partial_TablesAndViews_"
+			"FilterLeafSubset_request-or-prompts_versions_": {
+				"$ref": "#/components/schemas/Pick_FilterLeaf.request-or-prompts_versions_"
 			},
-			"FilterLeaf": {
-				"$ref": "#/components/schemas/SingleKey_TablesAndViews_"
-			},
-			"FilterNode": {
+			"DatasetFilterNode": {
 				"anyOf": [
 					{
-						"$ref": "#/components/schemas/FilterLeaf"
+						"$ref": "#/components/schemas/FilterLeafSubset_request-or-prompts_versions_"
 					},
 					{
-						"$ref": "#/components/schemas/FilterBranch"
+						"$ref": "#/components/schemas/DatasetFilterBranch"
 					},
 					{
 						"type": "string",
@@ -1687,10 +1340,10 @@
 					}
 				]
 			},
-			"FilterBranch": {
+			"DatasetFilterBranch": {
 				"properties": {
-					"left": {
-						"$ref": "#/components/schemas/FilterNode"
+					"right": {
+						"$ref": "#/components/schemas/DatasetFilterNode"
 					},
 					"operator": {
 						"type": "string",
@@ -1699,17 +1352,16 @@
 							"and"
 						]
 					},
-					"right": {
-						"$ref": "#/components/schemas/FilterNode"
+					"left": {
+						"$ref": "#/components/schemas/DatasetFilterNode"
 					}
 				},
 				"required": [
-					"left",
+					"right",
 					"operator",
-					"right"
+					"left"
 				],
-				"type": "object",
-				"additionalProperties": false
+				"type": "object"
 			},
 			"RandomDatasetParams": {
 				"properties": {
@@ -1717,7 +1369,7 @@
 						"type": "string"
 					},
 					"filter": {
-						"$ref": "#/components/schemas/FilterNode"
+						"$ref": "#/components/schemas/DatasetFilterNode"
 					},
 					"offset": {
 						"type": "number",

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -583,48 +583,6 @@
 					}
 				]
 			},
-			"Partial_TextOperators_": {
-				"properties": {
-					"not-equals": {
-						"type": "string"
-					},
-					"equals": {
-						"type": "string"
-					},
-					"like": {
-						"type": "string"
-					},
-					"ilike": {
-						"type": "string"
-					},
-					"contains": {
-						"type": "string"
-					},
-					"not-contains": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_TimestampOperators_": {
-				"properties": {
-					"gte": {
-						"type": "string"
-					},
-					"lte": {
-						"type": "string"
-					},
-					"lt": {
-						"type": "string"
-					},
-					"gt": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
 			"Partial_NumberOperators_": {
 				"properties": {
 					"not-equals": {
@@ -655,48 +613,69 @@
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Partial_UserMetricsToOperators_": {
+			"Partial_TimestampOperators_": {
 				"properties": {
-					"user_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
+					"gte": {
+						"type": "string"
 					},
-					"last_active": {
+					"lte": {
+						"type": "string"
+					},
+					"lt": {
+						"type": "string"
+					},
+					"gt": {
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"description": "Make all properties in T optional"
+			},
+			"Partial_BooleanOperators_": {
+				"properties": {
+					"equals": {
+						"type": "boolean"
+					}
+				},
+				"type": "object",
+				"description": "Make all properties in T optional"
+			},
+			"Partial_TextOperators_": {
+				"properties": {
+					"not-equals": {
+						"type": "string"
+					},
+					"equals": {
+						"type": "string"
+					},
+					"like": {
+						"type": "string"
+					},
+					"ilike": {
+						"type": "string"
+					},
+					"contains": {
+						"type": "string"
+					},
+					"not-contains": {
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"description": "Make all properties in T optional"
+			},
+			"Partial_FeedbackTableToOperators_": {
+				"properties": {
+					"id": {
+						"$ref": "#/components/schemas/Partial_NumberOperators_"
+					},
+					"created_at": {
 						"$ref": "#/components/schemas/Partial_TimestampOperators_"
 					},
-					"total_requests": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_UserApiKeysTableToOperators_": {
-				"properties": {
-					"api_key_hash": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
+					"rating": {
+						"$ref": "#/components/schemas/Partial_BooleanOperators_"
 					},
-					"api_key_name": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
-			"Partial_ResponseTableToOperators_": {
-				"properties": {
-					"body_tokens": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"body_model": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"body_completion": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"status": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
-					},
-					"model": {
+					"response_id": {
 						"$ref": "#/components/schemas/Partial_TextOperators_"
 					}
 				},
@@ -739,27 +718,608 @@
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Partial_BooleanOperators_": {
+			"Partial_ResponseTableToOperators_": {
 				"properties": {
-					"equals": {
-						"type": "boolean"
+					"body_tokens": {
+						"$ref": "#/components/schemas/Partial_NumberOperators_"
+					},
+					"body_model": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
+					},
+					"body_completion": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
+					},
+					"status": {
+						"$ref": "#/components/schemas/Partial_NumberOperators_"
+					},
+					"model": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
 					}
 				},
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Partial_FeedbackTableToOperators_": {
+			"Pick_TablesAndViews.feedback-or-request-or-response_": {
+				"properties": {
+					"feedback": {
+						"$ref": "#/components/schemas/Partial_FeedbackTableToOperators_"
+					},
+					"request": {
+						"$ref": "#/components/schemas/Partial_RequestTableToOperators_"
+					},
+					"response": {
+						"$ref": "#/components/schemas/Partial_ResponseTableToOperators_"
+					}
+				},
+				"required": [
+					"feedback",
+					"request",
+					"response"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"FilterLeafSubset_feedback-or-request-or-response_": {
+				"$ref": "#/components/schemas/Pick_TablesAndViews.feedback-or-request-or-response_"
+			},
+			"RequestFilterNode": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/FilterLeafSubset_feedback-or-request-or-response_"
+					},
+					{
+						"$ref": "#/components/schemas/RequestFilterBranch"
+					},
+					{
+						"type": "string",
+						"enum": [
+							"all"
+						]
+					}
+				]
+			},
+			"RequestFilterBranch": {
+				"properties": {
+					"right": {
+						"$ref": "#/components/schemas/RequestFilterNode"
+					},
+					"operator": {
+						"type": "string",
+						"enum": [
+							"or",
+							"and"
+						]
+					},
+					"left": {
+						"$ref": "#/components/schemas/RequestFilterNode"
+					}
+				},
+				"required": [
+					"right",
+					"operator",
+					"left"
+				],
+				"type": "object"
+			},
+			"SortDirection": {
+				"type": "string",
+				"enum": [
+					"asc",
+					"desc"
+				]
+			},
+			"SortLeafRequest": {
+				"properties": {
+					"created_at": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"cache_created_at": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"latency": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"last_active": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"total_tokens": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"completion_tokens": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"prompt_tokens": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"user_id": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"body_model": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"is_cached": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"request_prompt": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"response_text": {
+						"$ref": "#/components/schemas/SortDirection"
+					},
+					"properties": {
+						"properties": {},
+						"additionalProperties": {
+							"$ref": "#/components/schemas/SortDirection"
+						},
+						"type": "object"
+					},
+					"values": {
+						"properties": {},
+						"additionalProperties": {
+							"$ref": "#/components/schemas/SortDirection"
+						},
+						"type": "object"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RequestQueryParams": {
+				"properties": {
+					"filter": {
+						"$ref": "#/components/schemas/RequestFilterNode"
+					},
+					"offset": {
+						"type": "number",
+						"format": "double"
+					},
+					"limit": {
+						"type": "number",
+						"format": "double"
+					},
+					"sort": {
+						"$ref": "#/components/schemas/SortLeafRequest"
+					},
+					"isCached": {
+						"type": "boolean"
+					},
+					"includeInputs": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"filter"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ResultSuccess_null_": {
+				"properties": {
+					"data": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result_null.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_null_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
+			"PromptsResult": {
 				"properties": {
 					"id": {
-						"$ref": "#/components/schemas/Partial_NumberOperators_"
+						"type": "string"
+					},
+					"user_defined_id": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"pretty_name": {
+						"type": "string"
+					},
+					"major_version": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"id",
+					"user_defined_id",
+					"description",
+					"pretty_name",
+					"major_version"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ResultSuccess_PromptsResult-Array_": {
+				"properties": {
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/PromptsResult"
+						},
+						"type": "array"
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result_PromptsResult-Array.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_PromptsResult-Array_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
+			"Partial_PromptToOperators_": {
+				"properties": {
+					"id": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
+					},
+					"user_defined_id": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
+					}
+				},
+				"type": "object",
+				"description": "Make all properties in T optional"
+			},
+			"Pick_TablesAndViews.prompt_v2_": {
+				"properties": {
+					"prompt_v2": {
+						"$ref": "#/components/schemas/Partial_PromptToOperators_"
+					}
+				},
+				"required": [
+					"prompt_v2"
+				],
+				"type": "object",
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"FilterLeafSubset_prompt_v2_": {
+				"$ref": "#/components/schemas/Pick_TablesAndViews.prompt_v2_"
+			},
+			"PromptsFilterNode": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/FilterLeafSubset_prompt_v2_"
+					},
+					{
+						"$ref": "#/components/schemas/PromptsFilterBranch"
+					},
+					{
+						"type": "string",
+						"enum": [
+							"all"
+						]
+					}
+				]
+			},
+			"PromptsFilterBranch": {
+				"properties": {
+					"right": {
+						"$ref": "#/components/schemas/PromptsFilterNode"
+					},
+					"operator": {
+						"type": "string",
+						"enum": [
+							"or",
+							"and"
+						]
+					},
+					"left": {
+						"$ref": "#/components/schemas/PromptsFilterNode"
+					}
+				},
+				"required": [
+					"right",
+					"operator",
+					"left"
+				],
+				"type": "object"
+			},
+			"PromptsQueryParams": {
+				"properties": {
+					"filter": {
+						"$ref": "#/components/schemas/PromptsFilterNode"
+					}
+				},
+				"required": [
+					"filter"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"PromptResult": {
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"user_defined_id": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"pretty_name": {
+						"type": "string"
+					},
+					"major_version": {
+						"type": "number",
+						"format": "double"
+					},
+					"latest_version_id": {
+						"type": "string"
+					},
+					"latest_model_used": {
+						"type": "string"
 					},
 					"created_at": {
+						"type": "string"
+					},
+					"last_used": {
+						"type": "string"
+					},
+					"versions": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"id",
+					"user_defined_id",
+					"description",
+					"pretty_name",
+					"major_version",
+					"latest_version_id",
+					"latest_model_used",
+					"created_at",
+					"last_used",
+					"versions"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ResultSuccess_PromptResult_": {
+				"properties": {
+					"data": {
+						"$ref": "#/components/schemas/PromptResult"
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result_PromptResult.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_PromptResult_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
+			"PromptQueryParams": {
+				"properties": {
+					"timeFilter": {
+						"properties": {
+							"end": {
+								"type": "string"
+							},
+							"start": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"end",
+							"start"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"timeFilter"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"PromptVersionResult": {
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"minor_version": {
+						"type": "number",
+						"format": "double"
+					},
+					"major_version": {
+						"type": "number",
+						"format": "double"
+					},
+					"helicone_template": {
+						"type": "string"
+					},
+					"prompt_v2": {
+						"type": "string"
+					},
+					"model": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"id",
+					"minor_version",
+					"major_version",
+					"helicone_template",
+					"prompt_v2",
+					"model"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ResultSuccess_PromptVersionResult_": {
+				"properties": {
+					"data": {
+						"$ref": "#/components/schemas/PromptVersionResult"
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result_PromptVersionResult.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_PromptVersionResult_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
+			"PromptCreateSubversionParams": {
+				"properties": {
+					"newHeliconeTemplate": {}
+				},
+				"required": [
+					"newHeliconeTemplate"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ResultSuccess_PromptVersionResult-Array_": {
+				"properties": {
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/PromptVersionResult"
+						},
+						"type": "array"
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result_PromptVersionResult-Array.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_PromptVersionResult-Array_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
+			"NewDatasetParams": {
+				"properties": {
+					"datasetName": {
+						"type": "string"
+					},
+					"requestIds": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"datasetName",
+					"requestIds"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Partial_UserMetricsToOperators_": {
+				"properties": {
+					"user_id": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
+					},
+					"last_active": {
 						"$ref": "#/components/schemas/Partial_TimestampOperators_"
 					},
-					"rating": {
-						"$ref": "#/components/schemas/Partial_BooleanOperators_"
+					"total_requests": {
+						"$ref": "#/components/schemas/Partial_NumberOperators_"
+					}
+				},
+				"type": "object",
+				"description": "Make all properties in T optional"
+			},
+			"Partial_UserApiKeysTableToOperators_": {
+				"properties": {
+					"api_key_hash": {
+						"$ref": "#/components/schemas/Partial_TextOperators_"
 					},
-					"response_id": {
+					"api_key_name": {
 						"$ref": "#/components/schemas/Partial_TextOperators_"
 					}
 				},
@@ -1027,18 +1587,6 @@
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Partial_PromptToOperators_": {
-				"properties": {
-					"id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					},
-					"user_defined_id": {
-						"$ref": "#/components/schemas/Partial_TextOperators_"
-					}
-				},
-				"type": "object",
-				"description": "Make all properties in T optional"
-			},
 			"Partial_PromptVersionsToOperators_": {
 				"properties": {
 					"minor_version": {
@@ -1167,438 +1715,6 @@
 					"left",
 					"operator",
 					"right"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"SortDirection": {
-				"type": "string",
-				"enum": [
-					"asc",
-					"desc"
-				]
-			},
-			"SortLeafRequest": {
-				"properties": {
-					"created_at": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"cache_created_at": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"latency": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"last_active": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"total_tokens": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"completion_tokens": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"prompt_tokens": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"user_id": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"body_model": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"is_cached": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"request_prompt": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"response_text": {
-						"$ref": "#/components/schemas/SortDirection"
-					},
-					"properties": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/SortDirection"
-						},
-						"type": "object"
-					},
-					"values": {
-						"properties": {},
-						"additionalProperties": {
-							"$ref": "#/components/schemas/SortDirection"
-						},
-						"type": "object"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"RequestQueryParams": {
-				"properties": {
-					"filter": {
-						"$ref": "#/components/schemas/FilterNode"
-					},
-					"offset": {
-						"type": "number",
-						"format": "double"
-					},
-					"limit": {
-						"type": "number",
-						"format": "double"
-					},
-					"sort": {
-						"$ref": "#/components/schemas/SortLeafRequest"
-					},
-					"isCached": {
-						"type": "boolean"
-					},
-					"includeInputs": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"filter"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ResultSuccess_null_": {
-				"properties": {
-					"data": {
-						"type": "number",
-						"enum": [
-							null
-						],
-						"nullable": true
-					},
-					"error": {
-						"type": "number",
-						"enum": [
-							null
-						],
-						"nullable": true
-					}
-				},
-				"required": [
-					"data",
-					"error"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Result_null.string_": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ResultSuccess_null_"
-					},
-					{
-						"$ref": "#/components/schemas/ResultError_string_"
-					}
-				]
-			},
-			"PromptsResult": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"user_defined_id": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"pretty_name": {
-						"type": "string"
-					},
-					"major_version": {
-						"type": "number",
-						"format": "double"
-					}
-				},
-				"required": [
-					"id",
-					"user_defined_id",
-					"description",
-					"pretty_name",
-					"major_version"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ResultSuccess_PromptsResult-Array_": {
-				"properties": {
-					"data": {
-						"items": {
-							"$ref": "#/components/schemas/PromptsResult"
-						},
-						"type": "array"
-					},
-					"error": {
-						"type": "number",
-						"enum": [
-							null
-						],
-						"nullable": true
-					}
-				},
-				"required": [
-					"data",
-					"error"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Result_PromptsResult-Array.string_": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ResultSuccess_PromptsResult-Array_"
-					},
-					{
-						"$ref": "#/components/schemas/ResultError_string_"
-					}
-				]
-			},
-			"PromptsQueryParams": {
-				"properties": {
-					"filter": {
-						"$ref": "#/components/schemas/FilterNode"
-					}
-				},
-				"required": [
-					"filter"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"PromptResult": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"user_defined_id": {
-						"type": "string"
-					},
-					"description": {
-						"type": "string"
-					},
-					"pretty_name": {
-						"type": "string"
-					},
-					"major_version": {
-						"type": "number",
-						"format": "double"
-					},
-					"latest_version_id": {
-						"type": "string"
-					},
-					"latest_model_used": {
-						"type": "string"
-					},
-					"created_at": {
-						"type": "string"
-					},
-					"last_used": {
-						"type": "string"
-					},
-					"versions": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"id",
-					"user_defined_id",
-					"description",
-					"pretty_name",
-					"major_version",
-					"latest_version_id",
-					"latest_model_used",
-					"created_at",
-					"last_used",
-					"versions"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ResultSuccess_PromptResult_": {
-				"properties": {
-					"data": {
-						"$ref": "#/components/schemas/PromptResult"
-					},
-					"error": {
-						"type": "number",
-						"enum": [
-							null
-						],
-						"nullable": true
-					}
-				},
-				"required": [
-					"data",
-					"error"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Result_PromptResult.string_": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ResultSuccess_PromptResult_"
-					},
-					{
-						"$ref": "#/components/schemas/ResultError_string_"
-					}
-				]
-			},
-			"PromptQueryParams": {
-				"properties": {
-					"timeFilter": {
-						"properties": {
-							"end": {
-								"type": "string"
-							},
-							"start": {
-								"type": "string"
-							}
-						},
-						"required": [
-							"end",
-							"start"
-						],
-						"type": "object"
-					}
-				},
-				"required": [
-					"timeFilter"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"PromptVersionResult": {
-				"properties": {
-					"id": {
-						"type": "string"
-					},
-					"minor_version": {
-						"type": "number",
-						"format": "double"
-					},
-					"major_version": {
-						"type": "number",
-						"format": "double"
-					},
-					"helicone_template": {
-						"type": "string"
-					},
-					"prompt_v2": {
-						"type": "string"
-					},
-					"model": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"id",
-					"minor_version",
-					"major_version",
-					"helicone_template",
-					"prompt_v2",
-					"model"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ResultSuccess_PromptVersionResult_": {
-				"properties": {
-					"data": {
-						"$ref": "#/components/schemas/PromptVersionResult"
-					},
-					"error": {
-						"type": "number",
-						"enum": [
-							null
-						],
-						"nullable": true
-					}
-				},
-				"required": [
-					"data",
-					"error"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Result_PromptVersionResult.string_": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ResultSuccess_PromptVersionResult_"
-					},
-					{
-						"$ref": "#/components/schemas/ResultError_string_"
-					}
-				]
-			},
-			"PromptCreateSubversionParams": {
-				"properties": {
-					"newHeliconeTemplate": {}
-				},
-				"required": [
-					"newHeliconeTemplate"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"ResultSuccess_PromptVersionResult-Array_": {
-				"properties": {
-					"data": {
-						"items": {
-							"$ref": "#/components/schemas/PromptVersionResult"
-						},
-						"type": "array"
-					},
-					"error": {
-						"type": "number",
-						"enum": [
-							null
-						],
-						"nullable": true
-					}
-				},
-				"required": [
-					"data",
-					"error"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"Result_PromptVersionResult-Array.string_": {
-				"anyOf": [
-					{
-						"$ref": "#/components/schemas/ResultSuccess_PromptVersionResult-Array_"
-					},
-					{
-						"$ref": "#/components/schemas/ResultError_string_"
-					}
-				]
-			},
-			"NewDatasetParams": {
-				"properties": {
-					"datasetName": {
-						"type": "string"
-					},
-					"requestIds": {
-						"items": {
-							"type": "string"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"datasetName",
-					"requestIds"
 				],
 				"type": "object",
 				"additionalProperties": false

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -739,7 +739,7 @@
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Pick_TablesAndViews.feedback-or-request-or-response_": {
+			"Pick_FilterLeaf.feedback-or-request-or-response_": {
 				"properties": {
 					"feedback": {
 						"$ref": "#/components/schemas/Partial_FeedbackTableToOperators_"
@@ -751,16 +751,11 @@
 						"$ref": "#/components/schemas/Partial_ResponseTableToOperators_"
 					}
 				},
-				"required": [
-					"feedback",
-					"request",
-					"response"
-				],
 				"type": "object",
 				"description": "From T, pick a set of properties whose keys are in the union K"
 			},
 			"FilterLeafSubset_feedback-or-request-or-response_": {
-				"$ref": "#/components/schemas/Pick_TablesAndViews.feedback-or-request-or-response_"
+				"$ref": "#/components/schemas/Pick_FilterLeaf.feedback-or-request-or-response_"
 			},
 			"RequestFilterNode": {
 				"anyOf": [
@@ -1001,20 +996,17 @@
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Pick_TablesAndViews.prompt_v2_": {
+			"Pick_FilterLeaf.prompt_v2_": {
 				"properties": {
 					"prompt_v2": {
 						"$ref": "#/components/schemas/Partial_PromptToOperators_"
 					}
 				},
-				"required": [
-					"prompt_v2"
-				],
 				"type": "object",
 				"description": "From T, pick a set of properties whose keys are in the union K"
 			},
 			"FilterLeafSubset_prompt_v2_": {
-				"$ref": "#/components/schemas/Pick_TablesAndViews.prompt_v2_"
+				"$ref": "#/components/schemas/Pick_FilterLeaf.prompt_v2_"
 			},
 			"PromptsFilterNode": {
 				"anyOf": [

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -204,22 +204,6 @@ Json: JsonObject;
     };
     "Result_HeliconeRequest-Array.string_": components["schemas"]["ResultSuccess_HeliconeRequest-Array_"] | components["schemas"]["ResultError_string_"];
     /** @description Make all properties in T optional */
-    Partial_TextOperators_: {
-      "not-equals"?: string;
-      equals?: string;
-      like?: string;
-      ilike?: string;
-      contains?: string;
-      "not-contains"?: string;
-    };
-    /** @description Make all properties in T optional */
-    Partial_TimestampOperators_: {
-      gte?: string;
-      lte?: string;
-      lt?: string;
-      gt?: string;
-    };
-    /** @description Make all properties in T optional */
     Partial_NumberOperators_: {
       /** Format: double */
       "not-equals"?: number;
@@ -235,23 +219,31 @@ Json: JsonObject;
       gt?: number;
     };
     /** @description Make all properties in T optional */
-    Partial_UserMetricsToOperators_: {
-      user_id?: components["schemas"]["Partial_TextOperators_"];
-      last_active?: components["schemas"]["Partial_TimestampOperators_"];
-      total_requests?: components["schemas"]["Partial_NumberOperators_"];
+    Partial_TimestampOperators_: {
+      gte?: string;
+      lte?: string;
+      lt?: string;
+      gt?: string;
     };
     /** @description Make all properties in T optional */
-    Partial_UserApiKeysTableToOperators_: {
-      api_key_hash?: components["schemas"]["Partial_TextOperators_"];
-      api_key_name?: components["schemas"]["Partial_TextOperators_"];
+    Partial_BooleanOperators_: {
+      equals?: boolean;
     };
     /** @description Make all properties in T optional */
-    Partial_ResponseTableToOperators_: {
-      body_tokens?: components["schemas"]["Partial_NumberOperators_"];
-      body_model?: components["schemas"]["Partial_TextOperators_"];
-      body_completion?: components["schemas"]["Partial_TextOperators_"];
-      status?: components["schemas"]["Partial_NumberOperators_"];
-      model?: components["schemas"]["Partial_TextOperators_"];
+    Partial_TextOperators_: {
+      "not-equals"?: string;
+      equals?: string;
+      like?: string;
+      ilike?: string;
+      contains?: string;
+      "not-contains"?: string;
+    };
+    /** @description Make all properties in T optional */
+    Partial_FeedbackTableToOperators_: {
+      id?: components["schemas"]["Partial_NumberOperators_"];
+      created_at?: components["schemas"]["Partial_TimestampOperators_"];
+      rating?: components["schemas"]["Partial_BooleanOperators_"];
+      response_id?: components["schemas"]["Partial_TextOperators_"];
     };
     /** @description Make all properties in T optional */
     Partial_RequestTableToOperators_: {
@@ -267,15 +259,164 @@ Json: JsonObject;
       path?: components["schemas"]["Partial_TextOperators_"];
     };
     /** @description Make all properties in T optional */
-    Partial_BooleanOperators_: {
-      equals?: boolean;
+    Partial_ResponseTableToOperators_: {
+      body_tokens?: components["schemas"]["Partial_NumberOperators_"];
+      body_model?: components["schemas"]["Partial_TextOperators_"];
+      body_completion?: components["schemas"]["Partial_TextOperators_"];
+      status?: components["schemas"]["Partial_NumberOperators_"];
+      model?: components["schemas"]["Partial_TextOperators_"];
+    };
+    /** @description From T, pick a set of properties whose keys are in the union K */
+    "Pick_TablesAndViews.feedback-or-request-or-response_": {
+      feedback: components["schemas"]["Partial_FeedbackTableToOperators_"];
+      request: components["schemas"]["Partial_RequestTableToOperators_"];
+      response: components["schemas"]["Partial_ResponseTableToOperators_"];
+    };
+    "FilterLeafSubset_feedback-or-request-or-response_": components["schemas"]["Pick_TablesAndViews.feedback-or-request-or-response_"];
+    RequestFilterNode: components["schemas"]["FilterLeafSubset_feedback-or-request-or-response_"] | components["schemas"]["RequestFilterBranch"] | "all";
+    RequestFilterBranch: {
+      right: components["schemas"]["RequestFilterNode"];
+      /** @enum {string} */
+      operator: "or" | "and";
+      left: components["schemas"]["RequestFilterNode"];
+    };
+    /** @enum {string} */
+    SortDirection: "asc" | "desc";
+    SortLeafRequest: {
+      created_at?: components["schemas"]["SortDirection"];
+      cache_created_at?: components["schemas"]["SortDirection"];
+      latency?: components["schemas"]["SortDirection"];
+      last_active?: components["schemas"]["SortDirection"];
+      total_tokens?: components["schemas"]["SortDirection"];
+      completion_tokens?: components["schemas"]["SortDirection"];
+      prompt_tokens?: components["schemas"]["SortDirection"];
+      user_id?: components["schemas"]["SortDirection"];
+      body_model?: components["schemas"]["SortDirection"];
+      is_cached?: components["schemas"]["SortDirection"];
+      request_prompt?: components["schemas"]["SortDirection"];
+      response_text?: components["schemas"]["SortDirection"];
+      properties?: {
+        [key: string]: components["schemas"]["SortDirection"];
+      };
+      values?: {
+        [key: string]: components["schemas"]["SortDirection"];
+      };
+    };
+    RequestQueryParams: {
+      filter: components["schemas"]["RequestFilterNode"];
+      /** Format: double */
+      offset?: number;
+      /** Format: double */
+      limit?: number;
+      sort?: components["schemas"]["SortLeafRequest"];
+      isCached?: boolean;
+      includeInputs?: boolean;
+    };
+    ResultSuccess_null_: {
+      /** @enum {number|null} */
+      data: null;
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result_null.string_": components["schemas"]["ResultSuccess_null_"] | components["schemas"]["ResultError_string_"];
+    PromptsResult: {
+      id: string;
+      user_defined_id: string;
+      description: string;
+      pretty_name: string;
+      /** Format: double */
+      major_version: number;
+    };
+    "ResultSuccess_PromptsResult-Array_": {
+      data: components["schemas"]["PromptsResult"][];
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result_PromptsResult-Array.string_": components["schemas"]["ResultSuccess_PromptsResult-Array_"] | components["schemas"]["ResultError_string_"];
+    /** @description Make all properties in T optional */
+    Partial_PromptToOperators_: {
+      id?: components["schemas"]["Partial_TextOperators_"];
+      user_defined_id?: components["schemas"]["Partial_TextOperators_"];
+    };
+    /** @description From T, pick a set of properties whose keys are in the union K */
+    "Pick_TablesAndViews.prompt_v2_": {
+      prompt_v2: components["schemas"]["Partial_PromptToOperators_"];
+    };
+    FilterLeafSubset_prompt_v2_: components["schemas"]["Pick_TablesAndViews.prompt_v2_"];
+    PromptsFilterNode: components["schemas"]["FilterLeafSubset_prompt_v2_"] | components["schemas"]["PromptsFilterBranch"] | "all";
+    PromptsFilterBranch: {
+      right: components["schemas"]["PromptsFilterNode"];
+      /** @enum {string} */
+      operator: "or" | "and";
+      left: components["schemas"]["PromptsFilterNode"];
+    };
+    PromptsQueryParams: {
+      filter: components["schemas"]["PromptsFilterNode"];
+    };
+    PromptResult: {
+      id: string;
+      user_defined_id: string;
+      description: string;
+      pretty_name: string;
+      /** Format: double */
+      major_version: number;
+      latest_version_id: string;
+      latest_model_used: string;
+      created_at: string;
+      last_used: string;
+      versions: string[];
+    };
+    ResultSuccess_PromptResult_: {
+      data: components["schemas"]["PromptResult"];
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result_PromptResult.string_": components["schemas"]["ResultSuccess_PromptResult_"] | components["schemas"]["ResultError_string_"];
+    PromptQueryParams: {
+      timeFilter: {
+        end: string;
+        start: string;
+      };
+    };
+    PromptVersionResult: {
+      id: string;
+      /** Format: double */
+      minor_version: number;
+      /** Format: double */
+      major_version: number;
+      helicone_template: string;
+      prompt_v2: string;
+      model: string;
+    };
+    ResultSuccess_PromptVersionResult_: {
+      data: components["schemas"]["PromptVersionResult"];
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result_PromptVersionResult.string_": components["schemas"]["ResultSuccess_PromptVersionResult_"] | components["schemas"]["ResultError_string_"];
+    PromptCreateSubversionParams: {
+      newHeliconeTemplate: unknown;
+    };
+    "ResultSuccess_PromptVersionResult-Array_": {
+      data: components["schemas"]["PromptVersionResult"][];
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result_PromptVersionResult-Array.string_": components["schemas"]["ResultSuccess_PromptVersionResult-Array_"] | components["schemas"]["ResultError_string_"];
+    NewDatasetParams: {
+      datasetName: string;
+      requestIds: string[];
     };
     /** @description Make all properties in T optional */
-    Partial_FeedbackTableToOperators_: {
-      id?: components["schemas"]["Partial_NumberOperators_"];
-      created_at?: components["schemas"]["Partial_TimestampOperators_"];
-      rating?: components["schemas"]["Partial_BooleanOperators_"];
-      response_id?: components["schemas"]["Partial_TextOperators_"];
+    Partial_UserMetricsToOperators_: {
+      user_id?: components["schemas"]["Partial_TextOperators_"];
+      last_active?: components["schemas"]["Partial_TimestampOperators_"];
+      total_requests?: components["schemas"]["Partial_NumberOperators_"];
+    };
+    /** @description Make all properties in T optional */
+    Partial_UserApiKeysTableToOperators_: {
+      api_key_hash?: components["schemas"]["Partial_TextOperators_"];
+      api_key_name?: components["schemas"]["Partial_TextOperators_"];
     };
     /** @description Make all properties in T optional */
     Partial_PropertiesTableToOperators_: {
@@ -379,11 +520,6 @@ Json: JsonObject;
       created_at?: components["schemas"]["Partial_TimestampOperatorsTyped_"];
     };
     /** @description Make all properties in T optional */
-    Partial_PromptToOperators_: {
-      id?: components["schemas"]["Partial_TextOperators_"];
-      user_defined_id?: components["schemas"]["Partial_TextOperators_"];
-    };
-    /** @description Make all properties in T optional */
     Partial_PromptVersionsToOperators_: {
       minor_version?: components["schemas"]["Partial_NumberOperators_"];
       major_version?: components["schemas"]["Partial_NumberOperators_"];
@@ -423,116 +559,6 @@ Json: JsonObject;
       /** @enum {string} */
       operator: "or" | "and";
       right: components["schemas"]["FilterNode"];
-    };
-    /** @enum {string} */
-    SortDirection: "asc" | "desc";
-    SortLeafRequest: {
-      created_at?: components["schemas"]["SortDirection"];
-      cache_created_at?: components["schemas"]["SortDirection"];
-      latency?: components["schemas"]["SortDirection"];
-      last_active?: components["schemas"]["SortDirection"];
-      total_tokens?: components["schemas"]["SortDirection"];
-      completion_tokens?: components["schemas"]["SortDirection"];
-      prompt_tokens?: components["schemas"]["SortDirection"];
-      user_id?: components["schemas"]["SortDirection"];
-      body_model?: components["schemas"]["SortDirection"];
-      is_cached?: components["schemas"]["SortDirection"];
-      request_prompt?: components["schemas"]["SortDirection"];
-      response_text?: components["schemas"]["SortDirection"];
-      properties?: {
-        [key: string]: components["schemas"]["SortDirection"];
-      };
-      values?: {
-        [key: string]: components["schemas"]["SortDirection"];
-      };
-    };
-    RequestQueryParams: {
-      filter: components["schemas"]["FilterNode"];
-      /** Format: double */
-      offset?: number;
-      /** Format: double */
-      limit?: number;
-      sort?: components["schemas"]["SortLeafRequest"];
-      isCached?: boolean;
-      includeInputs?: boolean;
-    };
-    ResultSuccess_null_: {
-      /** @enum {number|null} */
-      data: null;
-      /** @enum {number|null} */
-      error: null;
-    };
-    "Result_null.string_": components["schemas"]["ResultSuccess_null_"] | components["schemas"]["ResultError_string_"];
-    PromptsResult: {
-      id: string;
-      user_defined_id: string;
-      description: string;
-      pretty_name: string;
-      /** Format: double */
-      major_version: number;
-    };
-    "ResultSuccess_PromptsResult-Array_": {
-      data: components["schemas"]["PromptsResult"][];
-      /** @enum {number|null} */
-      error: null;
-    };
-    "Result_PromptsResult-Array.string_": components["schemas"]["ResultSuccess_PromptsResult-Array_"] | components["schemas"]["ResultError_string_"];
-    PromptsQueryParams: {
-      filter: components["schemas"]["FilterNode"];
-    };
-    PromptResult: {
-      id: string;
-      user_defined_id: string;
-      description: string;
-      pretty_name: string;
-      /** Format: double */
-      major_version: number;
-      latest_version_id: string;
-      latest_model_used: string;
-      created_at: string;
-      last_used: string;
-      versions: string[];
-    };
-    ResultSuccess_PromptResult_: {
-      data: components["schemas"]["PromptResult"];
-      /** @enum {number|null} */
-      error: null;
-    };
-    "Result_PromptResult.string_": components["schemas"]["ResultSuccess_PromptResult_"] | components["schemas"]["ResultError_string_"];
-    PromptQueryParams: {
-      timeFilter: {
-        end: string;
-        start: string;
-      };
-    };
-    PromptVersionResult: {
-      id: string;
-      /** Format: double */
-      minor_version: number;
-      /** Format: double */
-      major_version: number;
-      helicone_template: string;
-      prompt_v2: string;
-      model: string;
-    };
-    ResultSuccess_PromptVersionResult_: {
-      data: components["schemas"]["PromptVersionResult"];
-      /** @enum {number|null} */
-      error: null;
-    };
-    "Result_PromptVersionResult.string_": components["schemas"]["ResultSuccess_PromptVersionResult_"] | components["schemas"]["ResultError_string_"];
-    PromptCreateSubversionParams: {
-      newHeliconeTemplate: unknown;
-    };
-    "ResultSuccess_PromptVersionResult-Array_": {
-      data: components["schemas"]["PromptVersionResult"][];
-      /** @enum {number|null} */
-      error: null;
-    };
-    "Result_PromptVersionResult-Array.string_": components["schemas"]["ResultSuccess_PromptVersionResult-Array_"] | components["schemas"]["ResultError_string_"];
-    NewDatasetParams: {
-      datasetName: string;
-      requestIds: string[];
     };
     RandomDatasetParams: {
       datasetName: string;

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -267,12 +267,12 @@ Json: JsonObject;
       model?: components["schemas"]["Partial_TextOperators_"];
     };
     /** @description From T, pick a set of properties whose keys are in the union K */
-    "Pick_TablesAndViews.feedback-or-request-or-response_": {
-      feedback: components["schemas"]["Partial_FeedbackTableToOperators_"];
-      request: components["schemas"]["Partial_RequestTableToOperators_"];
-      response: components["schemas"]["Partial_ResponseTableToOperators_"];
+    "Pick_FilterLeaf.feedback-or-request-or-response_": {
+      feedback?: components["schemas"]["Partial_FeedbackTableToOperators_"];
+      request?: components["schemas"]["Partial_RequestTableToOperators_"];
+      response?: components["schemas"]["Partial_ResponseTableToOperators_"];
     };
-    "FilterLeafSubset_feedback-or-request-or-response_": components["schemas"]["Pick_TablesAndViews.feedback-or-request-or-response_"];
+    "FilterLeafSubset_feedback-or-request-or-response_": components["schemas"]["Pick_FilterLeaf.feedback-or-request-or-response_"];
     RequestFilterNode: components["schemas"]["FilterLeafSubset_feedback-or-request-or-response_"] | components["schemas"]["RequestFilterBranch"] | "all";
     RequestFilterBranch: {
       right: components["schemas"]["RequestFilterNode"];
@@ -339,10 +339,10 @@ Json: JsonObject;
       user_defined_id?: components["schemas"]["Partial_TextOperators_"];
     };
     /** @description From T, pick a set of properties whose keys are in the union K */
-    "Pick_TablesAndViews.prompt_v2_": {
-      prompt_v2: components["schemas"]["Partial_PromptToOperators_"];
+    "Pick_FilterLeaf.prompt_v2_": {
+      prompt_v2?: components["schemas"]["Partial_PromptToOperators_"];
     };
-    FilterLeafSubset_prompt_v2_: components["schemas"]["Pick_TablesAndViews.prompt_v2_"];
+    FilterLeafSubset_prompt_v2_: components["schemas"]["Pick_FilterLeaf.prompt_v2_"];
     PromptsFilterNode: components["schemas"]["FilterLeafSubset_prompt_v2_"] | components["schemas"]["PromptsFilterBranch"] | "all";
     PromptsFilterBranch: {
       right: components["schemas"]["PromptsFilterNode"];

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -408,161 +408,28 @@ Json: JsonObject;
       requestIds: string[];
     };
     /** @description Make all properties in T optional */
-    Partial_UserMetricsToOperators_: {
-      user_id?: components["schemas"]["Partial_TextOperators_"];
-      last_active?: components["schemas"]["Partial_TimestampOperators_"];
-      total_requests?: components["schemas"]["Partial_NumberOperators_"];
-    };
-    /** @description Make all properties in T optional */
-    Partial_UserApiKeysTableToOperators_: {
-      api_key_hash?: components["schemas"]["Partial_TextOperators_"];
-      api_key_name?: components["schemas"]["Partial_TextOperators_"];
-    };
-    /** @description Make all properties in T optional */
-    Partial_PropertiesTableToOperators_: {
-      auth_hash?: components["schemas"]["Partial_TextOperators_"];
-      key?: components["schemas"]["Partial_TextOperators_"];
-      value?: components["schemas"]["Partial_TextOperators_"];
-    };
-    /** @description Make all properties in T optional */
-    Partial_TimestampOperatorsTyped_: {
-      /** Format: date-time */
-      gte?: string;
-      /** Format: date-time */
-      lte?: string;
-      /** Format: date-time */
-      lt?: string;
-      /** Format: date-time */
-      gt?: string;
-    };
-    /** @description Make all properties in T optional */
-    Partial_RequestResponseLogToOperators_: {
-      latency?: components["schemas"]["Partial_NumberOperators_"];
-      status?: components["schemas"]["Partial_NumberOperators_"];
-      request_created_at?: components["schemas"]["Partial_TimestampOperatorsTyped_"];
-      response_created_at?: components["schemas"]["Partial_TimestampOperatorsTyped_"];
-      auth_hash?: components["schemas"]["Partial_TextOperators_"];
-      model?: components["schemas"]["Partial_TextOperators_"];
-      user_id?: components["schemas"]["Partial_TextOperators_"];
-      organization_id?: components["schemas"]["Partial_TextOperators_"];
-      node_id?: components["schemas"]["Partial_TextOperators_"];
-      job_id?: components["schemas"]["Partial_TextOperators_"];
-      threat?: components["schemas"]["Partial_BooleanOperators_"];
-    };
-    /** @description Make all properties in T optional */
-    Partial_UserViewToOperators_: {
-      user_id?: components["schemas"]["Partial_TextOperators_"];
-      active_for?: components["schemas"]["Partial_NumberOperators_"];
-      first_active?: components["schemas"]["Partial_TimestampOperators_"];
-      last_active?: components["schemas"]["Partial_TimestampOperators_"];
-      total_requests?: components["schemas"]["Partial_NumberOperators_"];
-      average_requests_per_day_active?: components["schemas"]["Partial_NumberOperators_"];
-      average_tokens_per_request?: components["schemas"]["Partial_NumberOperators_"];
-      total_completion_tokens?: components["schemas"]["Partial_NumberOperators_"];
-      total_prompt_token?: components["schemas"]["Partial_NumberOperators_"];
-      cost?: components["schemas"]["Partial_NumberOperators_"];
-    };
-    /** @description Make all properties in T optional */
-    Partial_PropertiesCopyV2ToOperators_: {
-      key?: components["schemas"]["Partial_TextOperators_"];
-      value?: components["schemas"]["Partial_TextOperators_"];
-      organization_id?: components["schemas"]["Partial_TextOperators_"];
-    };
-    /** @description Make all properties in T optional */
-    Partial_PropertyWithResponseV1ToOperators_: {
-      property_key?: components["schemas"]["Partial_TextOperators_"];
-      property_value?: components["schemas"]["Partial_TextOperators_"];
-      request_created_at?: components["schemas"]["Partial_TimestampOperatorsTyped_"];
-      organization_id?: components["schemas"]["Partial_TextOperators_"];
-      threat?: components["schemas"]["Partial_BooleanOperators_"];
-    };
-    /** @description Make all properties in T optional */
-    Partial_JobToOperators_: {
-      id?: components["schemas"]["Partial_TextOperators_"];
-      name?: components["schemas"]["Partial_TextOperators_"];
-      description?: components["schemas"]["Partial_TextOperators_"];
-      status?: components["schemas"]["Partial_TextOperators_"];
-      created_at?: components["schemas"]["Partial_TimestampOperators_"];
-      updated_at?: components["schemas"]["Partial_TimestampOperators_"];
-      timeout_seconds?: components["schemas"]["Partial_NumberOperators_"];
-      custom_properties?: {
-        [key: string]: components["schemas"]["Partial_TextOperators_"];
-      };
-      org_id?: components["schemas"]["Partial_TextOperators_"];
-    };
-    /** @description Make all properties in T optional */
-    Partial_NodesToOperators_: {
-      id?: components["schemas"]["Partial_TextOperators_"];
-      name?: components["schemas"]["Partial_TextOperators_"];
-      description?: components["schemas"]["Partial_TextOperators_"];
-      job_id?: components["schemas"]["Partial_TextOperators_"];
-      status?: components["schemas"]["Partial_TextOperators_"];
-      created_at?: components["schemas"]["Partial_TimestampOperators_"];
-      updated_at?: components["schemas"]["Partial_TimestampOperators_"];
-      timeout_seconds?: components["schemas"]["Partial_NumberOperators_"];
-      custom_properties?: {
-        [key: string]: components["schemas"]["Partial_TextOperators_"];
-      };
-      org_id?: components["schemas"]["Partial_TextOperators_"];
-    };
-    /** @description Make all properties in T optional */
-    Partial_CacheHitsTableToOperators_: {
-      organization_id?: components["schemas"]["Partial_TextOperators_"];
-      request_id?: components["schemas"]["Partial_TextOperators_"];
-      latency?: components["schemas"]["Partial_NumberOperators_"];
-      completion_tokens?: components["schemas"]["Partial_NumberOperators_"];
-      prompt_tokens?: components["schemas"]["Partial_NumberOperators_"];
-      created_at?: components["schemas"]["Partial_TimestampOperatorsTyped_"];
-    };
-    /** @description Make all properties in T optional */
-    Partial_RateLimitTableToOperators_: {
-      organization_id?: components["schemas"]["Partial_TextOperators_"];
-      created_at?: components["schemas"]["Partial_TimestampOperatorsTyped_"];
-    };
-    /** @description Make all properties in T optional */
     Partial_PromptVersionsToOperators_: {
       minor_version?: components["schemas"]["Partial_NumberOperators_"];
       major_version?: components["schemas"]["Partial_NumberOperators_"];
       id?: components["schemas"]["Partial_TextOperators_"];
       prompt_v2?: components["schemas"]["Partial_TextOperators_"];
     };
-    /** @description Make all properties in T optional */
-    Partial_TablesAndViews_: {
-      user_metrics?: components["schemas"]["Partial_UserMetricsToOperators_"];
-      user_api_keys?: components["schemas"]["Partial_UserApiKeysTableToOperators_"];
-      response?: components["schemas"]["Partial_ResponseTableToOperators_"];
+    /** @description From T, pick a set of properties whose keys are in the union K */
+    "Pick_FilterLeaf.request-or-prompts_versions_": {
       request?: components["schemas"]["Partial_RequestTableToOperators_"];
-      feedback?: components["schemas"]["Partial_FeedbackTableToOperators_"];
-      properties_table?: components["schemas"]["Partial_PropertiesTableToOperators_"];
-      request_response_log?: components["schemas"]["Partial_RequestResponseLogToOperators_"];
-      users_view?: components["schemas"]["Partial_UserViewToOperators_"];
-      properties_v3?: components["schemas"]["Partial_PropertiesCopyV2ToOperators_"];
-      property_with_response_v1?: components["schemas"]["Partial_PropertyWithResponseV1ToOperators_"];
-      job?: components["schemas"]["Partial_JobToOperators_"];
-      job_node?: components["schemas"]["Partial_NodesToOperators_"];
-      cache_hits?: components["schemas"]["Partial_CacheHitsTableToOperators_"];
-      rate_limit_log?: components["schemas"]["Partial_RateLimitTableToOperators_"];
-      properties?: {
-        [key: string]: components["schemas"]["Partial_TextOperators_"];
-      };
-      values?: {
-        [key: string]: components["schemas"]["Partial_TextOperators_"];
-      };
-      prompt_v2?: components["schemas"]["Partial_PromptToOperators_"];
       prompts_versions?: components["schemas"]["Partial_PromptVersionsToOperators_"];
     };
-    SingleKey_TablesAndViews_: components["schemas"]["Partial_TablesAndViews_"];
-    FilterLeaf: components["schemas"]["SingleKey_TablesAndViews_"];
-    FilterNode: components["schemas"]["FilterLeaf"] | components["schemas"]["FilterBranch"] | "all";
-    FilterBranch: {
-      left: components["schemas"]["FilterNode"];
+    "FilterLeafSubset_request-or-prompts_versions_": components["schemas"]["Pick_FilterLeaf.request-or-prompts_versions_"];
+    DatasetFilterNode: components["schemas"]["FilterLeafSubset_request-or-prompts_versions_"] | components["schemas"]["DatasetFilterBranch"] | "all";
+    DatasetFilterBranch: {
+      right: components["schemas"]["DatasetFilterNode"];
       /** @enum {string} */
       operator: "or" | "and";
-      right: components["schemas"]["FilterNode"];
+      left: components["schemas"]["DatasetFilterNode"];
     };
     RandomDatasetParams: {
       datasetName: string;
-      filter: components["schemas"]["FilterNode"];
+      filter: components["schemas"]["DatasetFilterNode"];
       /** Format: double */
       offset?: number;
       /** Format: double */

--- a/web/services/hooks/requests.tsx
+++ b/web/services/hooks/requests.tsx
@@ -33,6 +33,7 @@ const useGetRequests = (
         const isCached = query.queryKey[5];
         const response = await jawn.POST("/v1/request/query", {
           body: {
+            filter: advancedFilter as any,
             offset: (currentPage - 1) * currentPageSize,
             limit: currentPageSize,
             sort: sortLeaf as any,

--- a/web/services/hooks/requests.tsx
+++ b/web/services/hooks/requests.tsx
@@ -33,7 +33,6 @@ const useGetRequests = (
         const isCached = query.queryKey[5];
         const response = await jawn.POST("/v1/request/query", {
           body: {
-            filter: advancedFilter as any,
             offset: (currentPage - 1) * currentPageSize,
             limit: currentPageSize,
             sort: sortLeaf as any,


### PR DESCRIPTION
# break through to limit keys and filters to only allowed filters per endpoint 🚀

One of the annoying things about `FilterNode` is that there was no way to isolate what filters a specific endpoint had access to. Now it is possible to isolate exactly what an endpoint can filter by...


## Internal development impact

Here is the new request's endpoint limited to just request, response and feedback

<img width="491" alt="image" src="https://github.com/Helicone/helicone/assets/26822232/932803ee-8242-4ae7-b204-07c60eab2b31">

## Customer impact

In the docs they are no longer inundated with a bunch filters that would fail (some users were trying to filter by tables and getting errors)

<img width="1177" alt="image" src="https://github.com/Helicone/helicone/assets/26822232/b964ee7e-7fa0-494c-9f07-1bf4bda8d16c">

