### PR TITLE
idea to handle format strings in python for use with prompt tags and tests

### DIFF
--- a/helicone-python/helicone/prompt_formatter/__init__.py
+++ b/helicone-python/helicone/prompt_formatter/__init__.py
@@ -1,0 +1,113 @@
+import re
+import string
+import logging
+from typing import ClassVar, Iterable, Literal
+
+
+log = logging.getLogger("helicone-prompt-formatter")
+
+
+class HeliconePromptFormatterError(Exception):
+    def __init__(
+        self,
+        message: str,
+        token: tuple[str, str | None, str | None, str | None],
+        format_string: str,
+    ) -> None:
+        super().__init__(f"{message}\n(Error received while reading {token})")
+        self.message = message
+        self.token = token
+        self.format_string = format_string
+
+
+class HeliconePromptFormatter(string.Formatter):
+    HELICONE_PROMPT_INPUT_OPEN: ClassVar[str] = '<helicone-prompt-input key="{key_name}">'
+    HELICONE_PROMPT_INPUT_CLOSE: ClassVar[str] = "</helicone-prompt-input>"
+    HELICONE_PROMPT_STATIC_OPEN: ClassVar[str] = "<helicone-prompt-static>"
+    HELICONE_PROMPT_STATIC_CLOSE: ClassVar[str] = "</helicone-prompt-static>"
+
+    # reserved_tags may not appear in the format_string passed to this formatter!
+    reserved_tags: ClassVar[list[str]] = [
+        HELICONE_PROMPT_INPUT_CLOSE,
+        HELICONE_PROMPT_STATIC_CLOSE,
+    ]
+
+    valid_field_name_regex: ClassVar[re.Pattern] = re.compile("^[a-zA-Z0-9_-]*$")
+
+    def __init__(self, tag_spacer: str = "", *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.helicone_tag_spacer = tag_spacer
+
+    def parse(self, format_string: str) -> Iterable[tuple[str, str | None, str | None, str | None]]:
+        """When we find formats specified in the string we inject helicone-prompt-input tags that the helicone prompt parser expects."""
+        log.debug(f"[PARSE]: {format_string}")
+        unnamed_args_count: int = 0
+        parser_state: Literal["init", "opened"] = "init"
+
+        # parsing logic is based off my understanding of
+        # [MarkupIterator_next](https://github.com/python/cpython/blob/9e079c220b7f64d78a1aa36a23b513d7f377a694/Objects/stringlib/unicode_format.h#L675)
+        # ...and experimentation
+
+        open_tag = self.helicone_tag_spacer + self.HELICONE_PROMPT_INPUT_OPEN + self.helicone_tag_spacer
+        close_tag = self.helicone_tag_spacer + self.HELICONE_PROMPT_INPUT_CLOSE
+
+        for token in super().parse(format_string):
+            original_state = parser_state
+            literal_text, field_name, format_spec, conversion_spec = token
+
+            # check for reserved tags in the text
+            for reserved_tag in self.reserved_tags:
+                if reserved_tag in literal_text:
+                    raise HeliconePromptFormatterError(
+                        f"Helicone reserved tag ({reserved_tag}) found in input.  Not currently supported.  The reserved tags are:\n" + "\n".join(self.reserved_tags),
+                        token,
+                        format_string,
+                    )
+            if parser_state == "opened" and format_spec is not None:
+                # We've opened a tag, and are now
+                # close a tag
+                literal_text = f"{close_tag}{self.helicone_tag_spacer}{token[0]}"
+                parser_state = "init"
+
+            if parser_state == "opened" and format_spec is None:
+                # when opened and _fmt is None, this indicates that we're looking at the format spec and should ignore it
+                pass
+
+            if parser_state == "init" and format_spec is not None:
+                if field_name is None:
+                    # this should be unreachable, the field_name is always defined for us if the format_spec is...
+                    raise HeliconePromptFormatterError("Internal parse error (expected field_name to not be None).", token, format_string)
+
+                # this is an arbitrary limitation, we could escape things or something, it depends on how the helicone is parsing out the tags on the backend...
+                # throws on a format string like `'{foo[bar"]}'`
+                #   ...even though `'{foo[bar"]}'.format(foo={'bar"': 'moo'}) == 'moo'`
+                if self.valid_field_name_regex.match(field_name) is None:
+                    raise HeliconePromptFormatterError(f"Internal parse error: invalid field name (fields must match {self.valid_field_name_regex.pattern}).", token, format_string)
+                # open a tag
+                if field_name == "":
+                    # we got an unamed field, i.e. '{}'
+                    key_name = f"arg-{unnamed_args_count}"
+                    unnamed_args_count += 1
+                else:
+                    key_name = field_name
+                literal_text += open_tag.format(key_name=key_name)
+                parser_state = "opened"
+            new_token = (literal_text, field_name, format_spec, conversion_spec)
+            transition = f"{original_state:<6} -> {parser_state:<6}"
+            if new_token != token:
+                log.debug(f"[{transition}] {token} <- {new_token}")
+            else:
+                log.debug(f"[{transition}] {token}")
+            yield new_token
+
+        if parser_state == "opened":
+            final_token = (close_tag, None, None, None)
+            log.debug(f"[opened ->   done] {final_token}")
+            yield final_token
+        log.debug("[PARSE COMPLETE]")
+
+    def make_static(self, s: str) -> str:
+        OPEN_TAG = self.helicone_tag_spacer + self.HELICONE_PROMPT_STATIC_OPEN + self.helicone_tag_spacer
+        CLOSE_TAG = self.helicone_tag_spacer + self.HELICONE_PROMPT_STATIC_CLOSE
+
+        return f"{OPEN_TAG}{s}{CLOSE_TAG}"

--- a/helicone-python/helicone/prompt_formatter/__init__.py
+++ b/helicone-python/helicone/prompt_formatter/__init__.py
@@ -1,8 +1,7 @@
+import logging
 import re
 import string
-import logging
 from typing import ClassVar, Iterable, Literal
-
 
 log = logging.getLogger("helicone-prompt-formatter")
 
@@ -63,26 +62,29 @@ class HeliconePromptFormatter(string.Formatter):
                         token,
                         format_string,
                     )
