### PR TITLE
Token counting for stream on OpenAI removed because it was causing lag

### DIFF
--- a/valhalla/dockerfile_eu
+++ b/valhalla/dockerfile_eu
@@ -10,7 +10,7 @@ COPY ./valhalla/jawn/package.json ./valhalla/jawn/yarn.lock ./
 
 RUN yarn install
 
-WORKDIR /usr/src/app
+WORKDIR /usr/src/app/shared
 COPY ./shared .
 
 WORKDIR /usr/src/app/valhalla/jawn

--- a/valhalla/jawn/src/lib/tokens/tokenCounter.ts
+++ b/valhalla/jawn/src/lib/tokens/tokenCounter.ts
@@ -14,12 +14,6 @@ const anthropicTokenizer = new Tiktoken({
   pat_str: claudeRanks.pat_str,
 });
 
-let gptWorker = new Worker(`${__dirname}/gptWorker.js`);
-function restartGptWorker() {
-  gptWorker.terminate();
-  gptWorker = new Worker(`${__dirname}/gptWorker.js`);
-}
-
 const TIKTOKEN_MODELS = [
   "davinci-002",
   "babbage-002",
@@ -83,11 +77,12 @@ export async function getTokenCountGPT3(
   model: string
 ): Promise<number> {
   if (!inputText) return 0;
-  model = TIKTOKEN_MODELS.find((m) => m === model) ?? "gpt-3.5-turbo";
+  return -1;
+  // model = TIKTOKEN_MODELS.find((m) => m === model) ?? "gpt-3.5-turbo";
 
-  const encoding = encoding_for_model(model as any);
-  const tokens = encoding.encode(inputText);
-  return tokens.length;
+  // const encoding = encoding_for_model(model as any);
+  // const tokens = encoding.encode(inputText);
+  // return tokens.length;
 }
 
 export async function getTokenCountAnthropic(


### PR DESCRIPTION
remove token counting on stream in favor of https://docs.helicone.ai/use-cases/enable-stream-usage\#correct-cost-calculation-while-streaming