### PR TITLE
fix: signup link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 ## Quick Start ⚡️ One line of code
 
-1. Get your `write-only` API key by signing up [here](helicone.ai/signup).
+1. Get your `write-only` API key by signing up [here](https://helicone.ai/signup).
 
 2. Update only the `baseURL` in your code:
 


### PR DESCRIPTION
This link is broken clicking on Github repository.  Adding https:// like the other links.
Reported: https://github.com/Helicone/helicone/issues/3093