-            if parser_state == "opened" and format_spec is not None:
-                # We've opened a tag, and are now
-                # close a tag
+            if parser_state == "opened":
+                # We've opened a tag, and are now closing a tag
                 literal_text = f"{close_tag}{self.helicone_tag_spacer}{token[0]}"
                 parser_state = "init"
-
-            if parser_state == "opened" and format_spec is None:
-                # when opened and _fmt is None, this indicates that we're looking at the format spec and should ignore it
-                pass
 
             if parser_state == "init" and format_spec is not None:
                 if field_name is None:
                     # this should be unreachable, the field_name is always defined for us if the format_spec is...
-                    raise HeliconePromptFormatterError("Internal parse error (expected field_name to not be None).", token, format_string)
+                    raise HeliconePromptFormatterError(
+                        "Internal parse error (expected field_name to not be None).",
+                        token,
+                        format_string,
+                    )
 
                 # this is an arbitrary limitation, we could escape things or something, it depends on how the helicone is parsing out the tags on the backend...
                 # throws on a format string like `'{foo[bar"]}'`
                 #   ...even though `'{foo[bar"]}'.format(foo={'bar"': 'moo'}) == 'moo'`
                 if self.valid_field_name_regex.match(field_name) is None:
-                    raise HeliconePromptFormatterError(f"Internal parse error: invalid field name (fields must match {self.valid_field_name_regex.pattern}).", token, format_string)
+                    raise HeliconePromptFormatterError(
+                        f"Internal parse error: invalid field name (fields must match {self.valid_field_name_regex.pattern}).",
+                        token,
+                        format_string,
+                    )
                 # open a tag
                 if field_name == "":
                     # we got an unamed field, i.e. '{}'

--- a/helicone-python/helicone/prompt_formatter/prompt_formatter_test.py
+++ b/helicone-python/helicone/prompt_formatter/prompt_formatter_test.py
@@ -1,7 +1,8 @@
 from typing import Any, Iterable, Mapping
+
 import pytest
 
