### PR TITLE
Hyperbolic

### DIFF
--- a/docs/getting-started/integration-method/hyperbolic.mdx
+++ b/docs/getting-started/integration-method/hyperbolic.mdx
@@ -2,7 +2,7 @@
 title: "Hyperbolic"
 ---
 
-You can seamlessly integrate Helicone with your OpenAI compatible models that are deployed on Hyperbolic.
+You can seamlessly integrate Helicone with the OpenAI compatible models that are deployed on Hyperbolic.
 
 The integration process closely mirrors the [proxy approach](/integrations/openai/javascript). The only distinction lies in the modification of the base_url to point to the dedicated Hyperbolic endpoint `https://hyperbolic.helicone.ai/v1`.
 

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -32,8 +32,14 @@ Integrate with Helicone and send your first events in seconds.
   <Card title="Together AI" href="/getting-started/integration-method/together">
 
   </Card>
+  <Card title="Hyperbolic" href="/getting-started/integration-method/hyperbolic">
+
+  </Card>
   <Card title="Groq" href="/integrations/groq/javascript">
       Javascript, Python, cURL
+  </Card>
+  <Card title="Deepinfra" href="/getting-started/integration-method/deepinfra">
+
   </Card>
   <Card title="OpenRouter" href="/getting-started/integration-method/openrouter">
 


### PR DESCRIPTION
- Changed "You can seamlessly integrate Helicone **with your** OpenAI compatible models that are deployed on Hyperbolic." to "You can seamlessly integrate Helicone **with the** OpenAI compatible models that are deployed on Hyperbolic."
- since they haven't enabled users to deploy their own models yet
