### PR TITLE
added direct access to the open stats page

### DIFF
--- a/bifrost/components/layout/navbar.tsx
+++ b/bifrost/components/layout/navbar.tsx
@@ -76,6 +76,10 @@ const NavLinks = () => {
       label: "Pricing",
     },
     {
+      href: "https://us.helicone.ai/open-stats",
+      label: "🌑 Open Stats",
+    },
+    {
       href: "/community",
       label: "Community",
     },


### PR DESCRIPTION
<img width="1253" alt="Screenshot 2024-07-17 at 1 01 08 PM" src="https://github.com/user-attachments/assets/a5255ffe-4b4e-40ab-9d87-694d43dc3b7f">
