### PR TITLE
Update studio port to the one mentioned in the compose.yml

### DIFF
--- a/docs/getting-started/self-host/docker.mdx
+++ b/docs/getting-started/self-host/docker.mdx
@@ -15,7 +15,7 @@ docker compose up
 ```
 
 <Note>
-  To create a user go to http://localhost:8989/project/default/auth/users and
+  To create a user go to http://localhost:54323/project/default/auth/users and
   add your account. You can use this account to sign into Helicone at
   localhost:3000 via your browser.
 </Note>

--- a/docs/getting-started/self-host/docker.mdx
+++ b/docs/getting-started/self-host/docker.mdx
@@ -15,9 +15,10 @@ docker compose up
 ```
 
 <Note>
-  To create a user go to http://localhost:54323/project/default/auth/users and
+  - To create a user go to http://localhost:54323/project/default/auth/users and
   add your account. You can use this account to sign into Helicone at
   localhost:3000 via your browser.
+  - Also update `ENABLE_EMAIL_AUTOCONFIRM` to `true` in `./docker/.env` to allow user addition without confirmation.
 </Note>
 
 **Default URLs:**


### PR DESCRIPTION
The previous add user flow doesnt work

Fix in the doc Includes:
1. Correcting the port in the docs (8989) to the host port for the studio (54323)
2. Letting user know to update env variable `ENABLE_EMAIL_AUTOCONFIRM` to `true` - to let auth work locally


Related : #2977 