### PR TITLE
getting docker in a much better state, works out of the box

### DIFF
--- a/clickhouse/ch_hcone.py
+++ b/clickhouse/ch_hcone.py
@@ -163,12 +163,14 @@ def main():
                         help='ClickHouse server user')
     parser.add_argument('--list-migrations', action='store_true',
                         help='List applied migrations')
+    parser.add_argument('--no-password', action='store_true',
+                        help='Do not prompt for password')
 
     args = parser.parse_args()
 
     password = os.getenv('CLICKHOUSE_PASSWORD')
 
-    if args.user and not password:
+    if args.user and not password and not args.no_password:
         password = getpass.getpass(
             prompt='Enter password for ClickHouse server user: ')
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -313,6 +313,8 @@ services:
     environment:
       CLICKHOUSE_HOST: ${CLICKHOUSE_HOST}
       CLICKHOUSE_PORT: ${CLICKHOUSE_PORT}
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
 
   supabase-migration-runner:
     container_name: supabase-migration-runner
@@ -408,8 +410,8 @@ services:
   jawn:
     container_name: helicone-jawn
     build:
-      context: ../valhalla
-      dockerfile: ../valhalla/dockerfile
+      context: ../
+      dockerfile: valhalla/dockerfile
     restart: unless-stopped
     ports:
       - ${JAWN_PORT}:${JAWN_PORT}
@@ -433,6 +435,7 @@ services:
           "CLICKHOUSE_USER": "${CLICKHOUSE_USER}",
           "CLICKHOUSE_PASSWORD": "${CLICKHOUSE_PASSWORD}"
         }
+      VERCEL_ENV: ${VERCEL_ENV}
 
   minio:
     container_name: helicone-minio

--- a/docker/dockerfiles/dockerfile_clickhouse_migration_runner
+++ b/docker/dockerfiles/dockerfile_clickhouse_migration_runner
@@ -12,5 +12,6 @@ COPY . /app
 RUN find /app -name ".env.*" -exec rm {} \;
 
 RUN python3 -m pip install -r requirements.txt
+ENV CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
 
-CMD python3 ch_hcone.py --upgrade --host ${CLICKHOUSE_HOST} --port ${CLICKHOUSE_PORT} --user ${CLICKHOUSE_USER} --password ${CLICKHOUSE_PASSWORD}
+CMD python3 ch_hcone.py --upgrade --host ${CLICKHOUSE_HOST} --port ${CLICKHOUSE_PORT} --user ${CLICKHOUSE_USER} --no-password

--- a/valhalla/dockerfile
+++ b/valhalla/dockerfile
@@ -21,7 +21,7 @@ RUN find /usr/src/app/valhalla/jawn -name ".env.*" -exec rm {} \;
 #yarn workspace jawn serve
 ENV PORT=8585
 
-RUN yarn build
+RUN yarn && yarn build
 
 ENV DLQ_MESSAGES_PER_MINI_BATCH=1
 ENV DLQ_WORKER_COUNT=1

--- a/valhalla/jawn/src/lib/handlers/OnlineEvalHandler.ts
+++ b/valhalla/jawn/src/lib/handlers/OnlineEvalHandler.ts
@@ -99,8 +99,8 @@ export class OnlineEvalHandler extends AbstractLogHandler {
           },
           inputRecord,
           request_id: context.message.log.request.id,
-          requestBody: JSON.stringify(context.processedLog.request.body),
-          responseBody: JSON.stringify(context.processedLog.response.body),
+          requestBody: context.processedLog.request.body,
+          responseBody: context.processedLog.response.body,
           heliconeRequest: toHeliconeRequest(context),
         });
 


### PR DESCRIPTION
## Changes

1. Fix `jawn` build
2. fixed clickhouse migration runner to work without a password
3. Added docs around worker issues and pushing users to use jawn as proxy

## Testing criteria

```
git clone git@github.com:Helicone/helicone.git
cd helicone
git checkout docker-compose-working
cd docker 
cp .env.example .env
docker compose up
```

make an account by doing to `localhost:54324`
sign in and make an API key

then make a request
```
from openai import OpenAI
import os
from dotenv import load_dotenv

# Load environment variables from .env file
load_dotenv()

SESSION_ID = "test-session-id-4"

openai_client = OpenAI(
    api_key=os.getenv("OPENAI_API_KEY"),
    base_url="http://127.0.0.1:8585/v1/gateway/oai/v1",
    default_headers={
        "Helicone-Auth": f"Bearer ...",
        "Helicone-Session-Id": SESSION_ID,
    }
)

response = openai_client.completions.create(
    model="gpt-3.5-turbo-instruct",
    prompt="Count to 5",
    stream=False,
    extra_headers={
        "Helicone-Property-Test": "Instruct",
    }
)
assert response.choices[0].text is not None

```
