### PR TITLE
Fixed broken readme link to signup page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 ## Quick Start ⚡️ One line of code
 
-1. Get your `write-only` API key by signing up [here](helicone.ai/signup).
+1. Get your `write-only` API key by signing up [here](https://helicone.ai/signup).
 
 2. Update only the `baseURL` in your code:
 


### PR DESCRIPTION
Updated readme link in Quick Start step 1. Was previously linking to "helicone.ai/signup" so GitHub was looking for that file within the repo. Now links to "https://helicone.ai/signup". Fixes [issue2979](https://github.com/Helicone/helicone/issues/2979).