### PR TITLE
Add Custom Properties Soft Delete Functionality

### DIFF
--- a/supabase/migrations/20241215_add_hidden_properties_table.sql
+++ b/supabase/migrations/20241215_add_hidden_properties_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "public"."hidden_properties" (
+                                              "id" UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+                                              "organization_id" UUID NOT NULL REFERENCES organization(id),
+                                              "property_key" TEXT NOT NULL,
+                                              "hidden_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                              "hidden_by" UUID REFERENCES auth.users(id)
+);
+
+-- ensure no duplicates
+CREATE UNIQUE INDEX hidden_properties_org_key_unique
+    ON "public"."hidden_properties" ("organization_id", "property_key");
+
+-- Enable Row Level Security
+ALTER TABLE "public"."hidden_properties" ENABLE ROW LEVEL SECURITY;

--- a/web/components/shared/themed/table/requestRow.tsx
+++ b/web/components/shared/themed/table/requestRow.tsx
@@ -22,6 +22,26 @@ const RequestRow = (props: RequestRowProps) => {
 
   const [isExpanded, setIsExpanded] = useState(false);
 
+  const handleDeleteProperty = async (property: string) => {
+    try {
+      const response = await fetch("/api/propertiesV2/hide", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ property_key: property }),
+      });
+      if (response.ok) {
+        console.log(`${property} deleted successfully`);
+      } else {
+        console.error(`Failed to delete ${property}`);
+      }
+    } catch (error) {
+      console.error("Error deleting property:", error);
+    }
+  };
+
+
   return (
     <li
       key={"request-row-view-" + index}
@@ -84,24 +104,35 @@ const RequestRow = (props: RequestRowProps) => {
             </span>
           </p>
           {row.customProperties &&
-            properties.length > 0 &&
-            Object.keys(row.customProperties).length > 0 && (
-              <>
-                {properties.map((property, i) => {
-                  if (
-                    row.customProperties &&
-                    row.customProperties.hasOwnProperty(property)
-                  ) {
-                    return (
-                      <p className="text-sm" key={i}>
-                        <span className="font-semibold">{property}:</span>{" "}
-                        {row.customProperties[property] as string}
-                      </p>
-                    );
-                  }
-                })}
-              </>
-            )}
+              properties.length > 0 &&
+              Object.keys(row.customProperties).length > 0 && (
+                  <>
+                    {properties.map((property, i) => {
+                      if (
+                          row.customProperties &&
+                          row.customProperties.hasOwnProperty(property)
+                      ) {
+                        return (
+                            <div className="flex justify-between items-center" key={i}>
+                              <p className="text-sm">
+                                <span className="font-semibold">{property}:</span>{" "}
+                                {row.customProperties[property] as string}
+                              </p>
+                              <button
+                                  className="text-red-500 hover:text-red-700 text-xs"
+                                  onClick={(e) => {
+                                    e.stopPropagation(); // Prevent row selection on button click
+                                    handleDeleteProperty(property);
+                                  }}
+                              >
+                                Delete
+                              </button>
+                            </div>
+                        );
+                      }
+                    })}
+                  </>
+              )}
         </div>
       )}
     </li>

--- a/web/lib/api/properties/properties.ts
+++ b/web/lib/api/properties/properties.ts
@@ -4,6 +4,7 @@ import { dbQueryClickhouse } from "../db/dbExecute";
 
 export interface Property {
   property: string;
+  visibility: "hidden" | "visible";
 }
 
 export async function getProperties(

--- a/worker/src/lib/managers/PropertiesManager.ts
+++ b/worker/src/lib/managers/PropertiesManager.ts
@@ -71,55 +71,6 @@ export async function updateRequestProperties(
   }
 }
 
-// New functionality for managing property visibility
-export async function fetchVisibleProperties(
-    request: RequestWrapper,
-    env: Env
-): Promise<Response> {
-  const headers = request.getHeaders(); // Get all headers
-  const organizationId = headers.get("organization-id"); // Retrieve the specific header value
-
-  if (!organizationId) {
-    return new Response("Missing organization ID", { status: 400 });
-  }
-
-  const dbClient = createClient(
-      env.SUPABASE_URL,
-      env.SUPABASE_SERVICE_ROLE_KEY
-  );
-
-  try {
-    const { data: allProps, error: fetchError } = await dbClient
-        .from("properties")
-        .select("key")
-        .eq("organization_id", organizationId);
-
-    if (fetchError) {
-      console.error("Error fetching properties:", fetchError.message);
-      throw fetchError;
-    }
-
-    const { data: hiddenProps, error: hiddenError } = await dbClient
-        .from("hidden_properties")
-        .select("property_key")
-        .eq("organization_id", organizationId);
-
-    if (hiddenError) {
-      console.error("Error fetching hidden properties:", hiddenError.message);
-      throw hiddenError;
-    }
-
-    const hiddenSet = new Set(hiddenProps?.map((p) => p.property_key));
-    const visibleProperties =
-        allProps?.filter((prop) => !hiddenSet.has(prop.key)) || [];
-
-    return Response.json({ properties: visibleProperties });
-  } catch (error) {
-    console.error("Error fetching visible properties:", error);
-    return new Response("Error fetching visible properties", { status: 500 });
-  }
-}
-
 export async function hideProperty(
     request: RequestWrapper,
     env: Env
@@ -200,4 +151,3 @@ export async function unhideProperty(
     });
   }
 }
