### PR TITLE
Add Optional Lytix Host Header

### DIFF
--- a/valhalla/jawn/src/lib/handlers/HandlerContext.ts
+++ b/valhalla/jawn/src/lib/handlers/HandlerContext.ts
@@ -90,6 +90,7 @@ export type HeliconeMeta = {
   posthogApiKey?: string;
   posthogHost?: string;
   lytixKey?: string;
+  lytixHost?: string;
 };
 
 export type Message = {

--- a/valhalla/jawn/src/tsoa-build/private/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/private/routes.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { ExpressTemplateService, TsoaRoute, fetchMiddlewares } from '@tsoa/runtime';
+import { TsoaRoute, fetchMiddlewares, ExpressTemplateService } from '@tsoa/runtime';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { PromptController } from './../../controllers/public/promptController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -19,8 +19,8 @@ import { FineTuneMainController } from './../../controllers/private/fineTuneCont
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { DemoController } from './../../controllers/private/demoController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { expressAuthentication } from './../../authentication';
 import { AdminController } from './../../controllers/private/adminController';
+import { expressAuthentication } from './../../authentication';
 // @ts-ignore - no great way to install types from subpackage
 import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
 

--- a/valhalla/jawn/src/tsoa-build/private/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/private/routes.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { TsoaRoute, fetchMiddlewares, ExpressTemplateService } from '@tsoa/runtime';
+import { ExpressTemplateService, TsoaRoute, fetchMiddlewares } from '@tsoa/runtime';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { PromptController } from './../../controllers/public/promptController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -19,8 +19,8 @@ import { FineTuneMainController } from './../../controllers/private/fineTuneCont
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { DemoController } from './../../controllers/private/demoController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { AdminController } from './../../controllers/private/adminController';
 import { expressAuthentication } from './../../authentication';
+import { AdminController } from './../../controllers/private/adminController';
 // @ts-ignore - no great way to install types from subpackage
 import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
 
@@ -342,7 +342,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "HeliconeMeta": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"lytixKey":{"dataType":"string"},"posthogHost":{"dataType":"string"},"posthogApiKey":{"dataType":"string"},"webhookEnabled":{"dataType":"boolean","required":true},"omitResponseLog":{"dataType":"boolean","required":true},"omitRequestLog":{"dataType":"boolean","required":true},"modelOverride":{"dataType":"string"}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"lytixKey":{"dataType":"string"},"lytixHost":{"dataType":"string"},"posthogHost":{"dataType":"string"},"posthogApiKey":{"dataType":"string"},"webhookEnabled":{"dataType":"boolean","required":true},"omitResponseLog":{"dataType":"boolean","required":true},"omitRequestLog":{"dataType":"boolean","required":true},"modelOverride":{"dataType":"string"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ProviderName": {

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -936,6 +936,9 @@
 					"lytixKey": {
 						"type": "string"
 					},
+					"lytixHost": {
+						"type": "string"
+					},
 					"posthogHost": {
 						"type": "string"
 					},

--- a/web/lib/clients/jawnTypes/private.ts
+++ b/web/lib/clients/jawnTypes/private.ts
@@ -340,6 +340,7 @@ Json: JsonObject;
     "Result_OrganizationOwner-Array.string_": components["schemas"]["ResultSuccess_OrganizationOwner-Array_"] | components["schemas"]["ResultError_string_"];
     HeliconeMeta: {
       lytixKey?: string;
+      lytixHost?: string;
       posthogHost?: string;
       posthogApiKey?: string;
       webhookEnabled: boolean;

--- a/worker/src/lib/clients/KafkaProducer.ts
+++ b/worker/src/lib/clients/KafkaProducer.ts
@@ -1,7 +1,7 @@
-import { TemplateWithInputs } from "@helicone/prompts/dist/objectParser";
-import { Kafka } from "@upstash/kafka";
 import { Env, Provider } from "../..";
+import { Kafka } from "@upstash/kafka";
 import { err } from "../util/results";
+import { TemplateWithInputs } from "@helicone/prompts/dist/objectParser";
 
 export type Log = {
   request: {

--- a/worker/src/lib/clients/KafkaProducer.ts
+++ b/worker/src/lib/clients/KafkaProducer.ts
@@ -1,7 +1,7 @@
-import { Env, Provider } from "../..";
-import { Kafka } from "@upstash/kafka";
-import { err } from "../util/results";
 import { TemplateWithInputs } from "@helicone/prompts/dist/objectParser";
+import { Kafka } from "@upstash/kafka";
+import { Env, Provider } from "../..";
+import { err } from "../util/results";
 
 export type Log = {
   request: {
@@ -40,6 +40,7 @@ export type HeliconeMeta = {
   posthogApiKey?: string;
   posthogHost?: string;
   lytixKey?: string;
+  lytixHost?: string;
 };
 
 export type KafkaMessage = {

--- a/worker/src/lib/dbLogger/DBLoggable.ts
+++ b/worker/src/lib/dbLogger/DBLoggable.ts
@@ -3,37 +3,37 @@ import { Headers } from "@cloudflare/workers-types";
 import { SupabaseClient } from "@supabase/supabase-js";
 import { Env, Provider } from "../..";
 import { Database, Json } from "../../../supabase/database.types";
-import { PromptSettings, RequestWrapper } from "../RequestWrapper";
-import { getTokenCount } from "../clients/TokenCounterClient";
-import { formatTimeStringDateTime } from "../db/ClickhouseStore";
-import { ClickhouseClientWrapper } from "../db/ClickhouseWrapper";
 import { DBWrapper } from "../db/DBWrapper";
-import { RequestResponseStore } from "../db/RequestResponseStore";
-import { RequestResponseManager } from "../managers/RequestResponseManager";
-import { AsyncLogModel } from "../models/AsyncLog";
+import { withTimeout } from "../util/helpers";
+import { Result, err, ok } from "../util/results";
 import { HeliconeHeaders } from "../models/HeliconeHeaders";
 import { HeliconeProxyRequest } from "../models/HeliconeProxyRequest";
+import { PromptSettings, RequestWrapper } from "../RequestWrapper";
 import { INTERNAL_ERRORS } from "../util/constants";
-import { withTimeout } from "../util/helpers";
-import {
-  isRequestImageModel,
-  isResponseImageModel,
-} from "../util/imageModelMapper";
-import { Result, err, ok } from "../util/results";
-import {
-  getRequestImageModelParser,
-  getResponseImageModelParser,
-} from "./imageParsers/parserMapper";
+import { AsyncLogModel } from "../models/AsyncLog";
+import { formatTimeStringDateTime } from "../db/ClickhouseStore";
+import { RequestResponseStore } from "../db/RequestResponseStore";
 import {
   anthropicAIStream,
   getModel,
 } from "./streamParsers/anthropicStreamParser";
 import { parseOpenAIStream } from "./streamParsers/openAIStreamParser";
+import { getTokenCount } from "../clients/TokenCounterClient";
+import { ClickhouseClientWrapper } from "../db/ClickhouseWrapper";
+import { RequestResponseManager } from "../managers/RequestResponseManager";
+import {
+  isRequestImageModel,
+  isResponseImageModel,
+} from "../util/imageModelMapper";
+import {
+  getRequestImageModelParser,
+  getResponseImageModelParser,
+} from "./imageParsers/parserMapper";
 
-import { TemplateWithInputs } from "@helicone/prompts/dist/objectParser";
+import { ImageModelParsingResponse } from "./imageParsers/core/parsingResponse";
 import { costOfPrompt } from "../../packages/cost";
 import { KafkaMessage, KafkaProducer } from "../clients/KafkaProducer";
-import { ImageModelParsingResponse } from "./imageParsers/core/parsingResponse";
+import { TemplateWithInputs } from "@helicone/prompts/dist/objectParser";
 
 export interface DBLoggableProps {
   response: {
@@ -734,9 +734,9 @@ export class DBLoggable {
         omitResponseLog: requestHeaders.omitHeaders.omitResponse,
         webhookEnabled: requestHeaders.webhookEnabled,
         posthogApiKey: requestHeaders.posthogKey ?? undefined,
-        posthogHost: requestHeaders.posthogHost ?? undefined,
         lytixKey: requestHeaders.lytixKey ?? undefined,
         lytixHost: requestHeaders.lytixHost ?? undefined,
+        posthogHost: requestHeaders.posthogHost ?? undefined,
       },
       log: {
         request: {

--- a/worker/src/lib/models/HeliconeHeaders.ts
+++ b/worker/src/lib/models/HeliconeHeaders.ts
@@ -57,6 +57,7 @@ export interface IHeliconeHeaders {
   moderationsEnabled: boolean;
   posthogKey: Nullable<string>;
   lytixKey: Nullable<string>;
+  lytixHost: Nullable<string>;
   posthogHost: Nullable<string>;
   webhookEnabled: boolean;
 }
@@ -104,6 +105,7 @@ export class HeliconeHeaders implements IHeliconeHeaders {
   posthogHost: Nullable<string>;
   webhookEnabled: boolean;
   lytixKey: Nullable<string>;
+  lytixHost: Nullable<string>;
 
   constructor(private headers: Headers) {
     const heliconeHeaders = this.getHeliconeHeaders();
@@ -133,6 +135,7 @@ export class HeliconeHeaders implements IHeliconeHeaders {
     this.promptSecurityEnabled = heliconeHeaders.promptSecurityEnabled;
     this.moderationsEnabled = heliconeHeaders.moderationsEnabled;
     this.lytixKey = heliconeHeaders.lytixKey;
+    this.lytixHost = heliconeHeaders.lytixHost;
     this.posthogKey = heliconeHeaders.posthogKey;
     this.posthogHost = heliconeHeaders.posthogHost;
     this.webhookEnabled = heliconeHeaders.webhookEnabled;
@@ -264,6 +267,7 @@ export class HeliconeHeaders implements IHeliconeHeaders {
           : false,
       posthogKey: this.headers.get("Helicone-Posthog-Key") ?? null,
       lytixKey: this.headers.get("Helicone-Lytix-Key") ?? null,
+      lytixHost: this.headers.get("Helicone-Lytix-Host") ?? null,
       posthogHost: this.headers.get("Helicone-Posthog-Host") ?? null,
       webhookEnabled:
         this.headers.get("Helicone-Webhook-Enabled") == "true" ? true : false,


### PR DESCRIPTION
We (Lytix) have just provisioned some EU servers and we have someone who would like to use us via Helicone. They want to remain GDPR compliant so we have provisioned some EU servers and would like to push metrics directly to that server.

See the original PR that added lytix [here](https://github.com/Helicone/helicone/pull/2157)