### PR TITLE
Fix: Specifies localhost schema as "public" in supabase/config.toml

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -7,7 +7,7 @@ project_id = "helicone"
 port = 54321
 # Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
 # endpoints. public and storage are always included.
-schemas = []
+schemas = ["public"]
 # Extra schemas to add to the search_path of every request.
 extra_search_path = ["extensions"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size


### PR DESCRIPTION
Found when going through [https://docs.helicone.ai/getting-started/self-host/manual](https://docs.helicone.ai/getting-started/self-host/manual) with a modern Supabase CLI version.