-

--- a/worker/src/lib/managers/PropertiesManager.ts
+++ b/worker/src/lib/managers/PropertiesManager.ts
@@ -70,3 +70,134 @@ export async function updateRequestProperties(
     console.log("Update successful");
   }
 }
+
+// New functionality for managing property visibility
+export async function fetchVisibleProperties(
+    request: RequestWrapper,
+    env: Env
+): Promise<Response> {
+  const headers = request.getHeaders(); // Get all headers
+  const organizationId = headers.get("organization-id"); // Retrieve the specific header value
+
+  if (!organizationId) {
+    return new Response("Missing organization ID", { status: 400 });
+  }
+
+  const dbClient = createClient(
+      env.SUPABASE_URL,
+      env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  try {
+    const { data: allProps, error: fetchError } = await dbClient
+        .from("properties")
+        .select("key")
+        .eq("organization_id", organizationId);
+
+    if (fetchError) {
+      console.error("Error fetching properties:", fetchError.message);
+      throw fetchError;
+    }
+
+    const { data: hiddenProps, error: hiddenError } = await dbClient
+        .from("hidden_properties")
+        .select("property_key")
+        .eq("organization_id", organizationId);
+
+    if (hiddenError) {
+      console.error("Error fetching hidden properties:", hiddenError.message);
+      throw hiddenError;
+    }
+
+    const hiddenSet = new Set(hiddenProps?.map((p) => p.property_key));
+    const visibleProperties =
+        allProps?.filter((prop) => !hiddenSet.has(prop.key)) || [];
+
+    return Response.json({ properties: visibleProperties });
+  } catch (error) {
+    console.error("Error fetching visible properties:", error);
+    return new Response("Error fetching visible properties", { status: 500 });
+  }
+}
+
+export async function hideProperty(
+    request: RequestWrapper,
+    env: Env
+): Promise<Response> {
+  const body = await request.getJson<{
+    organization_id: string;
+    property_key: string;
+    user_id: string;
+  }>();
+  if (!body.organization_id || !body.property_key || !body.user_id) {
+    return new Response("Missing required fields", { status: 400 });
+  }
+
+  const dbClient = createClient(
+      env.SUPABASE_URL,
+      env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  try {
+    const { error } = await dbClient.from("hidden_properties").insert({
+      organization_id: body.organization_id,
+      property_key: body.property_key,
+      hidden_by: body.user_id,
+      hidden_at: new Date().toISOString(),
+    });
+
+    if (error) {
+      console.error("Error hiding property:", (error as Error).message);
+      throw error;
+    }
+
+    return new Response("Property hidden successfully", { status: 200 });
+  } catch (error: unknown) {
+    const errorMessage =
+        error instanceof Error ? error.message : "Unknown error occurred";
+    console.error("Failed to hide property:", errorMessage);
+    return new Response(`Failed to hide property: ${errorMessage}`, {
+      status: 500,
+    });
+  }
+}
+
+export async function unhideProperty(
+    request: RequestWrapper,
+    env: Env
+): Promise<Response> {
+  const body = await request.getJson<{
+    organization_id: string;
+    property_key: string;
+  }>();
+  if (!body.organization_id || !body.property_key) {
+    return new Response("Missing required fields", { status: 400 });
+  }
+
+  const dbClient = createClient(
+      env.SUPABASE_URL,
+      env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  try {
+    const { error } = await dbClient.from("hidden_properties").delete().match({
+      organization_id: body.organization_id,
+      property_key: body.property_key,
+    });
+
+    if (error) {
+      console.error("Error unhiding property:", error.message);
+      throw error;
+    }
+
+    return new Response("Property unhidden successfully", { status: 200 });
+  } catch (error: unknown) {
+    const errorMessage =
+        error instanceof Error ? error.message : "Unknown error occurred";
+    console.error("Failed to unhide property:", errorMessage);
+    return new Response(`Failed to unhide property: ${errorMessage}`, {
+      status: 500,
+    });
+  }
+}
+

--- a/worker/src/routers/api/apiRouter.ts
+++ b/worker/src/routers/api/apiRouter.ts
@@ -11,7 +11,6 @@ import { logAsync } from "../../lib/managers/AsyncLogManager";
 import { createAPIClient } from "../../api/lib/apiClient";
 
 import {
-  fetchVisibleProperties,
   hideProperty,
   unhideProperty,
 } from "../../lib/managers/PropertiesManager";
@@ -473,44 +472,30 @@ function getAPIRouterV1(
     }
   );
 
-  // Route to fetch visible properties
-  router.get(
-    "/v1/properties/visible",
-    async (
-      _,
-      requestWrapper: RequestWrapper,
-      env: Env,
-      _ctx: ExecutionContext
-    ) => {
-      return await fetchVisibleProperties(requestWrapper, env);
-    }
+  router.post(
+      "/v2/properties/hide",
+      async (
+          _,
+          requestWrapper: RequestWrapper,
+          env: Env,
+          _ctx: ExecutionContext
+      ) => {
+        return await hideProperty(requestWrapper, env); // Ensure the updated hide logic is used.
+      }
   );
 
-  // Route to hide a property
   router.post(
-    "/v1/properties/hide",
-    async (
-      _,
-      requestWrapper: RequestWrapper,
-      env: Env,
-      _ctx: ExecutionContext
-    ) => {
-      return await hideProperty(requestWrapper, env);
-    }
+      "/v2/properties/unhide",
+      async (
+          _,
+          requestWrapper: RequestWrapper,
+          env: Env,
+          _ctx: ExecutionContext
+      ) => {
+        return await unhideProperty(requestWrapper, env); // Ensure the updated unhide logic is used.
+      }
   );
 
-  // Route to unhide a property
-  router.post(
-    "/v1/properties/unhide",
-    async (
-      _,
-      requestWrapper: RequestWrapper,
-      env: Env,
-      _ctx: ExecutionContext
-    ) => {
-      return await unhideProperty(requestWrapper, env);
-    }
-  );
 }
 
 export const getAPIRouter = (

--- a/worker/src/routers/api/apiRouter.ts
+++ b/worker/src/routers/api/apiRouter.ts
@@ -10,6 +10,12 @@ import { Route } from "itty-router";
 import { logAsync } from "../../lib/managers/AsyncLogManager";
 import { createAPIClient } from "../../api/lib/apiClient";
 
+import {
+  fetchVisibleProperties,
+  hideProperty,
+  unhideProperty,
+} from "../../lib/managers/PropertiesManager";
+
 function getAPIRouterV1(
   router: OpenAPIRouterType<
     Route,
@@ -464,6 +470,45 @@ function getAPIRouterV1(
             "Content-Type, helicone-jwt, helicone-org-id",
         },
       });
+    }
+  );
+
+  // Route to fetch visible properties
+  router.get(
+    "/v1/properties/visible",
+    async (
+      _,
+      requestWrapper: RequestWrapper,
+      env: Env,
+      _ctx: ExecutionContext
+    ) => {
+      return await fetchVisibleProperties(requestWrapper, env);
+    }
+  );
+
+  // Route to hide a property
+  router.post(
+    "/v1/properties/hide",
+    async (
+      _,
+      requestWrapper: RequestWrapper,
+      env: Env,
+      _ctx: ExecutionContext
+    ) => {
+      return await hideProperty(requestWrapper, env);
+    }
+  );
+
+  // Route to unhide a property
+  router.post(
+    "/v1/properties/unhide",
+    async (
+      _,
+      requestWrapper: RequestWrapper,
+      env: Env,
+      _ctx: ExecutionContext
+    ) => {
+      return await unhideProperty(requestWrapper, env);
     }
   );
 }


### PR DESCRIPTION
- Introduced a migration script to create the hidden_properties table with appropriate constraints and indexes.
- Added a "Delete" button to relevant UI components (e.g., RequestRow) to allow hiding properties.
- Updated property listings to only display visible properties.
- Integrated API calls to the new /v2/properties/hide endpoint for hiding properties from the UI.
- Added a new hidden_properties table to track hidden properties without modifying the existing properties schema.
- Updated the /v1/property/query endpoint to include a visibility column (hidden or visible) by joining the hidden_properties table.
- Implemented /v2/properties/hide and /v2/properties/unhide endpoints for hiding and unhiding properties.
