### PR TITLE
Authorization on useAuth function in server side. Now authorization is being done on client side.

### DIFF
--- a/web/lib/api/handlerWrappers.ts
+++ b/web/lib/api/handlerWrappers.ts
@@ -11,6 +11,7 @@ import { FilterNode } from "../../services/lib/filters/filterDefs";
 import { Permission, Role, hasPermission } from "../../services/lib/user";
 import { Database } from "../../supabase/database.types";
 import { getRequestCountClickhouse } from "./request/request";
+import { }
 
 export interface HandlerWrapperNext<RetVal> {
   req: NextApiRequest;
@@ -135,7 +136,8 @@ export function withAuth<T>(
       operator: "and",
       right: "all",
     });
-    if (count.error == null) {
+    
+    if (req.url && req.url.includes('/metrics') && count.error == null) {
       const currentTier = data.org?.tier;
       if (currentTier === "free" && count.data > 100000) {
         res.status(403).json({ error: "Forbidden please upgrade your plan" });

--- a/web/lib/api/handlerWrappers.ts
+++ b/web/lib/api/handlerWrappers.ts
@@ -11,7 +11,6 @@ import { FilterNode } from "../../services/lib/filters/filterDefs";
 import { Permission, Role, hasPermission } from "../../services/lib/user";
 import { Database } from "../../supabase/database.types";
 import { getRequestCountClickhouse } from "./request/request";
-import { }
 
 export interface HandlerWrapperNext<RetVal> {
   req: NextApiRequest;


### PR DESCRIPTION
Added check in useAuth handler to check for org tier and usage to handle case where user is over their limit and requires an upgrade.

Right now this check is being done on client side in `useGetUnauthorized` in web/services/hooks/dashboard.tsx. 

I was able to intercept the request of '/api/request/ch/count' and change the response body to `"data": "1"` giving me full paid access the dashboard. 

https://github.com/user-attachments/assets/4af48237-7dc7-4c43-a8f5-87ff081f6920