### PR TITLE
Add pricing for OpenAI text-embedding-3-large

### DIFF
--- a/costs/__tests__/ensureOnlyOne.ts
+++ b/costs/__tests__/ensureOnlyOne.ts
@@ -296,6 +296,7 @@ WHEN (request_response_log.model = 'text-embedding-ada-002') THEN 100 * request_
 WHEN (request_response_log.model = 'text-embedding-ada') THEN 100 * request_response_log.prompt_tokens + 0 * request_response_log.completion_tokens
 WHEN (request_response_log.model = 'text-embedding-ada-002-v2') THEN 100 * request_response_log.prompt_tokens + 0 * request_response_log.completion_tokens
 WHEN (request_response_log.model = 'text-embedding-3-small') THEN 20 * request_response_log.prompt_tokens + 0 * request_response_log.completion_tokens
+WHEN (request_response_log.model = 'text-embedding-3-large') THEN 130 * request_response_log.prompt_tokens + 0 * request_response_log.completion_tokens
 WHEN (request_response_log.model = 'gpt-4-vision-preview') THEN 10000 * request_response_log.prompt_tokens + 30000 * request_response_log.completion_tokens
 WHEN (request_response_log.model = 'gpt-35-turbo-16k-0613') THEN 3000 * request_response_log.prompt_tokens + 4000 * request_response_log.completion_tokens
   ELSE 0
@@ -616,6 +617,7 @@ WHEN (request_response_log.model = 'text-embedding-ada-002') THEN 100 * request_
 WHEN (request_response_log.model = 'text-embedding-ada') THEN 100 * request_response_log.prompt_tokens + 0 * request_response_log.completion_tokens
 WHEN (request_response_log.model = 'text-embedding-ada-002-v2') THEN 100 * request_response_log.prompt_tokens + 0 * request_response_log.completion_tokens
 WHEN (request_response_log.model = 'text-embedding-3-small') THEN 20 * request_response_log.prompt_tokens + 0 * request_response_log.completion_tokens
+WHEN (request_response_log.model = 'text-embedding-3-large') THEN 130 * request_response_log.prompt_tokens + 0 * request_response_log.completion_tokens
 WHEN (request_response_log.model = 'gpt-4-vision-preview') THEN 10000 * request_response_log.prompt_tokens + 30000 * request_response_log.completion_tokens
 WHEN (request_response_log.model = 'gpt-35-turbo-16k-0613') THEN 3000 * request_response_log.prompt_tokens + 4000 * request_response_log.completion_tokens
 WHEN (request_response_log.model LIKE 'ft:gpt-3.5-turbo-%') THEN 3000 * request_response_log.prompt_tokens + 6000 * request_response_log.completion_tokens

--- a/costs/src/providers/openai/index.ts
+++ b/costs/src/providers/openai/index.ts
@@ -401,6 +401,16 @@ export const costs: ModelRow[] = [
   {
     model: {
       operator: "equals",
+      value: "text-embedding-3-large",
+    },
+    cost: {
+      prompt_token: 0.00000013,
+      completion_token: 0.0,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
       value: "gpt-4-vision-preview",
     },
     cost: {

--- a/valhalla/jawn/src/packages/cost/providers/openai/index.ts
+++ b/valhalla/jawn/src/packages/cost/providers/openai/index.ts
@@ -401,6 +401,16 @@ export const costs: ModelRow[] = [
   {
     model: {
       operator: "equals",
+      value: "text-embedding-3-large",
+    },
+    cost: {
+      prompt_token: 0.00000013,
+      completion_token: 0.0,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
       value: "gpt-4-vision-preview",
     },
     cost: {

--- a/web/packages/cost/providers/openai/index.ts
+++ b/web/packages/cost/providers/openai/index.ts
@@ -401,6 +401,16 @@ export const costs: ModelRow[] = [
   {
     model: {
       operator: "equals",
+      value: "text-embedding-3-large",
+    },
+    cost: {
+      prompt_token: 0.00000013,
+      completion_token: 0.0,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
       value: "gpt-4-vision-preview",
     },
     cost: {

--- a/worker/src/packages/cost/providers/openai/index.ts
+++ b/worker/src/packages/cost/providers/openai/index.ts
@@ -401,6 +401,16 @@ export const costs: ModelRow[] = [
   {
     model: {
       operator: "equals",
+      value: "text-embedding-3-large",
+    },
+    cost: {
+      prompt_token: 0.00000013,
+      completion_token: 0.0,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
       value: "gpt-4-vision-preview",
     },
     cost: {


### PR DESCRIPTION
Pricing for the `text-embedding-3-large` model is missing. OpenAI docs are [here](https://openai.com/api/pricing/)

I've followed the https://github.com/Helicone/helicone/blob/main/costs/README.md, hope all good.