### PR TITLE
Update fine-tuned-models.ts

### DIFF
--- a/costs/src/providers/openai/fine-tuned-models.ts
+++ b/costs/src/providers/openai/fine-tuned-models.ts
@@ -16,4 +16,24 @@ export const costs: ModelRow[] = [
       completion_token: 0.000006,
     },
   },
+  {
+    model: {
+      operator: "startsWith",
+      value: "ft:gpt-4o-mini-2024-07-18:",
+    },
+    cost: {
+      prompt_token: 0.0000003,
+      completion_token: 0.0000012
+    }
+  },
+  {
+    model: {
+      operator: "startsWith",
+      value: "ft:gpt-4o-2024-08-06:",
+    },
+    cost: {
+      prompt_token: 0.00000375,
+      completion_token: 0.000015
+    }
+  }
 ];


### PR DESCRIPTION
Adds cost data for fine tuned GPT-4o models per https://openai.com/api/pricing/