### PR TITLE
Small change: Prompt cards required padding

### DIFF
--- a/web/components/templates/prompts/promptsPage.tsx
+++ b/web/components/templates/prompts/promptsPage.tsx
@@ -337,7 +337,7 @@ const PromptsPage = (props: PromptsPageProps) => {
 
               {filteredPrompts && (hasLimitedAccess || hasAccess) ? (
                 searchParams.get("view") === "card" ? (
-                  <ul className="w-full h-full grid grid-cols-2 xl:grid-cols-4 gap-4">
+                  <ul className={cn("w-full h-full grid grid-cols-2 xl:grid-cols-4 gap-4", ISLAND_MARGIN)}>
                     {filteredPrompts.map((prompt, i) => (
                       <li key={i} className="col-span-1">
                         <PromptCard prompt={prompt} />


### PR DESCRIPTION
<img width="916" alt="Screenshot 2024-12-24 at 8 55 16 AM" src="https://github.com/user-attachments/assets/4a01984f-fab7-4461-ad5a-712baa47876f" />
The padding on the left is fixed. Used ISLAND_MARGIN like the above component.