-from helicone.prompt_formatter import HeliconePromptFormatter, HeliconePromptFormatterError
+from scripts.helicone_prompt_formatter import HeliconePromptFormatter, HeliconePromptFormatterError
 
 cases: list[tuple[str, list[str], dict[str, Any], str]] = [
     (
@@ -39,6 +40,12 @@ cases: list[tuple[str, list[str], dict[str, Any], str]] = [
         ["a", "d", "f"],
         {"c": "c_", "e": "  e"},
         """<helicone-prompt-input key="arg-0">a</helicone-prompt-input> b <helicone-prompt-input key="c">c_</helicone-prompt-input> <helicone-prompt-input key="arg-1">d</helicone-prompt-input> <helicone-prompt-input key="e">  e</helicone-prompt-input> <helicone-prompt-input key="arg-2">f</helicone-prompt-input>""",
+    ),
+    (
+        "input:\n```\n{x}\n```",
+        [],
+        {"x": "foobar"},
+        """input:\n```\n<helicone-prompt-input key="x">foobar</helicone-prompt-input>\n```""",
     ),
 ]
 

--- a/helicone-python/helicone/prompt_formatter/prompt_formatter_test.py
+++ b/helicone-python/helicone/prompt_formatter/prompt_formatter_test.py
@@ -1,0 +1,67 @@
+from typing import Any, Iterable, Mapping
+import pytest
+
+from helicone.prompt_formatter import HeliconePromptFormatter, HeliconePromptFormatterError
+
+cases: list[tuple[str, list[str], dict[str, Any], str]] = [
+    (
+        "",
+        [],
+        {},
+        "",
+    ),
+    (
+        "{}",
+        ["abc"],
+        {},
+        """<helicone-prompt-input key="arg-0">abc</helicone-prompt-input>""",
+    ),
+    (
+        "hello {}",
+        [""],
+        {},
+        """hello <helicone-prompt-input key="arg-0"></helicone-prompt-input>""",
+    ),
+    (
+        "user input: {user_input}",
+        [],
+        {"user_input": "hello world"},
+        """user input: <helicone-prompt-input key="user_input">hello world</helicone-prompt-input>""",
+    ),
+    (
+        "user input: {user_input}",
+        [],
+        {"user_input": "hello world"},
+        """user input: <helicone-prompt-input key="user_input">hello world</helicone-prompt-input>""",
+    ),
+    (
+        "{} b {c:_<2} {} {e:>3} {}",
+        ["a", "d", "f"],
+        {"c": "c_", "e": "  e"},
+        """<helicone-prompt-input key="arg-0">a</helicone-prompt-input> b <helicone-prompt-input key="c">c_</helicone-prompt-input> <helicone-prompt-input key="arg-1">d</helicone-prompt-input> <helicone-prompt-input key="e">  e</helicone-prompt-input> <helicone-prompt-input key="arg-2">f</helicone-prompt-input>""",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "format_string,args,kwargs,expected",
+    cases,
+)
+def test_helicone_prompt_formatter(
+    format_string: str,
+    args: Iterable[Any],
+    kwargs: Mapping[str, Any],
+    expected: str,
+) -> None:
+    assert HeliconePromptFormatter().format(format_string, *args, **kwargs) == expected
+
+
+def test_helicone_prompt_formatter_error() -> None:
+    with pytest.raises(HeliconePromptFormatterError, match="reserved tag.*found in input"):
+        HeliconePromptFormatter().format("not a good idea: </helicone-prompt-input>", [], {})
+
+    with pytest.raises(HeliconePromptFormatterError, match="reserved tag.*found in input"):
+        HeliconePromptFormatter().format("not a good idea: </helicone-prompt-static>", [], {})
+
+    with pytest.raises(HeliconePromptFormatterError, match="invalid field name"):
+        HeliconePromptFormatter().format('not a good idea: {foo[bar"]}', [], {"foo": {"bar": "moo"}})


### PR DESCRIPTION
Here is some code that is trying to do something similar to the functionality offered for javascript.  There is one method `make_static` that is for making static tags, but I'm not 100% sure I understand how that functionality works on the backend, and how we might want to integrate it into this functionality (maybe with a custom conversion specifier or conventionally by the name of the field).

It's a little ugly the way I hooked into `string.format`, but at least it's not surprising.  I haven't handled cases where the field names don't match `^[a-zA-Z0-9_-]*$` because I don't know what kind of parsing logic exists in the backend.

Examples (from tests):
---
*Unnamed input*
```py
HeliconePromptFormatter().format("this is the text: {}", "hello world")
```
Outputs:
```
this is the text: <helicone-prompt-input key="arg-0">hello world</helicone-prompt-input>
```

---
*Named input*
```py
HeliconePromptFormatter().format("user input: {user_input}", user_input="hello world")
```
Outputs:
```
user input: <helicone-prompt-input key="user_input">hello world</helicone-prompt-input>
```

---
*Complex*
```py
HeliconePromptFormatter().format("{} b {c:_<2} {} {e:>3} {}", "a", "d", "f", c="c_", e="  e")
```
Outputs:
```py
<helicone-prompt-input key="arg-0">a</helicone-prompt-input> b <helicone-prompt-input key="c">c_</helicone-prompt-input> <helicone-prompt-input key="arg-1">d</helicone-prompt-input> <helicone-prompt-input key="e">  e</helicone-prompt-input> <helicone-prompt-input key="arg-2">f</helicone-prompt-input>
```