### PR TITLE
feat: add support for providing metadata via node sdk≤

### DIFF
--- a/helicone-node/async_logger/HeliconeAsyncLogger.ts
+++ b/helicone-node/async_logger/HeliconeAsyncLogger.ts
@@ -86,4 +86,8 @@ export class HeliconeAsyncLogger {
       },
     });
   }
+
+  withProperties(properties: Record<string, string>, fn: () => any) {
+    return traceloop.withAssociationProperties(properties, fn);
+  }
 }


### PR DESCRIPTION
example usage:
```ts
import { HeliconeAsyncLogger } from "@helicone/helicone";
import { OpenAI } from "openai";

const logger = new HeliconeAsyncLogger({
  apiKey: process.env.HELICONE_API_KEY
  providers: {
    openAI: OpenAI
  }
});
logger.init();

const openai = new OpenAI();

const headers = {
  "Helicone-Property-Client": "helicone-sdk"
};

logger.withProperties(
  headers,
  async () => {
    const completion = await openai.chat.completions.create({
      messages: [
        {"role": "system", "content": "You are a helpful assistant."},
        {"role": "user", "content": "How would a multi-galactiy civilization do things?"}
      ],
      model: "gpt-4o-mini",
      max_tokens: 50
    }, {
        headers: headers
      });
  }
);
```
![Screenshot 2024-08-28 at 17 09 35](https://github.com/user-attachments/assets/85de049d-ba3c-4c1e-935d-4aeb67423a89)


