### PR TITLE
Helicone Prompts: Generate Route V1

### DIFF
--- a/clickhouse/ch_hcone.py
+++ b/clickhouse/ch_hcone.py
@@ -10,21 +10,18 @@ from yarl import URL
 
 
 file_dir = os.path.dirname(os.path.realpath(__file__))
-schema_dir = os.path.join(file_dir, 'migrations')
-all_schemas = [
-    os.path.join(schema_dir, file)
-    for file in os.listdir(schema_dir)
-]
+schema_dir = os.path.join(file_dir, "migrations")
+all_schemas = [os.path.join(schema_dir, file) for file in os.listdir(schema_dir)]
 
 
 def schema_sort_key(filename):
-    match = re.search(r'schema_(\d+)', os.path.basename(filename))
+    match = re.search(r"schema_(\d+)", os.path.basename(filename))
     return int(match.group(1)) if match else -1
 
 
 all_schemas.sort(key=schema_sort_key)
 
-container_name = 'helicone-clickhouse-server'
+container_name = "helicone-clickhouse-server"
 
 
 def get_host(host: str):
@@ -37,18 +34,15 @@ def run_curl_command(query, host, port, user=None, password=None, migration_file
 
     if not query:
         curl_cmd = (
-            f"cat \"{migration_file}\" | "
-            f"curl {auth} '{base_url}' --data-binary @-"
+            f"cat \"{migration_file}\" | curl {auth} '{base_url}' --data-binary @-"
         ).strip()
     else:
         curl_cmd = (
-            f"echo \"{query}\" | "
-            f"curl {auth} '{base_url}' --data-binary @-"
+            f"echo \"{query}\" | curl {auth} '{base_url}' --data-binary @-"
         ).strip()
 
-    result = subprocess.run(curl_cmd, shell=True,
-                            capture_output=True, text=True)
-    if (result.returncode != 0):
+    result = subprocess.run(curl_cmd, shell=True, capture_output=True, text=True)
+    if result.returncode != 0:
         print("Error running query")
         print("STDOUT:", result.stdout)
         print("STDERR:", result.stderr)
@@ -57,184 +51,184 @@ def run_curl_command(query, host, port, user=None, password=None, migration_file
 
 
 def create_migration_table(host, port, user=None, password=None):
-    query = '''
+    query = """
     CREATE TABLE IF NOT EXISTS helicone_migrations (
         migration_name String,
         applied_date DateTime DEFAULT now()
     ) ENGINE = MergeTree() ORDER BY migration_name;
-    '''
+    """
     res = run_curl_command(query, host, port, user, password)
 
     if res.returncode != 0:
-        print('Failed to create helicone_migrations table')
-        print('STDOUT:', res.stdout)
-        print('STDERR:', res.stderr)
+        print("Failed to create helicone_migrations table")
+        print("STDOUT:", res.stdout)
+        print("STDERR:", res.stderr)
         sys.exit(1)
     else:
-        print('Created helicone_migrations table')
+        print("Created helicone_migrations table")
 
 
 def is_migration_applied(migration_name, host, port, user=None, password=None):
-    query = f'''
+    query = f"""
     SELECT count(*) FROM helicone_migrations WHERE migration_name = '{migration_name}';
-    '''
+    """
     res = run_curl_command(query, host, port, user, password)
     return int(res.stdout.strip()) > 0
 
 
 def mark_migration_as_applied(migration_name, host, port, user=None, password=None):
-    query = f'''
+    query = f"""
     INSERT INTO helicone_migrations (migration_name) VALUES ('{migration_name}');
-    '''
+    """
     run_curl_command(query, host, port, user, password)
 
 
 def run_migrations(host, port, retries=5, user=None, password=None):
-    print('Running migrations')
+    print("Running migrations")
     time.sleep(1)
     for schema_path in all_schemas:
         migration_name = os.path.basename(schema_path)
         if is_migration_applied(migration_name, host, port, user, password):
-            print(f'Skipping already applied migration: {migration_name}')
+            print(f"Skipping already applied migration: {migration_name}")
             continue
 
-        print(f'Running {schema_path}')
+        print(f"Running {schema_path}")
 
         res = run_curl_command(None, host, port, user, password, schema_path)
 
         if res.returncode != 0:
-            print(f'Failed to run {schema_path}')
+            print(f"Failed to run {schema_path}")
             retries -= 1
             if retries > 0:
                 time.sleep(1)
-                print('Retrying')
+                print("Retrying")
                 run_migrations(host, port, retries, user, password)
             break
         else:
-            mark_migration_as_applied(
-                migration_name, host, port, user, password)
+            mark_migration_as_applied(migration_name, host, port, user, password)
 
-    print('Finished running migrations')
+    print("Finished running migrations")
 
 
 def list_migrations(host, port, user=None, password=None):
-    query = '''
+    query = """
     SELECT migration_name, applied_date
     FROM helicone_migrations
     ORDER BY migration_name;
-    '''
+    """
     res = run_curl_command(query, host, port, user, password)
-    migrations = [line.split('\t') for line in res.stdout.strip().split('\n')]
+    migrations = [line.split("\t") for line in res.stdout.strip().split("\n")]
 
     # Sort migrations based on schema version number
     migrations.sort(key=lambda x: schema_sort_key(x[0]))
 
-    headers = ['Migration Name', 'Applied Date']
-    print(tabulate.tabulate(migrations, headers=headers, tablefmt='grid'))
+    headers = ["Migration Name", "Applied Date"]
+    print(tabulate.tabulate(migrations, headers=headers, tablefmt="grid"))
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Helicone CLI tool to manage migrations and start services'
+        description="Helicone CLI tool to manage migrations and start services"
     )
 
-    envhost = os.getenv('CLICKHOUSE_HOST')
-    envport = os.getenv('CLICKHOUSE_PORT')
+    envhost = os.getenv("CLICKHOUSE_HOST")
+    envport = os.getenv("CLICKHOUSE_PORT")
     if envhost:
         url = URL(envhost)
         envhost = str(url.host)
         envport = str(url.port) if url.port else envport
 
-    parser.add_argument('--version', action='version',
-                        version='%(prog)s 0.1.0')
-    parser.add_argument('--migrate', action='store_true',
-                        help='Run migrations')
-    parser.add_argument('--start', action='store_true', help='Start services')
-    parser.add_argument('--stop', action='store_true', help='Stop services')
-    parser.add_argument('--restart', action='store_true',
-                        help='Restart services')
-    parser.add_argument('--upgrade', action='store_true',
-                        help='Apply all migrations')
-    parser.add_argument('--host', default=envhost or "localhost",
-                        help='ClickHouse server host')
-    parser.add_argument('--port', default=envport or "18123",
-                        help='ClickHouse server port')
-    parser.add_argument('--user', default=os.getenv('CLICKHOUSE_USER') or "default",
-                        help='ClickHouse server user')
-    parser.add_argument('--list-migrations', action='store_true',
-                        help='List applied migrations')
-    parser.add_argument('--no-password', action='store_true',
-                        help='Do not prompt for password')
+    parser.add_argument("--version", action="version", version="%(prog)s 0.1.0")
+    parser.add_argument("--migrate", action="store_true", help="Run migrations")
+    parser.add_argument("--start", action="store_true", help="Start services")
+    parser.add_argument("--stop", action="store_true", help="Stop services")
+    parser.add_argument("--restart", action="store_true", help="Restart services")
+    parser.add_argument("--upgrade", action="store_true", help="Apply all migrations")
+    parser.add_argument(
+        "--host", default=envhost or "localhost", help="ClickHouse server host"
+    )
+    parser.add_argument(
+        "--port", default=envport or "18123", help="ClickHouse server port"
+    )
+    parser.add_argument(
+        "--user",
+        default=os.getenv("CLICKHOUSE_USER") or "default",
+        help="ClickHouse server user",
+    )
+    parser.add_argument(
+        "--list-migrations", action="store_true", help="List applied migrations"
+    )
+    parser.add_argument(
+        "--no-password", action="store_true", help="Do not prompt for password"
+    )
 
     args = parser.parse_args()
 
-    password = os.getenv('CLICKHOUSE_PASSWORD')
+    password = os.getenv("CLICKHOUSE_PASSWORD")
 
     if args.user and not password and not args.no_password:
-        password = getpass.getpass(
-            prompt='Enter password for ClickHouse server user: ')
+        password = getpass.getpass(prompt="Enter password for ClickHouse server user: ")
 
-    print(f'''
+    print(f"""
     Running:
-    {parser.prog} {' '.join(sys.argv[1:])}
+    {parser.prog} {" ".join(sys.argv[1:])}
 
     Args collected:
     {args}
-    ''')
+    """)
 
     if args.start:
-        print('Starting services')
+        print("Starting services")
         res = subprocess.run(
-            f'docker run -d -p {args.port}:8123 -p19000:9000 --name {container_name} '
-            '--ulimit nofile=262144:262144 clickhouse/clickhouse-server',
-            shell=True
+            f"docker run -d -p {args.port}:8123 -p19000:9000 --name {container_name} "
+            "--ulimit nofile=262144:262144 clickhouse/clickhouse-server:24.3.13.40",
+            shell=True,
         )
         time.sleep(1)
         if res.returncode != 0:
-            print('Failed to start services')
+            print("Failed to start services")
         else:
             create_migration_table(args.host, args.port, args.user, password)
-            run_migrations(args.host, args.port,
-                           user=args.user, password=password)
-            print(f'''
+            run_migrations(args.host, args.port, user=args.user, password=password)
+            print(f"""
 Test query by running:
 echo 'SELECT 1' | curl '{get_host(args.host)}:{args.port}/' --data-binary @-
-            ''')
+            """)
 
     elif args.stop:
-        print('Stopping services')
-        subprocess.run(f'docker stop {container_name}', shell=True)
-        subprocess.run(f'docker rm {container_name}', shell=True)
+        print("Stopping services")
+        subprocess.run(f"docker stop {container_name}", shell=True)
+        subprocess.run(f"docker rm {container_name}", shell=True)
 
     elif args.restart:
-        print('Restarting services')
-        subprocess.run(f'docker stop {container_name}', shell=True)
-        subprocess.run(f'docker rm {container_name}', shell=True)
+        print("Restarting services")
+        subprocess.run(f"docker stop {container_name}", shell=True)
+        subprocess.run(f"docker rm {container_name}", shell=True)
         subprocess.run(
-            f'docker run -d -p {args.port}:8123 -p19000:9000 --name {container_name} '
-            '--ulimit nofile=262144:262144 clickhouse/clickhouse-server',
-            shell=True
+            f"docker run -d -p {args.port}:8123 -p19000:9000 --name {container_name} "
+            "--ulimit nofile=262144:262144 clickhouse/clickhouse-server:24.3.13.40",
+            shell=True,
         )
         time.sleep(5)
         create_migration_table(args.host, args.port, args.user, password)
         run_migrations(args.host, args.port, user=args.user, password=password)
-        print(f'''
+        print(f"""
 Test query by running:
 echo 'SELECT 1' | curl '{get_host(args.host)}:{args.port}/' --data-binary @-
-        ''')
+        """)
 
     elif args.upgrade:
-        print('Applying all migrations')
+        print("Applying all migrations")
         create_migration_table(args.host, args.port, args.user, password)
         run_migrations(args.host, args.port, user=args.user, password=password)
 
     elif args.list_migrations:
-        print('Listing applied migrations')
+        print("Listing applied migrations")
         list_migrations(args.host, args.port, args.user, password)
 
     else:
-        print('No action specified')
+        print("No action specified")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/e2e_suite.py
+++ b/tests/e2e_suite.py
@@ -8,6 +8,9 @@ from PIL import Image
 import base64
 import pytest
 from dotenv import load_dotenv
+import pathlib
+import json
+import subprocess
 
 # Load environment variables from .env file
 load_dotenv()
@@ -20,34 +23,33 @@ openai_client = OpenAI(
     default_headers={
         "Helicone-Auth": f"Bearer {os.getenv('HELICONE_API_KEY')}",
         "Helicone-Session-Id": SESSION_ID,
-    }
+    },
 )
 
 genai.configure(
-    api_key=os.environ.get('GOOGLE_GENERATIVE_API_KEY'),
+    api_key=os.environ.get("GOOGLE_GENERATIVE_API_KEY"),
     client_options={
-        'api_endpoint': os.getenv("HELICONE_GATEWAY_BASE_URL"),
+        "api_endpoint": os.getenv("HELICONE_GATEWAY_BASE_URL"),
     },
     default_metadata=[
-        ('helicone-auth', f'Bearer {os.getenv("HELICONE_API_KEY")}'),
-        ('helicone-target-url', 'https://generativelanguage.googleapis.com'),
-        ('helicone-session-id', SESSION_ID)
+        ("helicone-auth", f"Bearer {os.getenv('HELICONE_API_KEY')}"),
+        ("helicone-target-url", "https://generativelanguage.googleapis.com"),
+        ("helicone-session-id", SESSION_ID),
     ],
-    transport="rest"
+    transport="rest",
 )
-google_model = genai.GenerativeModel('models/gemini-1.5-flash')
+google_model = genai.GenerativeModel("models/gemini-1.5-flash")
 anthropic_client = anthropic.Anthropic(
     api_key=os.getenv("ANTHROPIC_API_KEY"),
     base_url=os.getenv("HELICONE_ANTHROPIC_BASE_URL"),
     default_headers={
         "Helicone-Auth": f"Bearer {os.getenv('HELICONE_API_KEY')}",
-        "Helicone-Session-Id": SESSION_ID
-    }
+        "Helicone-Session-Id": SESSION_ID,
+    },
 )
 
 
 class TestHeliconeIntegrations:
-
     def test_openai_instruct(self):
         response = openai_client.completions.create(
             model="gpt-3.5-turbo-instruct",
@@ -55,7 +57,7 @@ class TestHeliconeIntegrations:
             stream=False,
             extra_headers={
                 "Helicone-Property-Test": "Instruct",
-            }
+            },
         )
         assert response.choices[0].text is not None
 
@@ -67,9 +69,7 @@ class TestHeliconeIntegrations:
             extra_headers={
                 "Helicone-Property-Test": "Instruct Streaming",
             },
-            stream_options={
-                "include_usage": True
-            }
+            stream_options={"include_usage": True},
         )
         for chunk in response:
             print(chunk.choices)
@@ -81,7 +81,7 @@ class TestHeliconeIntegrations:
             stream=False,
             extra_headers={
                 "Helicone-Property-Test": "Chat Completion",
-            }
+            },
         )
         assert response.choices[0].message.content is not None
 
@@ -92,8 +92,8 @@ class TestHeliconeIntegrations:
             stream=True,
             extra_headers={
                 "Helicone-Property-Test": "Chat Completion Streaming",
-                "helicone-stream-usage": "true"
-            }
+                "helicone-stream-usage": "true",
+            },
         )
         for chunk in response:
             print(chunk)
@@ -104,7 +104,7 @@ class TestHeliconeIntegrations:
             pytest.skip("test_image.png not found")
 
         with open("test_image.png", "rb") as image_file:
-            base64_image = base64.b64encode(image_file.read()).decode('utf-8')
+            base64_image = base64.b64encode(image_file.read()).decode("utf-8")
 
         response = openai_client.chat.completions.create(
             model="gpt-4o-mini",
@@ -113,14 +113,18 @@ class TestHeliconeIntegrations:
                     "role": "user",
                     "content": [
                         {"type": "text", "text": "What's in this image?"},
-                        {"type": "image_url", "image_url": {
-                            "url": f"data:image/jpeg;base64,{base64_image}"}}
-                    ]
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/jpeg;base64,{base64_image}"
+                            },
+                        },
+                    ],
                 }
             ],
             extra_headers={
                 "Helicone-Property-Test": "Chat with Image",
-            }
+            },
         )
 
         assert response.choices[0].message.content is not None
@@ -135,21 +139,22 @@ class TestHeliconeIntegrations:
                     "type": "object",
                     "properties": {
                         "location": {"type": "string"},
-                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
                     },
-                    "required": ["location"]
-                }
+                    "required": ["location"],
+                },
             }
         ]
         response = openai_client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[
-                {"role": "user", "content": "What's the weather in San Francisco?"}],
+                {"role": "user", "content": "What's the weather in San Francisco?"}
+            ],
             functions=functions,
             function_call="auto",
             extra_headers={
                 "Helicone-Property-Test": "Function Calling",
-            }
+            },
         )
         assert response.choices[0].message.function_call is not None
 
@@ -162,7 +167,7 @@ class TestHeliconeIntegrations:
             response_format="b64_json",
             extra_headers={
                 "Helicone-Property-Test": "Image Generation",
-            }
+            },
         )
         assert response.data[0].b64_json is not None
 
@@ -181,26 +186,23 @@ class TestHeliconeIntegrations:
             pytest.skip("test_image.png not found")
 
         image = Image.open("test_image.png")
-        response = google_model.generate_content(
-            ["What's in this image?", image])
+        response = google_model.generate_content(["What's in this image?", image])
         assert response.text is not None
 
     def test_anthropic_completion(self):
         message = anthropic_client.messages.create(
             model="claude-3-opus-20240229",
             max_tokens=1000,
-            messages=[{"role": "user", "content": "Count to 5"}]
+            messages=[{"role": "user", "content": "Count to 5"}],
         )
         assert message.content[0].text is not None
 
     def test_anthropic_streaming(self):
-        client = anthropic.Anthropic(
-            api_key=os.getenv("ANTHROPIC_API_KEY")
-        )
+        client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
         with client.messages.stream(
             model="claude-3-opus-20240229",
             max_tokens=1000,
-            messages=[{"role": "user", "content": "Count to 5"}]
+            messages=[{"role": "user", "content": "Count to 5"}],
         ) as stream:
             for text in stream.text_stream:
                 print(text)
@@ -210,7 +212,7 @@ class TestHeliconeIntegrations:
             pytest.skip("test_image.png not found")
 
         with open("test_image.png", "rb") as img_file:
-            image_data = base64.b64encode(img_file.read()).decode('utf-8')
+            image_data = base64.b64encode(img_file.read()).decode("utf-8")
 
         message = anthropic_client.messages.create(
             model="claude-3-opus-20240229",
@@ -224,19 +226,16 @@ class TestHeliconeIntegrations:
                             "source": {
                                 "type": "base64",
                                 "media_type": "image/png",
-                                "data": image_data
-                            }
+                                "data": image_data,
+                            },
                         },
-                        {
-                            "type": "text",
-                            "text": "What's in this image?"
-                        }
-                    ]
+                        {"type": "text", "text": "What's in this image?"},
+                    ],
                 }
             ],
             extra_headers={
                 "Helicone-Property-Test": "Chat with Image",
-            }
+            },
         )
         assert message.content[0].text is not None
 
@@ -261,10 +260,11 @@ class TestHeliconeIntegrations:
                 }
             ],
             messages=[
-                {"role": "user", "content": "What's the weather like in San Francisco?"}],
+                {"role": "user", "content": "What's the weather like in San Francisco?"}
+            ],
             extra_headers={
                 "Helicone-Property-Test": "Tool Call",
-            }
+            },
         )
         assert message.content[0].text is not None
 
@@ -281,35 +281,40 @@ class TestHeliconeIntegrations:
                         "properties": {
                             "location": {
                                 "type": "string",
-                                "description": "The city and state, e.g. San Francisco, CA"
+                                "description": "The city and state, e.g. San Francisco, CA",
                             },
                             "unit": {
                                 "type": "string",
                                 "enum": ["celsius", "fahrenheit"],
-                                "description": "The unit of temperature, either 'celsius' or 'fahrenheit'"
-                            }
+                                "description": "The unit of temperature, either 'celsius' or 'fahrenheit'",
+                            },
                         },
-                        "required": ["location"]
-                    }
+                        "required": ["location"],
+                    },
                 }
             ],
-
             messages=[
-                {"role": "user", "content": "What's the weather like in San Francisco?"},
+                {
+                    "role": "user",
+                    "content": "What's the weather like in San Francisco?",
+                },
                 {
                     "role": "assistant",
                     "content": [
                         {
                             "type": "text",
-                            "text": "<thinking>I need to use get_weather, and the user wants SF, which is likely San Francisco, CA.</thinking>"
+                            "text": "<thinking>I need to use get_weather, and the user wants SF, which is likely San Francisco, CA.</thinking>",
                         },
                         {
                             "type": "tool_use",
                             "id": "toolu_01A09q90qw90lq917835lq9",
                             "name": "get_weather",
-                            "input": {"location": "San Francisco, CA", "unit": "celsius"}
-                        }
-                    ]
+                            "input": {
+                                "location": "San Francisco, CA",
+                                "unit": "celsius",
+                            },
+                        },
+                    ],
                 },
                 {
                     "role": "user",
@@ -317,16 +322,125 @@ class TestHeliconeIntegrations:
                         {
                             "type": "tool_result",
                             "tool_use_id": "toolu_01A09q90qw90lq917835lq9",
-                            "content": "65 degrees"
+                            "content": "65 degrees",
                         }
-                    ]
-                }
+                    ],
+                },
             ],
             extra_headers={
                 "Helicone-Property-Test": "Tool Use",
             },
         )
         assert message.content[0].text is not None
+
+    def test_anthropic_cache(self):
+        """Test Anthropic's cache functionality with system prompts"""
+        message = anthropic_client.messages.create(
+            model="claude-3-5-sonnet-20241022",
+            max_tokens=1024,
+            system=[
+                {
+                    "type": "text",
+                    "text": "You are an AI assistant tasked with analyzing literary works. Your goal is to provide insightful commentary on themes, characters, and writing style.\n",
+                },
+                {
+                    "type": "text",
+                    "text": pathlib.Path("tests/test_data/pride.txt").read_text(),
+                    "cache_control": {"type": "ephemeral"},
+                },
+            ],
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Analyze the major themes in 'Pride and Prejudice'.",
+                }
+            ],
+            extra_headers={
+                "Helicone-Property-Test": "Cache Control",
+            },
+        )
+        assert message.content[0].text is not None
+
+    def test_generate_basic(self):
+        """Test basic prompt generation without variables"""
+        cmd = [
+            "curl",
+            "-X",
+            "POST",
+            os.getenv("HELICONE_GENERATE_BASE_URL"),
+            "-H",
+            f"Helicone-Auth: Bearer {os.getenv('HELICONE_API_KEY')}",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            json.dumps(
+                {
+                    "promptId": "test-prompt-id",
+                    "userId": "test-user",
+                    "sessionId": SESSION_ID,
+                }
+            ),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        assert result.returncode == 0
+        response = json.loads(result.stdout)
+        assert response is not None
+
+    def test_generate_with_variables(self):
+        """Test prompt generation with variables"""
+        cmd = [
+            "curl",
+            "-X",
+            "POST",
+            os.getenv("HELICONE_GENERATE_BASE_URL"),
+            "-H",
+            f"Helicone-Auth: Bearer {os.getenv('HELICONE_API_KEY')}",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            json.dumps(
+                {
+                    "promptId": "test-prompt-id",
+                    "variables": {"location": "Portugal", "time": "2:43"},
+                    "userId": "test-user",
+                    "sessionId": SESSION_ID,
+                }
+            ),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        assert result.returncode == 0
+        response = json.loads(result.stdout)
+        assert response is not None
+
+    def test_generate_with_chat(self):
+        """Test prompt generation with chat history"""
+        cmd = [
+            "curl",
+            "-X",
+            "POST",
+            os.getenv("HELICONE_GENERATE_BASE_URL"),
+            "-H",
+            f"Helicone-Auth: Bearer {os.getenv('HELICONE_API_KEY')}",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            json.dumps(
+                {
+                    "promptId": "test-prompt-id",
+                    "chat": [
+                        "User: Can you help me with my homework?",
+                        "Assistant: Of course! What subject are you working on?",
+                        "User: Math, I need help with algebra.",
+                    ],
+                    "userId": "test-user",
+                    "sessionId": SESSION_ID,
+                }
+            ),
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        assert result.returncode == 0
+        response = json.loads(result.stdout)
+        assert response is not None
 
 
 if __name__ == "__main__":

--- a/tests/e2e_suite.py
+++ b/tests/e2e_suite.py
@@ -367,14 +367,20 @@ class TestHeliconeIntegrations:
             pytest.skip("HELICONE_GENERATE_BASE_URL not set in environment")
 
         payload = {
+            # Prompt Info
             "promptId": "new-prompt",
-            # version: number or "production" (default)
-            # inputs: {}
-            "userId": "test-user",  # Helicone property
-            "sessionId": SESSION_ID,  # Helicone property
+            "version": "production",
+            "inputs": {
+                "num": "10",
+            },
+            # Helicone Properties
+            "userId": "test-user",
+            "sessionId": SESSION_ID,
         }
         headers = {
+            # Helicone Auth
             "Helicone-Auth": f"Bearer {os.getenv('HELICONE_API_KEY')}",
+            # Provider Keys
             "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY"),
             "ANTHROPIC_API_KEY": os.getenv("ANTHROPIC_API_KEY"),
             "GOOGLE_API_KEY": os.getenv("GOOGLE_GENERATIVE_API_KEY"),
@@ -385,9 +391,6 @@ class TestHeliconeIntegrations:
 
         # Assert that the HTTP status code indicates success
         assert response.status_code == 200, f"Request failed: {response.text}"
-
-    def test_generate_with_variables(self):
-        return "not implemented"
 
     def test_generate_with_chat(self):
         return "not implemented"

--- a/tests/e2e_suite.py
+++ b/tests/e2e_suite.py
@@ -384,7 +384,7 @@ class TestHeliconeIntegrations:
             "-d",
             json.dumps(
                 {
-                    "promptId": "helicone-classifier",
+                    "promptId": "new-prompt",
                     "userId": "test-user",
                     "sessionId": SESSION_ID,
                 }

--- a/tests/e2e_suite.py
+++ b/tests/e2e_suite.py
@@ -9,8 +9,7 @@ import base64
 import pytest
 from dotenv import load_dotenv
 import pathlib
-import json
-import subprocess
+import requests  # Ensure this is imported at the top of your file
 
 # Load environment variables from .env file
 load_dotenv()
@@ -362,104 +361,30 @@ class TestHeliconeIntegrations:
         assert message.content[0].text is not None
 
     def test_generate_basic(self):
-        """Test basic prompt generation without variables"""
+        """Test basic prompt generation without variables using requests"""
         generate_url = os.getenv("HELICONE_GENERATE_BASE_URL")
         if not generate_url:
             pytest.skip("HELICONE_GENERATE_BASE_URL not set in environment")
 
-        cmd = [
-            "curl",
-            "--compressed",
-            "-X",
-            "POST",
-            generate_url,
-            "-H",
-            f"Helicone-Auth: Bearer {os.getenv('HELICONE_API_KEY')}",
-            "-H",
-            f"Authorization: Bearer {os.getenv('OPENAI_API_KEY')}",
-            "-H",
-            "Content-Type: application/json",
-            "-H",
-            "Helicone-Property-Test: Generate Basic",
-            "-d",
-            json.dumps(
-                {
-                    "promptId": "new-prompt",
-                    "userId": "test-user",
-                    "sessionId": SESSION_ID,
-                }
-            ),
-        ]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        assert result.returncode == 0
-        response = json.loads(result.stdout)
-        assert response is not None
+        payload = {
+            "promptId": "new-prompt",
+            "userId": "test-user",
+            "sessionId": SESSION_ID,
+        }
+        headers = {
+            "Helicone-Auth": f"Bearer {os.getenv('HELICONE_API_KEY')}",
+            "Authorization": f"Bearer {os.getenv('OPENAI_API_KEY')}",
+        }
+        response = requests.post(generate_url, json=payload, headers=headers)
+
+        # Assert that the HTTP status code indicates success
+        assert response.status_code == 200, f"Request failed: {response.text}"
 
     def test_generate_with_variables(self):
-        """Test prompt generation with variables"""
-        cmd = [
-            "curl",
-            "--compressed",
-            "-X",
-            "POST",
-            os.getenv("HELICONE_GENERATE_BASE_URL"),
-            "-H",
-            f"Helicone-Auth: Bearer {os.getenv('HELICONE_API_KEY')}",
-            "-H",
-            f"Authorization: Bearer {os.getenv('OPENAI_API_KEY')}",
-            "-H",
-            "Content-Type: application/json",
-            "-H",
-            "Helicone-Property-Test: Generate With Variables",
-            "-d",
-            json.dumps(
-                {
-                    "promptId": "test-prompt-id",
-                    "variables": {"location": "Portugal", "time": "2:43"},
-                    "userId": "test-user",
-                    "sessionId": SESSION_ID,
-                }
-            ),
-        ]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        assert result.returncode == 0
-        response = json.loads(result.stdout)
-        assert response is not None
+        return "not implemented"
 
     def test_generate_with_chat(self):
-        """Test prompt generation with chat history"""
-        cmd = [
-            "curl",
-            "--compressed",
-            "-X",
-            "POST",
-            os.getenv("HELICONE_GENERATE_BASE_URL"),
-            "-H",
-            f"Helicone-Auth: Bearer {os.getenv('HELICONE_API_KEY')}",
-            "-H",
-            f"Authorization: Bearer {os.getenv('OPENAI_API_KEY')}",
-            "-H",
-            "Content-Type: application/json",
-            "-H",
-            "Helicone-Property-Test: Generate With Chat",
-            "-d",
-            json.dumps(
-                {
-                    "promptId": "test-prompt-id",
-                    "chat": [
-                        "User: Can you help me with my homework?",
-                        "Assistant: Of course! What subject are you working on?",
-                        "User: Math, I need help with algebra.",
-                    ],
-                    "userId": "test-user",
-                    "sessionId": SESSION_ID,
-                }
-            ),
-        ]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        assert result.returncode == 0
-        response = json.loads(result.stdout)
-        assert response is not None
+        return "not implemented"
 
 
 if __name__ == "__main__":

--- a/tests/e2e_suite.py
+++ b/tests/e2e_suite.py
@@ -363,19 +363,28 @@ class TestHeliconeIntegrations:
 
     def test_generate_basic(self):
         """Test basic prompt generation without variables"""
+        generate_url = os.getenv("HELICONE_GENERATE_BASE_URL")
+        if not generate_url:
+            pytest.skip("HELICONE_GENERATE_BASE_URL not set in environment")
+
         cmd = [
             "curl",
+            "--compressed",
             "-X",
             "POST",
-            os.getenv("HELICONE_GENERATE_BASE_URL"),
+            generate_url,
             "-H",
             f"Helicone-Auth: Bearer {os.getenv('HELICONE_API_KEY')}",
             "-H",
+            f"Authorization: Bearer {os.getenv('OPENAI_API_KEY')}",
+            "-H",
             "Content-Type: application/json",
+            "-H",
+            "Helicone-Property-Test: Generate Basic",
             "-d",
             json.dumps(
                 {
-                    "promptId": "test-prompt-id",
+                    "promptId": "helicone-classifier",
                     "userId": "test-user",
                     "sessionId": SESSION_ID,
                 }
@@ -390,13 +399,18 @@ class TestHeliconeIntegrations:
         """Test prompt generation with variables"""
         cmd = [
             "curl",
+            "--compressed",
             "-X",
             "POST",
             os.getenv("HELICONE_GENERATE_BASE_URL"),
             "-H",
             f"Helicone-Auth: Bearer {os.getenv('HELICONE_API_KEY')}",
             "-H",
+            f"Authorization: Bearer {os.getenv('OPENAI_API_KEY')}",
+            "-H",
             "Content-Type: application/json",
+            "-H",
+            "Helicone-Property-Test: Generate With Variables",
             "-d",
             json.dumps(
                 {
@@ -416,13 +430,18 @@ class TestHeliconeIntegrations:
         """Test prompt generation with chat history"""
         cmd = [
             "curl",
+            "--compressed",
             "-X",
             "POST",
             os.getenv("HELICONE_GENERATE_BASE_URL"),
             "-H",
             f"Helicone-Auth: Bearer {os.getenv('HELICONE_API_KEY')}",
             "-H",
+            f"Authorization: Bearer {os.getenv('OPENAI_API_KEY')}",
+            "-H",
             "Content-Type: application/json",
+            "-H",
+            "Helicone-Property-Test: Generate With Chat",
             "-d",
             json.dumps(
                 {

--- a/tests/e2e_suite.py
+++ b/tests/e2e_suite.py
@@ -368,12 +368,18 @@ class TestHeliconeIntegrations:
 
         payload = {
             "promptId": "new-prompt",
-            "userId": "test-user",
-            "sessionId": SESSION_ID,
+            # version: number or "production" (default)
+            # inputs: {}
+            "userId": "test-user",  # Helicone property
+            "sessionId": SESSION_ID,  # Helicone property
         }
         headers = {
             "Helicone-Auth": f"Bearer {os.getenv('HELICONE_API_KEY')}",
-            "Authorization": f"Bearer {os.getenv('OPENAI_API_KEY')}",
+            "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY"),
+            "ANTHROPIC_API_KEY": os.getenv("ANTHROPIC_API_KEY"),
+            "GOOGLE_API_KEY": os.getenv("GOOGLE_GENERATIVE_API_KEY"),
+            "COHERE_API_KEY": os.getenv("COHERE_API_KEY"),
+            "MISTRAL_API_KEY": os.getenv("MISTRAL_API_KEY"),
         }
         response = requests.post(generate_url, json=payload, headers=headers)
 

--- a/valhalla/jawn/src/managers/prompt/PromptManager.ts
+++ b/valhalla/jawn/src/managers/prompt/PromptManager.ts
@@ -719,7 +719,7 @@ export class PromptManager extends BaseManager {
     }>(
       `
     INSERT INTO prompts_versions (prompt_v2, organization, major_version, minor_version, helicone_template, model, created_at, metadata)
-    VALUES ($1, $2, $3, $4, $5, $6, NOW(), '{"isProduction": true}'::jsonb)
+    VALUES ($1, $2, $3, $4, $5, $6, NOW(), '{"isProduction": true, "provider": "OPENAI"}'::jsonb)
     RETURNING id
     `,
       [

--- a/web/components/shared/prompts/ParametersPanel.tsx
+++ b/web/components/shared/prompts/ParametersPanel.tsx
@@ -1,6 +1,3 @@
-import { useEffect } from "react";
-import { PiTargetBold, PiPaintBrushBold, PiPlugsBold } from "react-icons/pi";
-
 import {
   Select,
   SelectContent,
@@ -9,132 +6,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
-
-const PROVIDER_MODELS = {
-  // General Use Cases
-  anthropic: {
-    models: ["claude-3.5-haiku", "claude-3.5-sonnet", "claude-3-opus"],
-  },
-  openai: {
-    models: [
-      "gpt-4o-mini",
-      "gpt-4o",
-      "gpt-4-turbo",
-      "gpt-4",
-      "gpt-3.5-turbo",
-      "chatgpt-4o-latest",
-    ],
-  },
-  google: {
-    models: [
-      "gemini-flash-1.5",
-      "gemini-flash-1.5-8b",
-      "gemini-pro-1.5",
-      "gemma-2-27b-it",
-      "gemma-2-9b-it",
-    ],
-  },
-  "meta-llama": {
-    models: [
-      "llama-3.1-70b-instruct",
-      "llama-3.1-8b-instruct",
-      "llama-3.1-405b-instruct",
-      "llama-3.2-1b-instruct",
-      "llama-3.2-3b-instruct",
-      "llama-3.2-11b-vision-instruct",
-      "llama-3.2-90b-vision-instruct",
-      "llama-3-70b-instruct",
-      "llama-3-8b-instruct",
-      "llama-3-70b-instruct:nitro",
-      "llama-3-8b-instruct:nitro",
-      "llama-3-8b-instruct:extended",
-      "llama-guard-2-8b",
-      "llama-3.1-405b",
-    ],
-  },
-  deepseek: {
-    models: ["deepseek-r1", "deepseek-chat"],
-  },
-  mistralai: {
-    models: [
-      "mistral-nemo",
-      "codestral-2501",
-      "mixtral-8x7b-instruct",
-      "ministral-8b",
-      "ministral-3b",
-      "mistral-7b-instruct",
-      "mistral-large",
-      "mistral-small",
-      "codestral-mamba",
-      "pixtral-12b",
-      "pixtral-large-2411",
-      "mistral-7b-instruct-v0.1",
-      "mistral-7b-instruct-v0.3",
-      "mistral-medium",
-      "mistral-large-2411",
-      "mistral-large-2407",
-      "mixtral-8x7b-instruct:nitro",
-      "mixtral-8x22b-instruct",
-      "mistral-tiny",
-    ],
-  },
-  qwen: {
-    models: [
-      "qwen-2.5-72b-instruct",
-      "qwen-2.5-7b-instruct",
-      "qwen-2.5-coder-32b-instruct",
-      "eva-qwen-2.5-72b",
-    ],
-  },
-  "x-ai": {
-    models: ["grok-2-1212", "grok-beta", "grok-2-vision-1212"],
-  },
-  perplexity: {
-    models: [
-      "llama-3.1-sonar-large-128k-online",
-      "llama-3.1-sonar-large-128k-chat",
-      "llama-3.1-sonar-huge-128k-online",
-      "llama-3.1-sonar-small-128k-online",
-    ],
-  },
-  cohere: {
-    models: ["command-r-plus", "command-r"],
-  },
-  amazon: {
-    models: ["nova-lite-v1", "nova-micro-v1", "nova-pro-v1"],
-  },
-  microsoft: {
-    models: ["wizardlm-2-8x22b", "wizardlm-2-7b", "phi-4"],
-  },
-  nvidia: {
-    models: ["llama-3.1-nemotron-70b-instruct"],
-  },
-  // Finetunes and Roleplay Use Cases
-  nousresearch: {
-    models: [
-      "hermes-3-llama-3.1-405b",
-      "hermes-3-llama-3.1-70b",
-      "hermes-2-pro-llama-3-8b",
-      "nous-hermes-llama2-13b",
-    ],
-  },
-  sao10k: {
-    models: [
-      "l3-euryale-70b",
-      "l3.1-euryale-70b",
-      "l3-lunaris-8b",
-      "l3.1-70b-hanami-x1",
-    ],
-  },
-  gryphe: {
-    models: [
-      "mythomax-l2-13b",
-      "mythomax-l2-13b:nitro",
-      "mythomax-l2-13b:extended",
-    ],
-  },
-} as const;
-
+import { PROVIDER_MODELS } from "@/lib/api/llm/generate";
+import { useEffect } from "react";
+import { PiPaintBrushBold, PiPlugsBold, PiTargetBold } from "react-icons/pi";
 interface Parameters {
   model: string;
   provider: string;
@@ -195,9 +69,9 @@ export default function ParametersPanel({
                 <SelectValue placeholder="Provider" />
               </SelectTrigger>
               <SelectContent>
-                {Object.keys(PROVIDER_MODELS).map((provider) => (
+                {Object.entries(PROVIDER_MODELS).map(([provider, config]) => (
                   <SelectItem key={provider} value={provider}>
-                    {provider}
+                    {config.name}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/web/components/templates/prompts/id/promptIdPage.tsx
+++ b/web/components/templates/prompts/id/promptIdPage.tsx
@@ -2,21 +2,9 @@ import LoadingAnimation from "@/components/shared/loadingAnimation";
 import useNotification from "@/components/shared/notification/useNotification";
 import MessagesPanel from "@/components/shared/prompts/MessagesPanel";
 import ParametersPanel from "@/components/shared/prompts/ParametersPanel";
-import {
-  PiCaretLeftBold,
-  PiCommandBold,
-  PiPlayBold,
-  PiRocketLaunchBold,
-  PiStopBold,
-  PiSpinnerGapBold,
-} from "react-icons/pi";
-import { generateStream } from "@/lib/api/llm/generate-stream";
-import { readStream } from "@/lib/api/llm/read-stream";
-import { toKebabCase } from "@/utils/strings";
-import Link from "next/link";
-import GlassHeader from "@/components/shared/universal/GlassHeader";
 import ResponsePanel from "@/components/shared/prompts/ResponsePanel";
 import VariablesPanel from "@/components/shared/prompts/VariablesPanel";
+import GlassHeader from "@/components/shared/universal/GlassHeader";
 import ResizablePanels from "@/components/shared/universal/ResizablePanels";
 import VersionSelector from "@/components/shared/universal/VersionSelector";
 import {
@@ -27,6 +15,8 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { generateStream } from "@/lib/api/llm/generate-stream";
+import { readStream } from "@/lib/api/llm/read-stream";
 import { useJawnClient } from "@/lib/clients/jawnHook";
 import { PromptState, StateMessage, Variable } from "@/types/prompt-state";
 import {
@@ -35,23 +25,33 @@ import {
   isPrefillSupported,
   removeMessagePair,
 } from "@/utils/messages";
+import { toKebabCase } from "@/utils/strings";
 import {
   deduplicateVariables,
   extractVariables,
   isValidVariableName,
 } from "@/utils/variables";
 import { FlaskConicalIcon } from "lucide-react";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { MdKeyboardReturn } from "react-icons/md";
+import {
+  PiCaretLeftBold,
+  PiCommandBold,
+  PiPlayBold,
+  PiRocketLaunchBold,
+  PiSpinnerGapBold,
+  PiStopBold,
+} from "react-icons/pi";
 
+import { Button } from "@/components/ui/button";
+import { autoFillInputs } from "@helicone/prompts";
 import {
   usePrompt,
   usePromptVersions,
 } from "../../../../services/hooks/prompts/prompts";
 import { DiffHighlight } from "../../welcome/diffHighlight";
-import { autoFillInputs } from "@helicone/prompts";
-import { Button } from "@/components/ui/button";
 import { useExperiment } from "./hooks";
 import PromptMetricsTab from "./PromptMetricsTab";
 
@@ -459,9 +459,8 @@ export default function PromptIdPage(props: PromptIdPageProps) {
       };
 
       const metadata = {
+        provider: state.parameters.provider.toUpperCase(),
         isProduction: false,
-        createdFromUi: true,
-        provider: state.parameters.provider,
         inputs: variableMap,
       };
 

--- a/web/lib/api/llm/generate.ts
+++ b/web/lib/api/llm/generate.ts
@@ -19,10 +19,164 @@ export interface GenerateParams {
   };
 }
 
+export const PROVIDER_MODELS = {
+  // General Use Cases
+  ANTHROPIC: {
+    name: "Anthropic",
+    openrouterDirectory: "anthropic",
+    models: ["claude-3.5-haiku", "claude-3.5-sonnet", "claude-3-opus"],
+  },
+  OPENAI: {
+    name: "OpenAI",
+    openrouterDirectory: "openai",
+    models: [
+      "gpt-4o-mini",
+      "gpt-4o",
+      "gpt-4-turbo",
+      "gpt-4",
+      "gpt-3.5-turbo",
+      "chatgpt-4o-latest",
+    ],
+  },
+  GOOGLE: {
+    name: "Google",
+    openrouterDirectory: "google",
+    models: [
+      "gemini-flash-1.5",
+      "gemini-flash-1.5-8b",
+      "gemini-pro-1.5",
+      "gemma-2-27b-it",
+      "gemma-2-9b-it",
+    ],
+  },
+  META_LLAMA: {
+    name: "Meta Llama",
+    openrouterDirectory: "meta-llama",
+    models: [
+      "llama-3.1-70b-instruct",
+      "llama-3.1-8b-instruct",
+      "llama-3.1-405b-instruct",
+      "llama-3.2-1b-instruct",
+      "llama-3.2-3b-instruct",
+      "llama-3.2-11b-vision-instruct",
+      "llama-3.2-90b-vision-instruct",
+      "llama-3-70b-instruct",
+      "llama-3-8b-instruct",
+      "llama-3-70b-instruct:nitro",
+      "llama-3-8b-instruct:nitro",
+      "llama-3-8b-instruct:extended",
+      "llama-guard-2-8b",
+      "llama-3.1-405b",
+    ],
+  },
+  DEEPSEEK: {
+    name: "DeepSeek",
+    openrouterDirectory: "deepseek",
+    models: ["deepseek-r1", "deepseek-chat"],
+  },
+  MISTRALAI: {
+    name: "Mistral AI",
+    openrouterDirectory: "mistral",
+    models: [
+      "mistral-nemo",
+      "codestral-2501",
+      "mixtral-8x7b-instruct",
+      "ministral-8b",
+      "ministral-3b",
+      "mistral-7b-instruct",
+      "mistral-large",
+      "mistral-small",
+      "codestral-mamba",
+      "pixtral-12b",
+      "pixtral-large-2411",
+      "mistral-7b-instruct-v0.1",
+      "mistral-7b-instruct-v0.3",
+      "mistral-medium",
+      "mistral-large-2411",
+      "mistral-large-2407",
+      "mixtral-8x7b-instruct:nitro",
+      "mixtral-8x22b-instruct",
+      "mistral-tiny",
+    ],
+  },
+  QWEN: {
+    name: "Qwen",
+    openrouterDirectory: "qwen",
+    models: [
+      "qwen-2.5-72b-instruct",
+      "qwen-2.5-7b-instruct",
+      "qwen-2.5-coder-32b-instruct",
+      "eva-qwen-2.5-72b",
+    ],
+  },
+  X: {
+    name: "X AI",
+    openrouterDirectory: "x-ai",
+    models: ["grok-2-1212", "grok-beta", "grok-2-vision-1212"],
+  },
+  PERPLEXITY: {
+    name: "Perplexity",
+    openrouterDirectory: "perplexity",
+    models: [
+      "llama-3.1-sonar-large-128k-online",
+      "llama-3.1-sonar-large-128k-chat",
+      "llama-3.1-sonar-huge-128k-online",
+      "llama-3.1-sonar-small-128k-online",
+    ],
+  },
+  COHERE: {
+    name: "Cohere",
+    openrouterDirectory: "cohere",
+    models: ["command-r-plus", "command-r"],
+  },
+  AMAZON: {
+    name: "Amazon",
+    openrouterDirectory: "amazon",
+    models: ["nova-lite-v1", "nova-micro-v1", "nova-pro-v1"],
+  },
+  MICROSOFT: {
+    name: "Microsoft",
+    openrouterDirectory: "microsoft",
+    models: ["wizardlm-2-8x22b", "wizardlm-2-7b", "phi-4"],
+  },
+  NVIDIA: {
+    name: "NVIDIA",
+    openrouterDirectory: "nvidia",
+    models: ["llama-3.1-nemotron-70b-instruct"],
+  },
+  // Finetunes and Roleplay Use Cases
+  NOUSRESEARCH: {
+    name: "Nous Research",
+    openrouterDirectory: "nousresearch",
+    models: [
+      "hermes-3-llama-3.1-405b",
+      "hermes-3-llama-3.1-70b",
+      "hermes-2-pro-llama-3-8b",
+      "nous-hermes-llama2-13b",
+    ],
+  },
+  SAO10K: {
+    name: "SAO10K",
+    openrouterDirectory: "sao10k",
+    models: [
+      "l3-euryale-70b",
+      "l3.1-euryale-70b",
+      "l3-lunaris-8b",
+      "l3.1-70b-hanami-x1",
+    ],
+  },
+} as const;
+
 export async function generate<T extends object | undefined = undefined>(
   params: GenerateParams
 ): Promise<T extends object ? T : string> {
-  params.model = `${params.provider}/${params.model}`; // OpenRouter requires the model to be in the format of provider/model
+  const providerConfig =
+    PROVIDER_MODELS[params.provider as keyof typeof PROVIDER_MODELS];
+  if (!providerConfig) {
+    throw new Error(`Provider "${params.provider}" not found`);
+  }
+  // OpenRouter requires the model to be in the format of provider/model
+  params.model = `${providerConfig.openrouterDirectory}/${params.model}`;
 
   const response = await fetch("/api/llm", {
     method: "POST",

--- a/worker/package.json
+++ b/worker/package.json
@@ -25,7 +25,7 @@
     "prettier": "^2.8.7",
     "ts-jest": "^29.1.0",
     "typescript": "^4.9.3",
-    "wrangler": "^3.82.0",
+    "wrangler": "3.59.0",
     "yarn": "^1.22.19",
     "zod": "^3.23.8"
   },

--- a/worker/run_all_workers.sh
+++ b/worker/run_all_workers.sh
@@ -8,6 +8,8 @@ sleep 1
 npx wrangler dev --var WORKER_TYPE:GATEWAY_API --port 8789 &
 sleep 1
 npx wrangler dev --var WORKER_TYPE:ANTHROPIC_PROXY --port 8790 &
+sleep 1
+npx wrangler dev --var WORKER_TYPE:GENERATE_API --port 8791 &
 
 # Wait for all background processes to finish
 wait

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -45,7 +45,8 @@ export interface BASE_Env {
     | "ANTHROPIC_PROXY"
     | "HELICONE_API"
     | "GATEWAY_API"
-    | "CUSTOMER_GATEWAY";
+    | "CUSTOMER_GATEWAY"
+    | "GENERATE_API";
   TOKEN_CALC_URL: string;
   VAULT_ENABLED: string;
   STORAGE_URL: string;
@@ -141,6 +142,11 @@ async function modifyEnvBasedOnPath(
       return {
         ...env,
         WORKER_TYPE: "GATEWAY_API",
+      };
+    } else if (hostParts[0].includes("generate")) {
+      return {
+        ...env,
+        WORKER_TYPE: "GENERATE_API",
       };
     } else if (hostParts[0].includes("oai")) {
       return {

--- a/worker/src/lib/RequestWrapper.ts
+++ b/worker/src/lib/RequestWrapper.ts
@@ -6,19 +6,19 @@ import { SupabaseClient, createClient } from "@supabase/supabase-js";
 import { Env, hash } from "..";
 import { Database } from "../../supabase/database.types";
 import { HeliconeAuth } from "./db/DBWrapper";
-import { Result, err, map, mapPostgrestErr, ok } from "./util/results";
-import { HeliconeHeaders } from "./models/HeliconeHeaders";
 import {
   checkLimits,
   checkLimitsSingle,
 } from "./managers/UsageLimitManager.ts";
+import { HeliconeHeaders } from "./models/HeliconeHeaders";
 import { getAndStoreInCache } from "./util/cache/secureCache";
+import { Result, err, map, mapPostgrestErr, ok } from "./util/results";
 
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { CfProperties } from "@cloudflare/workers-types";
 import { parseJSXObject } from "@helicone/prompts";
-import { SignatureV4 } from "@smithy/signature-v4";
-import { Sha256 } from "@aws-crypto/sha256-js";
 import { HttpRequest } from "@smithy/protocol-http";
+import { SignatureV4 } from "@smithy/signature-v4";
 
 export type RequestHandlerType =
   | "proxy_only"
@@ -654,7 +654,7 @@ export async function getProviderKeyFromPortalKey(
     .from("decrypted_provider_keys")
     .select("decrypted_provider_key")
     .eq("id", providerKeyId.data?.id ?? "")
-    .eq("soft_delete", "false")
+    .eq("soft_delete", false)
     .single();
 
   return map(mapPostgrestErr(providerKey), (x) => ({
@@ -689,7 +689,7 @@ export async function getProviderKeyFromProxy(
       .from("helicone_proxy_keys")
       .select("*")
       .eq("id", proxyKeyId)
-      .eq("soft_delete", "false")
+      .eq("soft_delete", false)
       .single(),
     supabaseClient
       .from("helicone_proxy_key_limits")
@@ -721,7 +721,7 @@ export async function getProviderKeyFromProxy(
     .from("decrypted_provider_keys")
     .select("decrypted_provider_key")
     .eq("id", storedProxyKey.data.provider_key_id)
-    .eq("soft_delete", "false")
+    .eq("soft_delete", false)
     .single();
 
   if (providerKey.error || !providerKey.data?.decrypted_provider_key) {

--- a/worker/src/routers/gatewayRouter.ts
+++ b/worker/src/routers/gatewayRouter.ts
@@ -263,3 +263,6 @@ export const getGatewayAPIRouter = (router: BaseRouter) => {
 
   return router;
 };
+
+// Export the gatewayForwarder so the generate router can reuse its logic
+export { gatewayForwarder };

--- a/worker/src/routers/generateRouter.ts
+++ b/worker/src/routers/generateRouter.ts
@@ -1,3 +1,4 @@
+import { ExecutionContext } from "@cloudflare/workers-types";
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { type IRequest, type RouterType } from "itty-router";
 import { Env } from "..";

--- a/worker/src/routers/generateRouter.ts
+++ b/worker/src/routers/generateRouter.ts
@@ -1,8 +1,6 @@
 import type { IRequest, RouterType } from "itty-router";
-import { Env, Provider } from "..";
+import { Env } from "..";
 import { RequestWrapper } from "../lib/RequestWrapper";
-import { proxyForwarder } from "../lib/HeliconeProxyRequest/ProxyForwarder";
-import { formatPrompt } from "@helicone/prompts";
 import { createClient } from "@supabase/supabase-js";
 import { Database } from "../../supabase/database.types";
 import { gatewayForwarder } from "./gatewayRouter";

--- a/worker/src/routers/generateRouter.ts
+++ b/worker/src/routers/generateRouter.ts
@@ -1,9 +1,18 @@
-import type { IRequest, RouterType } from "itty-router";
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { type IRequest, type RouterType } from "itty-router";
 import { Env } from "..";
-import { RequestWrapper } from "../lib/RequestWrapper";
-import { createClient } from "@supabase/supabase-js";
 import { Database } from "../../supabase/database.types";
+import { DBWrapper } from "../lib/db/DBWrapper";
+import { RequestWrapper } from "../lib/RequestWrapper";
+import { providersNames } from "../packages/cost/providers/mappings";
 import { gatewayForwarder } from "./gatewayRouter";
+
+// TODO: Specify inputs to autoFill using inputs: {}
+
+type GenerateParameters = {
+  promptId: string;
+  version?: number | "production";
+};
 
 // Handler for generate route
 const generateHandler = async (
@@ -13,94 +22,118 @@ const generateHandler = async (
   ctx: ExecutionContext
 ): Promise<Response> => {
   try {
-    let requestData: any;
-    try {
-      requestData = await requestWrapper.getJson();
-    } catch (err) {
-      // Fallback if JSON parsing fails (assume promptId)
-      const text = await requestWrapper.getText();
-      requestData = { promptId: text.trim() };
+    // 1. VALIDATE AUTH AND GET ORG DATA
+    const { data: auth, error: authError } = await requestWrapper.auth();
+    if (authError || !auth) {
+      return new Response(authError || "Invalid authentication", {
+        status: 401,
+      });
     }
-    const promptId: string = requestData.promptId;
-    if (!promptId) {
+    const db = new DBWrapper(env, auth);
+    const { data: orgData, error: orgError } = await db.getAuthParams();
+    if (orgError || !orgData) {
+      return new Response(orgError || "Failed to get organization data", {
+        status: 401,
+      });
+    }
+
+    // 2. GET REQUEST PARAMETERS
+    const rawBody = await requestWrapper.getJson<GenerateParameters>();
+    const parameters: GenerateParameters = {
+      promptId: rawBody?.promptId || "",
+      version: rawBody?.version || "production",
+    };
+    if (!parameters.promptId) {
       return new Response("Missing promptId", { status: 400 });
     }
 
-    console.log("promptId", promptId);
-
-    // Query production prompt version from Supabase using promptId
+    // 3. START SUPABASE CLIENT
     const supabaseClient = createClient<Database>(
       env.SUPABASE_URL,
       env.SUPABASE_SERVICE_ROLE_KEY
     );
-    const { data: prodPrompt, error } = await supabaseClient
-      .from("prompts_versions")
-      .select(
-        `
-        *,
-        prompt_v2!inner (
-          user_defined_id
-        )
-      `
-      )
-      .eq("prompt_v2.user_defined_id", promptId)
-      .order("major_version", { ascending: false })
-      .order("minor_version", { ascending: false })
-      .limit(1)
-      .single();
 
-    if (error || !prodPrompt) {
-      return new Response("Production prompt version not found", {
-        status: 404,
+    // 4. GET PROMPT BASED ON REQUEST ID, VERSION, AND ORG ID
+    const prompt = await getPromptVersion(
+      supabaseClient,
+      parameters.promptId,
+      orgData.organizationId,
+      parameters.version
+    );
+    if (prompt instanceof Response) {
+      return prompt; // Return the response if it's an error
+    }
+
+    // 5. GET PROVIDER AND BASE URL
+    const providerResult = getProviderInfo(prompt.metadata);
+    if (providerResult instanceof Response) {
+      return providerResult; // Return the response if it's an error
+    }
+    const { targetBaseUrl, provider } = providerResult;
+
+    // Get the provider's API key from headers
+    const providerApiKey = requestWrapper
+      .getHeaders()
+      .get(`${provider}_API_KEY`);
+    if (!providerApiKey) {
+      return new Response(`Missing ${provider}_API_KEY in headers`, {
+        status: 400,
       });
     }
 
-    // Coerce metadata into an object if possible
-    const metadata =
-      prodPrompt.metadata && typeof prodPrompt.metadata === "object"
-        ? (prodPrompt.metadata as Record<string, any>)
-        : {};
+    // 6. FORWARD TO PROVIDER
+    const requestHeaders = new Headers(requestWrapper.getHeaders());
+    requestHeaders.set("Content-Type", "application/json");
+    // Set the Authorization header with the provider's API key
+    requestHeaders.set("Authorization", `Bearer ${providerApiKey}`);
+    // Request uncompressed response
+    requestHeaders.set("Accept-Encoding", "identity");
+    console.log("requestHeaders", requestHeaders);
 
-    const providerKey: string | undefined =
-      metadata.providerKey || metadata.provider;
-    let targetUrl: string | undefined = metadata.target_url;
-    // Fallback mapping for provider target URLs
-    const providerTargetMap: { [key: string]: string } = {
-      OPENAI: "https://api.openai.com/v1/chat/completions",
-      ANTHROPIC: "https://api.anthropic.com/v1/messages",
+    // Merge the template with any additional parameters from the request
+    const defaultTemplate = {
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: "Hello" }],
     };
-    if (!targetUrl && providerKey) {
-      targetUrl = providerTargetMap[providerKey.toUpperCase()];
-    }
-    if (!targetUrl) {
-      return new Response("No target URL found for provider", { status: 500 });
-    }
-    console.log("targetUrl", targetUrl);
+    const template =
+      typeof prompt.helicone_template === "object" &&
+      prompt.helicone_template !== null
+        ? (prompt.helicone_template as typeof defaultTemplate)
+        : defaultTemplate;
 
-    // Create the request body using the template
-    let requestBody: any;
-    if (typeof prodPrompt.helicone_template === "object") {
-      requestBody = prodPrompt.helicone_template;
-    } else if (typeof prodPrompt.helicone_template === "string") {
-      requestBody = { prompt: prodPrompt.helicone_template };
-    } else {
-      requestBody = { prompt: promptId };
-    }
+    // Only use the template and valid OpenAI parameters
+    const validOpenAIParams = [
+      "model",
+      "messages",
+      "temperature",
+      "top_p",
+      "n",
+      "stream",
+      "stop",
+      "max_tokens",
+      "presence_penalty",
+      "frequency_penalty",
+      "logit_bias",
+      "user",
+      "response_format",
+    ] as const;
 
-    // Prepare headers: copy existing headers and inject provider key if needed
-    const headers = new Headers(requestWrapper.getHeaders());
-    if (providerKey && !headers.has("Authorization")) {
-      headers.set("Authorization", `Bearer ${providerKey}`);
-    }
+    const mergedBody: Record<string, any> = {
+      ...template,
+      // Only include valid OpenAI parameters from the request
+      ...Object.fromEntries(
+        Object.entries(parameters).filter(([key]) =>
+          validOpenAIParams.includes(key as (typeof validOpenAIParams)[number])
+        )
+      ),
+    };
 
-    // Build a new request with the modified body and headers
-    const newRequest = new Request(targetUrl, {
-      method: requestWrapper.getMethod(),
-      headers,
-      body: JSON.stringify(requestBody),
+    const newRequest = new Request(`${targetBaseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: requestHeaders,
+      body: JSON.stringify(mergedBody),
     });
 
-    // Create a new RequestWrapper from the modified request
     const newWrapperResult = await RequestWrapper.create(newRequest, env);
     if (newWrapperResult.error || !newWrapperResult.data) {
       return new Response(
@@ -109,25 +142,68 @@ const generateHandler = async (
         { status: 500 }
       );
     }
-    const newWrapper = newWrapperResult.data;
-    // Set base URL override on the new wrapper
-    newWrapper.setBaseURLOverride(targetUrl);
 
-    // Delegate forwarding to the common gateway forwarder
-    return await gatewayForwarder(
+    // 7. Use gateway forwarder to handle the rest
+    const response = await gatewayForwarder(
       {
-        targetBaseUrl: targetUrl,
-        setBaseURLOverride: newWrapper.setBaseURLOverride.bind(newWrapper),
+        targetBaseUrl,
+        setBaseURLOverride: newWrapperResult.data.setBaseURLOverride.bind(
+          newWrapperResult.data
+        ),
       },
-      newWrapper,
+      newWrapperResult.data,
       env,
       ctx
     );
+
+    // 8. Verify the response is valid JSON and handle any compression
+    try {
+      const contentEncoding = response.headers.get("content-encoding");
+      const clonedResponse = response.clone();
+
+      // If the response is compressed, we'll return it as is since the browser/client
+      // will handle decompression. If we try to read it here, it might corrupt the stream.
+      if (contentEncoding && contentEncoding !== "identity") {
+        return response;
+      }
+
+      // For uncompressed responses, verify it's valid JSON
+      const responseText = await clonedResponse.text();
+      JSON.parse(responseText); // Test if response is valid JSON
+      return response;
+    } catch (e) {
+      return new Response(
+        JSON.stringify({
+          helicone_error: "error parsing response",
+          parse_response_error: `Error parsing body: ${e}`,
+          status: response.status,
+          statusText: response.statusText,
+          content_encoding: response.headers.get("content-encoding"),
+          content_type: response.headers.get("content-type"),
+        }),
+        {
+          status: 500,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    }
   } catch (e: any) {
     console.error("Error in generate route:", e);
-    return new Response("Error in generate route: " + e.message, {
-      status: 500,
-    });
+    return new Response(
+      JSON.stringify({
+        helicone_error: "internal server error",
+        error: e.message,
+      }),
+      {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json;charset=UTF-8",
+          "helicone-error": "true",
+        },
+      }
+    );
   }
 };
 
@@ -135,3 +211,123 @@ export const getGenerateRouter = (router: RouterType): RouterType => {
   router.all("*", generateHandler);
   return router;
 };
+
+/**
+ * Fetch and validate a prompt version from the database.
+ *
+ * @param supabaseClient - The Supabase client instance
+ * @param promptId - The user-defined ID of the prompt to fetch
+ * @param orgId - The organization ID from auth
+ * @param version - The version to fetch (either a number or "production")
+ * @returns Either a Response with an error or the prompt version row
+ */
+async function getPromptVersion(
+  supabaseClient: SupabaseClient<Database>,
+  promptId: string,
+  orgId: string,
+  version: number | "production" = "production"
+): Promise<Response | Database["public"]["Tables"]["prompts_versions"]["Row"]> {
+  console.log("Query params:", { promptId, orgId, version });
+
+  // Build an optimized single query with join
+  let query = supabaseClient
+    .from("prompt_v2")
+    .select(
+      `
+      prompts_versions!inner (
+        *
+      )
+    `
+    )
+    .eq("user_defined_id", promptId)
+    .eq("organization", orgId)
+    .eq("soft_delete", false)
+    .eq("prompts_versions.organization", orgId)
+    .eq("prompts_versions.soft_delete", false);
+
+  // Add version conditions
+  if (version === "production") {
+    // Get latest production version using index on (organization, major_version)
+    query = query.filter(
+      "prompts_versions.metadata->>isProduction",
+      "eq",
+      true
+    );
+  } else {
+    // Get specific version using the same index
+    query = query.eq("prompts_versions.major_version", version);
+  }
+
+  const { data, error } = await query.limit(1);
+  console.log("Final query result:", { data, error });
+
+  if (error) {
+    console.error("Error fetching prompt version:", error);
+    return new Response("Error fetching prompt version", { status: 500 });
+  }
+
+  if (!data || data.length === 0) {
+    return new Response("No prompt version found", { status: 404 });
+  }
+
+  // Extract the prompt version from the nested result
+  const promptVersion = data[0].prompts_versions[0];
+  if (!promptVersion) {
+    return new Response("No prompt version found", { status: 404 });
+  }
+
+  return promptVersion;
+}
+
+/**
+ * Extract and validate the provider from metadata, then get its base URL.
+ *
+ * @param metadata - The metadata object from the prompt version
+ * @returns Either a Response with an error or an object containing the provider's base URL and name
+ */
+function getProviderInfo(
+  metadata: any
+):
+  | Response
+  | { targetBaseUrl: string; provider: (typeof providersNames)[number] } {
+  const providerBaseUrls: Record<(typeof providersNames)[number], string> = {
+    OPENAI: "https://api.openai.com",
+    ANTHROPIC: "https://api.anthropic.com",
+    AZURE: "https://openai.azure.com",
+    LOCAL: "http://127.0.0.1",
+    HELICONE: "https://oai.hconeai.com",
+    AMDBARTEK: "https://amdbartek.dev",
+    ANYSCALE: "https://api.endpoints.anyscale.com",
+    CLOUDFLARE: "https://gateway.ai.cloudflare.com",
+    "2YFV": "https://api.2yfv.com",
+    TOGETHER: "https://api.together.xyz",
+    LEMONFOX: "https://api.lemonfox.ai",
+    FIREWORKS: "https://api.fireworks.ai",
+    PERPLEXITY: "https://api.perplexity.ai",
+    GOOGLE: "https://googleapis.com",
+    OPENROUTER: "https://api.openrouter.ai",
+    WISDOMINANUTSHELL: "https://api.wisdominanutshell.academy",
+    GROQ: "https://api.groq.com",
+    COHERE: "https://api.cohere.ai",
+    MISTRAL: "https://api.mistral.ai",
+    DEEPINFRA: "https://api.deepinfra.com",
+    QSTASH: "https://qstash.upstash.io",
+    FIRECRAWL: "https://api.firecrawl.dev",
+    AWS: "https://bedrock-runtime.us-east-1.amazonaws.com",
+    DEEPSEEK: "https://api.deepseek.com",
+    X: "https://api.x.ai",
+    AVIAN: "https://api.avian.io",
+    NEBIUS: "https://api.studio.nebius.ai",
+    NOVITA: "https://api.novita.ai",
+  };
+
+  // Extract and validate provider
+  const provider =
+    (metadata as { provider?: (typeof providersNames)[number] } | null)
+      ?.provider || "OPENAI";
+  if (!providersNames.includes(provider)) {
+    return new Response(`Invalid provider: ${provider}`, { status: 400 });
+  }
+
+  return { targetBaseUrl: providerBaseUrls[provider], provider };
+}

--- a/worker/src/routers/generateRouter.ts
+++ b/worker/src/routers/generateRouter.ts
@@ -1,0 +1,116 @@
+import type { IRequest, RouterType } from "itty-router";
+import { Env, Provider } from "..";
+import { RequestWrapper } from "../lib/RequestWrapper";
+import { proxyForwarder } from "../lib/HeliconeProxyRequest/ProxyForwarder";
+import { formatPrompt } from "@helicone/prompts";
+import { createClient } from "@supabase/supabase-js";
+import { Database } from "../../supabase/database.types";
+
+// Handler for generate route
+const generateHandler = async (
+  req: IRequest,
+  requestWrapper: RequestWrapper,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<Response> => {
+  try {
+    let requestData: any;
+    try {
+      requestData = await requestWrapper.getJson();
+    } catch (err) {
+      // If JSON parsing fails, fallback to plain text (assume promptId)
+      const text = await requestWrapper.getText();
+      requestData = { promptId: text.trim() };
+    }
+    const promptId: string = requestData.promptId;
+    if (!promptId) {
+      return new Response("Missing promptId", { status: 400 });
+    }
+
+    // Query production prompt version from Supabase using promptId
+    // TODO: Select for isProduction + allow for version selection
+    const supabaseClient = createClient<Database>(
+      env.SUPABASE_URL,
+      env.SUPABASE_SERVICE_ROLE_KEY
+    );
+    const { data: prodPrompt, error } = await supabaseClient
+      .from("prompts_versions")
+      .select("*")
+      .eq("prompt_v2", promptId)
+      .order("major_version", { ascending: false })
+      .order("minor_version", { ascending: false })
+      .limit(1)
+      .single();
+    if (error || !prodPrompt) {
+      return new Response("Production prompt version not found", {
+        status: 404,
+      });
+    }
+
+    // Coerce metadata into an object if possible
+    const metadata =
+      prodPrompt.metadata && typeof prodPrompt.metadata === "object"
+        ? (prodPrompt.metadata as Record<string, any>)
+        : {};
+
+    const providerKey: string | undefined = metadata.providerKey;
+    let targetUrl: string | undefined = metadata.target_url;
+    // Fallback mapping for provider target URLs
+    const providerTargetMap: { [key: string]: string } = {
+      OPENAI: "https://api.openai.com",
+      ANTHROPIC: "https://api.anthropic.com",
+    };
+    if (!targetUrl && providerKey && providerTargetMap[providerKey]) {
+      targetUrl = providerTargetMap[providerKey];
+    }
+    if (!targetUrl) {
+      return new Response("No target URL found for provider", { status: 500 });
+    }
+
+    // Process helicone_template if available
+    let heliconeTemplate = "";
+    if (prodPrompt.helicone_template) {
+      heliconeTemplate =
+        typeof prodPrompt.helicone_template === "string"
+          ? prodPrompt.helicone_template
+          : JSON.stringify(prodPrompt.helicone_template);
+    } else {
+      // Fallback: use promptId as default prompt text
+      heliconeTemplate = promptId;
+    }
+
+    let finalPrompt = heliconeTemplate;
+    if (requestData.variables) {
+      finalPrompt = formatPrompt(heliconeTemplate, requestData.variables);
+    }
+    if (requestData.chat && Array.isArray(requestData.chat)) {
+      // Prepend chat conversation if provided
+      // TODO: Do this correctly
+      finalPrompt = requestData.chat.join("\n") + "\n" + finalPrompt;
+    }
+
+    // Override the request body with the final prompt
+    requestData.prompt = finalPrompt;
+    requestWrapper.setBodyKeyOverride(requestData);
+
+    // Set the base URL override for forwarding
+    requestWrapper.setBaseURLOverride(targetUrl);
+
+    // Cast providerKey to Provider; default to 'CUSTOM' if not provided
+    const provider: Provider = providerKey
+      ? (providerKey as Provider)
+      : "CUSTOM";
+    const response = await proxyForwarder(requestWrapper, env, ctx, provider);
+    return response;
+  } catch (e: any) {
+    console.error("Error in generate route:", e);
+    return new Response("Error in generate route: " + e.message, {
+      status: 500,
+    });
+  }
+};
+
+export const getGenerateRouter = (router: RouterType): RouterType => {
+  router.all("*", generateHandler);
+  return router;
+};

--- a/worker/src/routers/routerFactory.ts
+++ b/worker/src/routers/routerFactory.ts
@@ -12,6 +12,7 @@ import { getOpenAIProxyRouter } from "./openaiProxyRouter";
 import { handleFeedback } from "../lib/managers/FeedbackManager";
 import { getGatewayAPIRouter } from "./gatewayRouter";
 import { handleLoggingEndpoint } from "../lib/managers/PropertiesManager";
+import { getGenerateRouter } from "./generateRouter";
 
 export type BaseRouter = RouterType<
   Route,
@@ -35,6 +36,7 @@ const WORKER_MAP: Omit<
   OPENAI_PROXY: getOpenAIProxyRouter,
   HELICONE_API: getAPIRouter,
   GATEWAY_API: getGatewayAPIRouter,
+  GENERATE_API: getGenerateRouter,
   CUSTOMER_GATEWAY: (router: BaseRouter) => {
     router.all(
       "*",

--- a/worker/supabase/database.types.ts
+++ b/worker/supabase/database.types.ts
@@ -4,2975 +4,2975 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[]
+  | Json[];
 
 export type Database = {
   public: {
     Tables: {
       admins: {
         Row: {
-          created_at: string
-          id: number
-          user_email: string | null
-          user_id: string | null
-        }
+          created_at: string;
+          id: number;
+          user_email: string | null;
+          user_id: string | null;
+        };
         Insert: {
-          created_at?: string
-          id?: number
-          user_email?: string | null
-          user_id?: string | null
-        }
+          created_at?: string;
+          id?: number;
+          user_email?: string | null;
+          user_id?: string | null;
+        };
         Update: {
-          created_at?: string
-          id?: number
-          user_email?: string | null
-          user_id?: string | null
-        }
+          created_at?: string;
+          id?: number;
+          user_email?: string | null;
+          user_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "admins_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: "admins_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "admins_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users_view"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "admins_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users_view";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       alert: {
         Row: {
-          created_at: string | null
-          emails: string[]
-          id: string
-          metric: string
-          minimum_request_count: number | null
-          name: string
-          org_id: string
-          slack_channels: string[]
-          soft_delete: boolean
-          status: string
-          threshold: number
-          time_block_duration: number
-          time_window: number
-          updated_at: string | null
-        }
+          created_at: string | null;
+          emails: string[];
+          id: string;
+          metric: string;
+          minimum_request_count: number | null;
+          name: string;
+          org_id: string;
+          slack_channels: string[];
+          soft_delete: boolean;
+          status: string;
+          threshold: number;
+          time_block_duration: number;
+          time_window: number;
+          updated_at: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          emails: string[]
-          id?: string
-          metric: string
-          minimum_request_count?: number | null
-          name: string
-          org_id: string
-          slack_channels?: string[]
-          soft_delete?: boolean
-          status?: string
-          threshold: number
-          time_block_duration?: number
-          time_window: number
-          updated_at?: string | null
-        }
+          created_at?: string | null;
+          emails: string[];
+          id?: string;
+          metric: string;
+          minimum_request_count?: number | null;
+          name: string;
+          org_id: string;
+          slack_channels?: string[];
+          soft_delete?: boolean;
+          status?: string;
+          threshold: number;
+          time_block_duration?: number;
+          time_window: number;
+          updated_at?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          emails?: string[]
-          id?: string
-          metric?: string
-          minimum_request_count?: number | null
-          name?: string
-          org_id?: string
-          slack_channels?: string[]
-          soft_delete?: boolean
-          status?: string
-          threshold?: number
-          time_block_duration?: number
-          time_window?: number
-          updated_at?: string | null
-        }
+          created_at?: string | null;
+          emails?: string[];
+          id?: string;
+          metric?: string;
+          minimum_request_count?: number | null;
+          name?: string;
+          org_id?: string;
+          slack_channels?: string[];
+          soft_delete?: boolean;
+          status?: string;
+          threshold?: number;
+          time_block_duration?: number;
+          time_window?: number;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "alert_org_id_fkey"
-            columns: ["org_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "alert_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       alert_banners: {
         Row: {
-          active: boolean
-          created_at: string
-          id: number
-          message: string | null
-          title: string | null
-          updated_at: string
-        }
+          active: boolean;
+          created_at: string;
+          id: number;
+          message: string | null;
+          title: string | null;
+          updated_at: string;
+        };
         Insert: {
-          active?: boolean
-          created_at?: string
-          id?: number
-          message?: string | null
-          title?: string | null
-          updated_at?: string
-        }
+          active?: boolean;
+          created_at?: string;
+          id?: number;
+          message?: string | null;
+          title?: string | null;
+          updated_at?: string;
+        };
         Update: {
-          active?: boolean
-          created_at?: string
-          id?: number
-          message?: string | null
-          title?: string | null
-          updated_at?: string
-        }
-        Relationships: []
-      }
+          active?: boolean;
+          created_at?: string;
+          id?: number;
+          message?: string | null;
+          title?: string | null;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       alert_history: {
         Row: {
-          alert_end_time: string | null
-          alert_id: string
-          alert_metric: string
-          alert_name: string
-          alert_start_time: string
-          created_at: string | null
-          id: string
-          org_id: string
-          soft_delete: boolean
-          status: string
-          triggered_value: string
-          updated_at: string | null
-        }
+          alert_end_time: string | null;
+          alert_id: string;
+          alert_metric: string;
+          alert_name: string;
+          alert_start_time: string;
+          created_at: string | null;
+          id: string;
+          org_id: string;
+          soft_delete: boolean;
+          status: string;
+          triggered_value: string;
+          updated_at: string | null;
+        };
         Insert: {
-          alert_end_time?: string | null
-          alert_id: string
-          alert_metric: string
-          alert_name: string
-          alert_start_time: string
-          created_at?: string | null
-          id?: string
-          org_id: string
-          soft_delete?: boolean
-          status: string
-          triggered_value: string
-          updated_at?: string | null
-        }
+          alert_end_time?: string | null;
+          alert_id: string;
+          alert_metric: string;
+          alert_name: string;
+          alert_start_time: string;
+          created_at?: string | null;
+          id?: string;
+          org_id: string;
+          soft_delete?: boolean;
+          status: string;
+          triggered_value: string;
+          updated_at?: string | null;
+        };
         Update: {
-          alert_end_time?: string | null
-          alert_id?: string
-          alert_metric?: string
-          alert_name?: string
-          alert_start_time?: string
-          created_at?: string | null
-          id?: string
-          org_id?: string
-          soft_delete?: boolean
-          status?: string
-          triggered_value?: string
-          updated_at?: string | null
-        }
+          alert_end_time?: string | null;
+          alert_id?: string;
+          alert_metric?: string;
+          alert_name?: string;
+          alert_start_time?: string;
+          created_at?: string | null;
+          id?: string;
+          org_id?: string;
+          soft_delete?: boolean;
+          status?: string;
+          triggered_value?: string;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "alert_history_alert_id_fkey"
-            columns: ["alert_id"]
-            isOneToOne: false
-            referencedRelation: "alert"
-            referencedColumns: ["id"]
+            foreignKeyName: "alert_history_alert_id_fkey";
+            columns: ["alert_id"];
+            isOneToOne: false;
+            referencedRelation: "alert";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "alert_history_org_id_fkey"
-            columns: ["org_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "alert_history_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       asset: {
         Row: {
-          created_at: string
-          id: string
-          organization_id: string
-          request_id: string
-        }
+          created_at: string;
+          id: string;
+          organization_id: string;
+          request_id: string;
+        };
         Insert: {
-          created_at?: string
-          id?: string
-          organization_id: string
-          request_id: string
-        }
+          created_at?: string;
+          id?: string;
+          organization_id: string;
+          request_id: string;
+        };
         Update: {
-          created_at?: string
-          id?: string
-          organization_id?: string
-          request_id?: string
-        }
+          created_at?: string;
+          id?: string;
+          organization_id?: string;
+          request_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "asset_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
+            foreignKeyName: "asset_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "asset_request_id_fkey"
-            columns: ["request_id"]
-            isOneToOne: false
-            referencedRelation: "request"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "asset_request_id_fkey";
+            columns: ["request_id"];
+            isOneToOne: false;
+            referencedRelation: "request";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       cache_hits: {
         Row: {
-          created_at: string
-          organization_id: string | null
-          request_id: string
-        }
+          created_at: string;
+          organization_id: string | null;
+          request_id: string;
+        };
         Insert: {
-          created_at?: string
-          organization_id?: string | null
-          request_id: string
-        }
+          created_at?: string;
+          organization_id?: string | null;
+          request_id: string;
+        };
         Update: {
-          created_at?: string
-          organization_id?: string | null
-          request_id?: string
-        }
+          created_at?: string;
+          organization_id?: string | null;
+          request_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "cache_hits_request_id_fkey"
-            columns: ["request_id"]
-            isOneToOne: false
-            referencedRelation: "request"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "cache_hits_request_id_fkey";
+            columns: ["request_id"];
+            isOneToOne: false;
+            referencedRelation: "request";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       contact_submissions: {
         Row: {
-          company_description: string | null
-          company_name: string | null
-          created_at: string | null
-          email_address: string | null
-          first_name: string | null
-          id: number
-          last_name: string | null
-          tag: string | null
-        }
+          company_description: string | null;
+          company_name: string | null;
+          created_at: string | null;
+          email_address: string | null;
+          first_name: string | null;
+          id: number;
+          last_name: string | null;
+          tag: string | null;
+        };
         Insert: {
-          company_description?: string | null
-          company_name?: string | null
-          created_at?: string | null
-          email_address?: string | null
-          first_name?: string | null
-          id?: number
-          last_name?: string | null
-          tag?: string | null
-        }
+          company_description?: string | null;
+          company_name?: string | null;
+          created_at?: string | null;
+          email_address?: string | null;
+          first_name?: string | null;
+          id?: number;
+          last_name?: string | null;
+          tag?: string | null;
+        };
         Update: {
-          company_description?: string | null
-          company_name?: string | null
-          created_at?: string | null
-          email_address?: string | null
-          first_name?: string | null
-          id?: number
-          last_name?: string | null
-          tag?: string | null
-        }
-        Relationships: []
-      }
+          company_description?: string | null;
+          company_name?: string | null;
+          created_at?: string | null;
+          email_address?: string | null;
+          first_name?: string | null;
+          id?: number;
+          last_name?: string | null;
+          tag?: string | null;
+        };
+        Relationships: [];
+      };
       evaluator: {
         Row: {
-          code_template: Json | null
-          created_at: string
-          id: string
-          last_mile_config: Json | null
-          llm_template: Json | null
-          name: string
-          organization_id: string
-          scoring_type: string
-          updated_at: string
-        }
+          code_template: Json | null;
+          created_at: string;
+          id: string;
+          last_mile_config: Json | null;
+          llm_template: Json | null;
+          name: string;
+          organization_id: string;
+          scoring_type: string;
+          updated_at: string;
+        };
         Insert: {
-          code_template?: Json | null
-          created_at?: string
-          id?: string
-          last_mile_config?: Json | null
-          llm_template?: Json | null
-          name: string
-          organization_id: string
-          scoring_type: string
-          updated_at?: string
-        }
+          code_template?: Json | null;
+          created_at?: string;
+          id?: string;
+          last_mile_config?: Json | null;
+          llm_template?: Json | null;
+          name: string;
+          organization_id: string;
+          scoring_type: string;
+          updated_at?: string;
+        };
         Update: {
-          code_template?: Json | null
-          created_at?: string
-          id?: string
-          last_mile_config?: Json | null
-          llm_template?: Json | null
-          name?: string
-          organization_id?: string
-          scoring_type?: string
-          updated_at?: string
-        }
+          code_template?: Json | null;
+          created_at?: string;
+          id?: string;
+          last_mile_config?: Json | null;
+          llm_template?: Json | null;
+          name?: string;
+          organization_id?: string;
+          scoring_type?: string;
+          updated_at?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "evaluator_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "evaluator_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       evaluator_experiments: {
         Row: {
-          created_at: string
-          evaluator: string
-          experiment: string
-          id: number
-        }
+          created_at: string;
+          evaluator: string;
+          experiment: string;
+          id: number;
+        };
         Insert: {
-          created_at?: string
-          evaluator: string
-          experiment: string
-          id?: number
-        }
+          created_at?: string;
+          evaluator: string;
+          experiment: string;
+          id?: number;
+        };
         Update: {
-          created_at?: string
-          evaluator?: string
-          experiment?: string
-          id?: number
-        }
+          created_at?: string;
+          evaluator?: string;
+          experiment?: string;
+          id?: number;
+        };
         Relationships: [
           {
-            foreignKeyName: "public_evaluator_experiments_evaluator_fkey"
-            columns: ["evaluator"]
-            isOneToOne: false
-            referencedRelation: "evaluator"
-            referencedColumns: ["id"]
+            foreignKeyName: "public_evaluator_experiments_evaluator_fkey";
+            columns: ["evaluator"];
+            isOneToOne: false;
+            referencedRelation: "evaluator";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_evaluator_experiments_experiment_fkey"
-            columns: ["experiment"]
-            isOneToOne: false
-            referencedRelation: "experiment_v2"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "public_evaluator_experiments_experiment_fkey";
+            columns: ["experiment"];
+            isOneToOne: false;
+            referencedRelation: "experiment_v2";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       evaluator_experiments_v3: {
         Row: {
-          created_at: string
-          evaluator: string
-          experiment: string
-          id: string
-        }
+          created_at: string;
+          evaluator: string;
+          experiment: string;
+          id: string;
+        };
         Insert: {
-          created_at?: string
-          evaluator: string
-          experiment: string
-          id?: string
-        }
+          created_at?: string;
+          evaluator: string;
+          experiment: string;
+          id?: string;
+        };
         Update: {
-          created_at?: string
-          evaluator?: string
-          experiment?: string
-          id?: string
-        }
+          created_at?: string;
+          evaluator?: string;
+          experiment?: string;
+          id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "public_evaluator_experiments_v3_evaluator_fkey"
-            columns: ["evaluator"]
-            isOneToOne: false
-            referencedRelation: "evaluator"
-            referencedColumns: ["id"]
+            foreignKeyName: "public_evaluator_experiments_v3_evaluator_fkey";
+            columns: ["evaluator"];
+            isOneToOne: false;
+            referencedRelation: "evaluator";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_evaluator_experiments_v3_experiment_fkey"
-            columns: ["experiment"]
-            isOneToOne: false
-            referencedRelation: "experiment_v3"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "public_evaluator_experiments_v3_experiment_fkey";
+            columns: ["experiment"];
+            isOneToOne: false;
+            referencedRelation: "experiment_v3";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       experiment_cell: {
         Row: {
-          column_id: string
-          created_at: string
-          id: string
-          metadata: Json | null
-          row_index: number
-          status: string | null
-          value: string | null
-        }
+          column_id: string;
+          created_at: string;
+          id: string;
+          metadata: Json | null;
+          row_index: number;
+          status: string | null;
+          value: string | null;
+        };
         Insert: {
-          column_id: string
-          created_at?: string
-          id?: string
-          metadata?: Json | null
-          row_index: number
-          status?: string | null
-          value?: string | null
-        }
+          column_id: string;
+          created_at?: string;
+          id?: string;
+          metadata?: Json | null;
+          row_index: number;
+          status?: string | null;
+          value?: string | null;
+        };
         Update: {
-          column_id?: string
-          created_at?: string
-          id?: string
-          metadata?: Json | null
-          row_index?: number
-          status?: string | null
-          value?: string | null
-        }
+          column_id?: string;
+          created_at?: string;
+          id?: string;
+          metadata?: Json | null;
+          row_index?: number;
+          status?: string | null;
+          value?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "experiment_cell_column_id_fkey"
-            columns: ["column_id"]
-            isOneToOne: false
-            referencedRelation: "experiment_column"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "experiment_cell_column_id_fkey";
+            columns: ["column_id"];
+            isOneToOne: false;
+            referencedRelation: "experiment_column";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       experiment_column: {
         Row: {
-          column_name: string
-          column_type: string
-          created_at: string
-          id: string
-          metadata: Json | null
-          table_id: string
-        }
+          column_name: string;
+          column_type: string;
+          created_at: string;
+          id: string;
+          metadata: Json | null;
+          table_id: string;
+        };
         Insert: {
-          column_name: string
-          column_type: string
-          created_at?: string
-          id?: string
-          metadata?: Json | null
-          table_id: string
-        }
+          column_name: string;
+          column_type: string;
+          created_at?: string;
+          id?: string;
+          metadata?: Json | null;
+          table_id: string;
+        };
         Update: {
-          column_name?: string
-          column_type?: string
-          created_at?: string
-          id?: string
-          metadata?: Json | null
-          table_id?: string
-        }
+          column_name?: string;
+          column_type?: string;
+          created_at?: string;
+          id?: string;
+          metadata?: Json | null;
+          table_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "experiment_column_table_id_fkey"
-            columns: ["table_id"]
-            isOneToOne: false
-            referencedRelation: "experiment_table"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "experiment_column_table_id_fkey";
+            columns: ["table_id"];
+            isOneToOne: false;
+            referencedRelation: "experiment_table";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       experiment_dataset_v2_row: {
         Row: {
-          created_at: string
-          dataset_id: string
-          id: string
-          input_record: string
-        }
+          created_at: string;
+          dataset_id: string;
+          id: string;
+          input_record: string;
+        };
         Insert: {
-          created_at?: string
-          dataset_id: string
-          id?: string
-          input_record: string
-        }
+          created_at?: string;
+          dataset_id: string;
+          id?: string;
+          input_record: string;
+        };
         Update: {
-          created_at?: string
-          dataset_id?: string
-          id?: string
-          input_record?: string
-        }
+          created_at?: string;
+          dataset_id?: string;
+          id?: string;
+          input_record?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "fk_dataset_id"
-            columns: ["dataset_id"]
-            isOneToOne: false
-            referencedRelation: "helicone_dataset"
-            referencedColumns: ["id"]
+            foreignKeyName: "fk_dataset_id";
+            columns: ["dataset_id"];
+            isOneToOne: false;
+            referencedRelation: "helicone_dataset";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_experiment_dataset_v2_row_input_record_fkey"
-            columns: ["input_record"]
-            isOneToOne: false
-            referencedRelation: "prompt_input_record"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "public_experiment_dataset_v2_row_input_record_fkey";
+            columns: ["input_record"];
+            isOneToOne: false;
+            referencedRelation: "prompt_input_record";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       experiment_output: {
         Row: {
-          created_at: string
-          experiment_id: string | null
-          id: number
-          input_record_id: string | null
-          is_original: boolean
-          prompt_version_id: string | null
-          request_id: string | null
-        }
+          created_at: string;
+          experiment_id: string | null;
+          id: number;
+          input_record_id: string | null;
+          is_original: boolean;
+          prompt_version_id: string | null;
+          request_id: string | null;
+        };
         Insert: {
-          created_at?: string
-          experiment_id?: string | null
-          id?: number
-          input_record_id?: string | null
-          is_original?: boolean
-          prompt_version_id?: string | null
-          request_id?: string | null
-        }
+          created_at?: string;
+          experiment_id?: string | null;
+          id?: number;
+          input_record_id?: string | null;
+          is_original?: boolean;
+          prompt_version_id?: string | null;
+          request_id?: string | null;
+        };
         Update: {
-          created_at?: string
-          experiment_id?: string | null
-          id?: number
-          input_record_id?: string | null
-          is_original?: boolean
-          prompt_version_id?: string | null
-          request_id?: string | null
-        }
+          created_at?: string;
+          experiment_id?: string | null;
+          id?: number;
+          input_record_id?: string | null;
+          is_original?: boolean;
+          prompt_version_id?: string | null;
+          request_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "public_experiment_output_experiment_id_fkey"
-            columns: ["experiment_id"]
-            isOneToOne: false
-            referencedRelation: "experiment_v3"
-            referencedColumns: ["id"]
+            foreignKeyName: "public_experiment_output_experiment_id_fkey";
+            columns: ["experiment_id"];
+            isOneToOne: false;
+            referencedRelation: "experiment_v3";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_experiment_output_input_record_id_fkey"
-            columns: ["input_record_id"]
-            isOneToOne: false
-            referencedRelation: "prompt_input_record"
-            referencedColumns: ["id"]
+            foreignKeyName: "public_experiment_output_input_record_id_fkey";
+            columns: ["input_record_id"];
+            isOneToOne: false;
+            referencedRelation: "prompt_input_record";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_experiment_output_prompt_version_id_fkey"
-            columns: ["prompt_version_id"]
-            isOneToOne: false
-            referencedRelation: "prompts_versions"
-            referencedColumns: ["id"]
+            foreignKeyName: "public_experiment_output_prompt_version_id_fkey";
+            columns: ["prompt_version_id"];
+            isOneToOne: false;
+            referencedRelation: "prompts_versions";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_experiment_output_request_id_fkey"
-            columns: ["request_id"]
-            isOneToOne: false
-            referencedRelation: "request"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "public_experiment_output_request_id_fkey";
+            columns: ["request_id"];
+            isOneToOne: false;
+            referencedRelation: "request";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       experiment_table: {
         Row: {
-          created_at: string
-          experiment_id: string
-          id: string
-          metadata: Json | null
-          name: string
-          organization_id: string
-        }
+          created_at: string;
+          experiment_id: string;
+          id: string;
+          metadata: Json | null;
+          name: string;
+          organization_id: string;
+        };
         Insert: {
-          created_at?: string
-          experiment_id: string
-          id?: string
-          metadata?: Json | null
-          name: string
-          organization_id: string
-        }
+          created_at?: string;
+          experiment_id: string;
+          id?: string;
+          metadata?: Json | null;
+          name: string;
+          organization_id: string;
+        };
         Update: {
-          created_at?: string
-          experiment_id?: string
-          id?: string
-          metadata?: Json | null
-          name?: string
-          organization_id?: string
-        }
+          created_at?: string;
+          experiment_id?: string;
+          id?: string;
+          metadata?: Json | null;
+          name?: string;
+          organization_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "experiment_table_experiment_id_fkey"
-            columns: ["experiment_id"]
-            isOneToOne: false
-            referencedRelation: "experiment_v2"
-            referencedColumns: ["id"]
+            foreignKeyName: "experiment_table_experiment_id_fkey";
+            columns: ["experiment_id"];
+            isOneToOne: false;
+            referencedRelation: "experiment_v2";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "experiment_table_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "experiment_table_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       experiment_v2: {
         Row: {
-          created_at: string | null
-          dataset: string | null
-          id: string
-          meta: Json | null
-          organization: string | null
-        }
+          created_at: string | null;
+          dataset: string | null;
+          id: string;
+          meta: Json | null;
+          organization: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          dataset?: string | null
-          id?: string
-          meta?: Json | null
-          organization?: string | null
-        }
+          created_at?: string | null;
+          dataset?: string | null;
+          id?: string;
+          meta?: Json | null;
+          organization?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          dataset?: string | null
-          id?: string
-          meta?: Json | null
-          organization?: string | null
-        }
+          created_at?: string | null;
+          dataset?: string | null;
+          id?: string;
+          meta?: Json | null;
+          organization?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "fk_dataset"
-            columns: ["dataset"]
-            isOneToOne: false
-            referencedRelation: "helicone_dataset"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "fk_dataset";
+            columns: ["dataset"];
+            isOneToOne: false;
+            referencedRelation: "helicone_dataset";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       experiment_v2_hypothesis: {
         Row: {
-          created_at: string | null
-          experiment_v2: string | null
-          id: string
-          model: string
-          prompt_version: string
-          provider_key: string | null
-          status: string
-        }
+          created_at: string | null;
+          experiment_v2: string | null;
+          id: string;
+          model: string;
+          prompt_version: string;
+          provider_key: string | null;
+          status: string;
+        };
         Insert: {
-          created_at?: string | null
-          experiment_v2?: string | null
-          id?: string
-          model: string
-          prompt_version: string
-          provider_key?: string | null
-          status: string
-        }
+          created_at?: string | null;
+          experiment_v2?: string | null;
+          id?: string;
+          model: string;
+          prompt_version: string;
+          provider_key?: string | null;
+          status: string;
+        };
         Update: {
-          created_at?: string | null
-          experiment_v2?: string | null
-          id?: string
-          model?: string
-          prompt_version?: string
-          provider_key?: string | null
-          status?: string
-        }
+          created_at?: string | null;
+          experiment_v2?: string | null;
+          id?: string;
+          model?: string;
+          prompt_version?: string;
+          provider_key?: string | null;
+          status?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "fk_experiment"
-            columns: ["experiment_v2"]
-            isOneToOne: false
-            referencedRelation: "experiment_v2"
-            referencedColumns: ["id"]
+            foreignKeyName: "fk_experiment";
+            columns: ["experiment_v2"];
+            isOneToOne: false;
+            referencedRelation: "experiment_v2";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "fk_prompt_version"
-            columns: ["prompt_version"]
-            isOneToOne: false
-            referencedRelation: "prompts_versions"
-            referencedColumns: ["id"]
+            foreignKeyName: "fk_prompt_version";
+            columns: ["prompt_version"];
+            isOneToOne: false;
+            referencedRelation: "prompts_versions";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_experiment_v2_hypothesis_provider_key_fkey"
-            columns: ["provider_key"]
-            isOneToOne: false
-            referencedRelation: "decrypted_provider_keys"
-            referencedColumns: ["id"]
+            foreignKeyName: "public_experiment_v2_hypothesis_provider_key_fkey";
+            columns: ["provider_key"];
+            isOneToOne: false;
+            referencedRelation: "decrypted_provider_keys";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_experiment_v2_hypothesis_provider_key_fkey"
-            columns: ["provider_key"]
-            isOneToOne: false
-            referencedRelation: "provider_keys"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "public_experiment_v2_hypothesis_provider_key_fkey";
+            columns: ["provider_key"];
+            isOneToOne: false;
+            referencedRelation: "provider_keys";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       experiment_v2_hypothesis_run: {
         Row: {
-          created_at: string | null
-          dataset_row: string
-          experiment_hypothesis: string
-          id: string
-          result_request_id: string
-        }
+          created_at: string | null;
+          dataset_row: string;
+          experiment_hypothesis: string;
+          id: string;
+          result_request_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          dataset_row: string
-          experiment_hypothesis: string
-          id?: string
-          result_request_id: string
-        }
+          created_at?: string | null;
+          dataset_row: string;
+          experiment_hypothesis: string;
+          id?: string;
+          result_request_id: string;
+        };
         Update: {
-          created_at?: string | null
-          dataset_row?: string
-          experiment_hypothesis?: string
-          id?: string
-          result_request_id?: string
-        }
+          created_at?: string | null;
+          dataset_row?: string;
+          experiment_hypothesis?: string;
+          id?: string;
+          result_request_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "fk_dataset_row"
-            columns: ["dataset_row"]
-            isOneToOne: false
-            referencedRelation: "experiment_dataset_v2_row"
-            referencedColumns: ["id"]
+            foreignKeyName: "fk_dataset_row";
+            columns: ["dataset_row"];
+            isOneToOne: false;
+            referencedRelation: "experiment_dataset_v2_row";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "fk_experiment_hypothesis"
-            columns: ["experiment_hypothesis"]
-            isOneToOne: false
-            referencedRelation: "experiment_v2_hypothesis"
-            referencedColumns: ["id"]
+            foreignKeyName: "fk_experiment_hypothesis";
+            columns: ["experiment_hypothesis"];
+            isOneToOne: false;
+            referencedRelation: "experiment_v2_hypothesis";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_experiment_v2_hypothesis_run_result_request_id_fkey"
-            columns: ["result_request_id"]
-            isOneToOne: false
-            referencedRelation: "request"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "public_experiment_v2_hypothesis_run_result_request_id_fkey";
+            columns: ["result_request_id"];
+            isOneToOne: false;
+            referencedRelation: "request";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       experiment_v3: {
         Row: {
-          copied_original_prompt_version: string | null
-          created_at: string
-          id: string
-          input_keys: string[] | null
-          name: string
-          organization: string
-          original_prompt_version: string
-        }
+          copied_original_prompt_version: string | null;
+          created_at: string;
+          id: string;
+          input_keys: string[] | null;
+          name: string;
+          organization: string;
+          original_prompt_version: string;
+        };
         Insert: {
-          copied_original_prompt_version?: string | null
-          created_at?: string
-          id?: string
-          input_keys?: string[] | null
-          name: string
-          organization: string
-          original_prompt_version: string
-        }
+          copied_original_prompt_version?: string | null;
+          created_at?: string;
+          id?: string;
+          input_keys?: string[] | null;
+          name: string;
+          organization: string;
+          original_prompt_version: string;
+        };
         Update: {
-          copied_original_prompt_version?: string | null
-          created_at?: string
-          id?: string
-          input_keys?: string[] | null
-          name?: string
-          organization?: string
-          original_prompt_version?: string
-        }
+          copied_original_prompt_version?: string | null;
+          created_at?: string;
+          id?: string;
+          input_keys?: string[] | null;
+          name?: string;
+          organization?: string;
+          original_prompt_version?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "public_experiment_v3_copied_original_prompt_version_fkey"
-            columns: ["copied_original_prompt_version"]
-            isOneToOne: false
-            referencedRelation: "prompts_versions"
-            referencedColumns: ["id"]
+            foreignKeyName: "public_experiment_v3_copied_original_prompt_version_fkey";
+            columns: ["copied_original_prompt_version"];
+            isOneToOne: false;
+            referencedRelation: "prompts_versions";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_experiment_v3_organization_fkey"
-            columns: ["organization"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
+            foreignKeyName: "public_experiment_v3_organization_fkey";
+            columns: ["organization"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_experiment_v3_original_prompt_version_fkey"
-            columns: ["original_prompt_version"]
-            isOneToOne: false
-            referencedRelation: "prompts_versions"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "public_experiment_v3_original_prompt_version_fkey";
+            columns: ["original_prompt_version"];
+            isOneToOne: false;
+            referencedRelation: "prompts_versions";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       experiments_waitlist: {
         Row: {
-          created_at: string
-          email: string
-          id: number
-        }
+          created_at: string;
+          email: string;
+          id: number;
+        };
         Insert: {
-          created_at?: string
-          email: string
-          id?: number
-        }
+          created_at?: string;
+          email: string;
+          id?: number;
+        };
         Update: {
-          created_at?: string
-          email?: string
-          id?: number
-        }
-        Relationships: []
-      }
+          created_at?: string;
+          email?: string;
+          id?: number;
+        };
+        Relationships: [];
+      };
       feature_flags: {
         Row: {
-          created_at: string | null
-          feature: string
-          id: number
-          org_id: string
-        }
+          created_at: string | null;
+          feature: string;
+          id: number;
+          org_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          feature: string
-          id?: number
-          org_id: string
-        }
+          created_at?: string | null;
+          feature: string;
+          id?: number;
+          org_id: string;
+        };
         Update: {
-          created_at?: string | null
-          feature?: string
-          id?: number
-          org_id?: string
-        }
+          created_at?: string | null;
+          feature?: string;
+          id?: number;
+          org_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "feature_flags_org_id_fkey"
-            columns: ["org_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "feature_flags_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       feedback: {
         Row: {
-          created_at: string
-          id: string
-          rating: boolean
-          response_id: string
-        }
+          created_at: string;
+          id: string;
+          rating: boolean;
+          response_id: string;
+        };
         Insert: {
-          created_at?: string
-          id?: string
-          rating: boolean
-          response_id: string
-        }
+          created_at?: string;
+          id?: string;
+          rating: boolean;
+          response_id: string;
+        };
         Update: {
-          created_at?: string
-          id?: string
-          rating?: boolean
-          response_id?: string
-        }
+          created_at?: string;
+          id?: string;
+          rating?: boolean;
+          response_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "feedback_response_id_fkey"
-            columns: ["response_id"]
-            isOneToOne: true
-            referencedRelation: "response"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "feedback_response_id_fkey";
+            columns: ["response_id"];
+            isOneToOne: true;
+            referencedRelation: "response";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       finetune_dataset: {
         Row: {
-          created_at: string
-          filter_node: string | null
-          filters: string | null
-          id: string
-          name: string
-          organization_id: string
-        }
+          created_at: string;
+          filter_node: string | null;
+          filters: string | null;
+          id: string;
+          name: string;
+          organization_id: string;
+        };
         Insert: {
-          created_at?: string
-          filter_node?: string | null
-          filters?: string | null
-          id?: string
-          name: string
-          organization_id: string
-        }
+          created_at?: string;
+          filter_node?: string | null;
+          filters?: string | null;
+          id?: string;
+          name: string;
+          organization_id: string;
+        };
         Update: {
-          created_at?: string
-          filter_node?: string | null
-          filters?: string | null
-          id?: string
-          name?: string
-          organization_id?: string
-        }
+          created_at?: string;
+          filter_node?: string | null;
+          filters?: string | null;
+          id?: string;
+          name?: string;
+          organization_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "finetune_dataset_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "finetune_dataset_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       finetune_dataset_data: {
         Row: {
-          created_at: string
-          id: string
-          organization_id: string
-          request_id: string
-        }
+          created_at: string;
+          id: string;
+          organization_id: string;
+          request_id: string;
+        };
         Insert: {
-          created_at?: string
-          id: string
-          organization_id: string
-          request_id: string
-        }
+          created_at?: string;
+          id: string;
+          organization_id: string;
+          request_id: string;
+        };
         Update: {
-          created_at?: string
-          id?: string
-          organization_id?: string
-          request_id?: string
-        }
+          created_at?: string;
+          id?: string;
+          organization_id?: string;
+          request_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "finetune_dataset_data_id_fkey"
-            columns: ["id"]
-            isOneToOne: false
-            referencedRelation: "finetune_dataset"
-            referencedColumns: ["id"]
+            foreignKeyName: "finetune_dataset_data_id_fkey";
+            columns: ["id"];
+            isOneToOne: false;
+            referencedRelation: "finetune_dataset";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "finetune_dataset_data_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
+            foreignKeyName: "finetune_dataset_data_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "finetune_dataset_data_request_id_fkey"
-            columns: ["request_id"]
-            isOneToOne: false
-            referencedRelation: "request"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "finetune_dataset_data_request_id_fkey";
+            columns: ["request_id"];
+            isOneToOne: false;
+            referencedRelation: "request";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       finetune_job: {
         Row: {
-          created_at: string
-          dataset_id: string
-          finetune_job_id: string
-          id: string
-          organization_id: string
-          provider_key_id: string
-          status: string
-        }
+          created_at: string;
+          dataset_id: string;
+          finetune_job_id: string;
+          id: string;
+          organization_id: string;
+          provider_key_id: string;
+          status: string;
+        };
         Insert: {
-          created_at?: string
-          dataset_id: string
-          finetune_job_id: string
-          id?: string
-          organization_id: string
-          provider_key_id: string
-          status: string
-        }
+          created_at?: string;
+          dataset_id: string;
+          finetune_job_id: string;
+          id?: string;
+          organization_id: string;
+          provider_key_id: string;
+          status: string;
+        };
         Update: {
-          created_at?: string
-          dataset_id?: string
-          finetune_job_id?: string
-          id?: string
-          organization_id?: string
-          provider_key_id?: string
-          status?: string
-        }
+          created_at?: string;
+          dataset_id?: string;
+          finetune_job_id?: string;
+          id?: string;
+          organization_id?: string;
+          provider_key_id?: string;
+          status?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "finetune_job_dataset_id_fkey"
-            columns: ["dataset_id"]
-            isOneToOne: false
-            referencedRelation: "finetune_dataset"
-            referencedColumns: ["id"]
+            foreignKeyName: "finetune_job_dataset_id_fkey";
+            columns: ["dataset_id"];
+            isOneToOne: false;
+            referencedRelation: "finetune_dataset";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "finetune_job_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
+            foreignKeyName: "finetune_job_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "finetune_job_provider_key_id_fkey"
-            columns: ["provider_key_id"]
-            isOneToOne: false
-            referencedRelation: "decrypted_provider_keys"
-            referencedColumns: ["id"]
+            foreignKeyName: "finetune_job_provider_key_id_fkey";
+            columns: ["provider_key_id"];
+            isOneToOne: false;
+            referencedRelation: "decrypted_provider_keys";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "finetune_job_provider_key_id_fkey"
-            columns: ["provider_key_id"]
-            isOneToOne: false
-            referencedRelation: "provider_keys"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "finetune_job_provider_key_id_fkey";
+            columns: ["provider_key_id"];
+            isOneToOne: false;
+            referencedRelation: "provider_keys";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       helicone_api_keys: {
         Row: {
-          api_key_hash: string
-          api_key_name: string
-          created_at: string
-          governance: boolean
-          id: number
-          key_permissions: string | null
-          organization_id: string
-          soft_delete: boolean
-          temp_key: boolean
-          user_id: string
-        }
+          api_key_hash: string;
+          api_key_name: string;
+          created_at: string;
+          governance: boolean;
+          id: number;
+          key_permissions: string | null;
+          organization_id: string;
+          soft_delete: boolean;
+          temp_key: boolean;
+          user_id: string;
+        };
         Insert: {
-          api_key_hash: string
-          api_key_name: string
-          created_at?: string
-          governance?: boolean
-          id?: number
-          key_permissions?: string | null
-          organization_id: string
-          soft_delete?: boolean
-          temp_key?: boolean
-          user_id: string
-        }
+          api_key_hash: string;
+          api_key_name: string;
+          created_at?: string;
+          governance?: boolean;
+          id?: number;
+          key_permissions?: string | null;
+          organization_id: string;
+          soft_delete?: boolean;
+          temp_key?: boolean;
+          user_id: string;
+        };
         Update: {
-          api_key_hash?: string
-          api_key_name?: string
-          created_at?: string
-          governance?: boolean
-          id?: number
-          key_permissions?: string | null
-          organization_id?: string
-          soft_delete?: boolean
-          temp_key?: boolean
-          user_id?: string
-        }
+          api_key_hash?: string;
+          api_key_name?: string;
+          created_at?: string;
+          governance?: boolean;
+          id?: number;
+          key_permissions?: string | null;
+          organization_id?: string;
+          soft_delete?: boolean;
+          temp_key?: boolean;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "helicone_api_keys_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
+            foreignKeyName: "helicone_api_keys_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "helicone_api_keys_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: "helicone_api_keys_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "helicone_api_keys_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users_view"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "helicone_api_keys_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users_view";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       helicone_dataset: {
         Row: {
-          created_at: string | null
-          dataset_type: string
-          deleted_at: string | null
-          id: string
-          meta: Json | null
-          name: string | null
-          organization: string
-        }
+          created_at: string | null;
+          dataset_type: string;
+          deleted_at: string | null;
+          id: string;
+          meta: Json | null;
+          name: string | null;
+          organization: string;
+        };
         Insert: {
-          created_at?: string | null
-          dataset_type?: string
-          deleted_at?: string | null
-          id?: string
-          meta?: Json | null
-          name?: string | null
-          organization: string
-        }
+          created_at?: string | null;
+          dataset_type?: string;
+          deleted_at?: string | null;
+          id?: string;
+          meta?: Json | null;
+          name?: string | null;
+          organization: string;
+        };
         Update: {
-          created_at?: string | null
-          dataset_type?: string
-          deleted_at?: string | null
-          id?: string
-          meta?: Json | null
-          name?: string | null
-          organization?: string
-        }
+          created_at?: string | null;
+          dataset_type?: string;
+          deleted_at?: string | null;
+          id?: string;
+          meta?: Json | null;
+          name?: string | null;
+          organization?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "fk_organization"
-            columns: ["organization"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "fk_organization";
+            columns: ["organization"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       helicone_dataset_row: {
         Row: {
-          created_at: string
-          dataset_id: string
-          id: string
-          organization_id: string
-          origin_request_id: string
-        }
+          created_at: string;
+          dataset_id: string;
+          id: string;
+          organization_id: string;
+          origin_request_id: string;
+        };
         Insert: {
-          created_at?: string
-          dataset_id: string
-          id?: string
-          organization_id: string
-          origin_request_id: string
-        }
+          created_at?: string;
+          dataset_id: string;
+          id?: string;
+          organization_id: string;
+          origin_request_id: string;
+        };
         Update: {
-          created_at?: string
-          dataset_id?: string
-          id?: string
-          organization_id?: string
-          origin_request_id?: string
-        }
+          created_at?: string;
+          dataset_id?: string;
+          id?: string;
+          organization_id?: string;
+          origin_request_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "public_helicone_dataset_row_dataset_id_fkey"
-            columns: ["dataset_id"]
-            isOneToOne: false
-            referencedRelation: "helicone_dataset"
-            referencedColumns: ["id"]
+            foreignKeyName: "public_helicone_dataset_row_dataset_id_fkey";
+            columns: ["dataset_id"];
+            isOneToOne: false;
+            referencedRelation: "helicone_dataset";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_helicone_dataset_row_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "public_helicone_dataset_row_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       helicone_proxy_key_limits: {
         Row: {
-          cost: number | null
-          count: number | null
-          created_at: string | null
-          currency: string | null
-          helicone_proxy_key: string
-          id: string
-          timewindow_seconds: number | null
-        }
+          cost: number | null;
+          count: number | null;
+          created_at: string | null;
+          currency: string | null;
+          helicone_proxy_key: string;
+          id: string;
+          timewindow_seconds: number | null;
+        };
         Insert: {
-          cost?: number | null
-          count?: number | null
-          created_at?: string | null
-          currency?: string | null
-          helicone_proxy_key: string
-          id: string
-          timewindow_seconds?: number | null
-        }
+          cost?: number | null;
+          count?: number | null;
+          created_at?: string | null;
+          currency?: string | null;
+          helicone_proxy_key: string;
+          id: string;
+          timewindow_seconds?: number | null;
+        };
         Update: {
-          cost?: number | null
-          count?: number | null
-          created_at?: string | null
-          currency?: string | null
-          helicone_proxy_key?: string
-          id?: string
-          timewindow_seconds?: number | null
-        }
+          cost?: number | null;
+          count?: number | null;
+          created_at?: string | null;
+          currency?: string | null;
+          helicone_proxy_key?: string;
+          id?: string;
+          timewindow_seconds?: number | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "helicone_proxy_key_limits_helicone_proxy_key_fkey"
-            columns: ["helicone_proxy_key"]
-            isOneToOne: false
-            referencedRelation: "helicone_proxy_keys"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "helicone_proxy_key_limits_helicone_proxy_key_fkey";
+            columns: ["helicone_proxy_key"];
+            isOneToOne: false;
+            referencedRelation: "helicone_proxy_keys";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       helicone_proxy_keys: {
         Row: {
-          created_at: string | null
-          experiment_use: boolean
-          helicone_proxy_key: string
-          helicone_proxy_key_name: string
-          id: string
-          org_id: string
-          provider_key_id: string
-          soft_delete: boolean
-        }
+          created_at: string | null;
+          experiment_use: boolean;
+          helicone_proxy_key: string;
+          helicone_proxy_key_name: string;
+          id: string;
+          org_id: string;
+          provider_key_id: string;
+          soft_delete: boolean;
+        };
         Insert: {
-          created_at?: string | null
-          experiment_use?: boolean
-          helicone_proxy_key: string
-          helicone_proxy_key_name: string
-          id?: string
-          org_id: string
-          provider_key_id: string
-          soft_delete?: boolean
-        }
+          created_at?: string | null;
+          experiment_use?: boolean;
+          helicone_proxy_key: string;
+          helicone_proxy_key_name: string;
+          id?: string;
+          org_id: string;
+          provider_key_id: string;
+          soft_delete?: boolean;
+        };
         Update: {
-          created_at?: string | null
-          experiment_use?: boolean
-          helicone_proxy_key?: string
-          helicone_proxy_key_name?: string
-          id?: string
-          org_id?: string
-          provider_key_id?: string
-          soft_delete?: boolean
-        }
+          created_at?: string | null;
+          experiment_use?: boolean;
+          helicone_proxy_key?: string;
+          helicone_proxy_key_name?: string;
+          id?: string;
+          org_id?: string;
+          provider_key_id?: string;
+          soft_delete?: boolean;
+        };
         Relationships: [
           {
-            foreignKeyName: "helicone_proxy_keys_org_id_fkey"
-            columns: ["org_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
+            foreignKeyName: "helicone_proxy_keys_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "helicone_proxy_keys_provider_key_id_fkey"
-            columns: ["provider_key_id"]
-            isOneToOne: false
-            referencedRelation: "decrypted_provider_keys"
-            referencedColumns: ["id"]
+            foreignKeyName: "helicone_proxy_keys_provider_key_id_fkey";
+            columns: ["provider_key_id"];
+            isOneToOne: false;
+            referencedRelation: "decrypted_provider_keys";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "helicone_proxy_keys_provider_key_id_fkey"
-            columns: ["provider_key_id"]
-            isOneToOne: false
-            referencedRelation: "provider_keys"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "helicone_proxy_keys_provider_key_id_fkey";
+            columns: ["provider_key_id"];
+            isOneToOne: false;
+            referencedRelation: "provider_keys";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       helicone_settings: {
         Row: {
-          created_at: string
-          id: string
-          name: string
-          settings: Json
-        }
+          created_at: string;
+          id: string;
+          name: string;
+          settings: Json;
+        };
         Insert: {
-          created_at?: string
-          id?: string
-          name: string
-          settings: Json
-        }
+          created_at?: string;
+          id?: string;
+          name: string;
+          settings: Json;
+        };
         Update: {
-          created_at?: string
-          id?: string
-          name?: string
-          settings?: Json
-        }
-        Relationships: []
-      }
+          created_at?: string;
+          id?: string;
+          name?: string;
+          settings?: Json;
+        };
+        Relationships: [];
+      };
       integrations: {
         Row: {
-          active: boolean
-          created_at: string | null
-          id: string
-          integration_name: string
-          organization_id: string
-          settings: Json | null
-        }
+          active: boolean;
+          created_at: string | null;
+          id: string;
+          integration_name: string;
+          organization_id: string;
+          settings: Json | null;
+        };
         Insert: {
-          active?: boolean
-          created_at?: string | null
-          id?: string
-          integration_name: string
-          organization_id: string
-          settings?: Json | null
-        }
+          active?: boolean;
+          created_at?: string | null;
+          id?: string;
+          integration_name: string;
+          organization_id: string;
+          settings?: Json | null;
+        };
         Update: {
-          active?: boolean
-          created_at?: string | null
-          id?: string
-          integration_name?: string
-          organization_id?: string
-          settings?: Json | null
-        }
+          active?: boolean;
+          created_at?: string | null;
+          id?: string;
+          integration_name?: string;
+          organization_id?: string;
+          settings?: Json | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "fk_organization"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "fk_organization";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       job: {
         Row: {
-          created_at: string | null
-          custom_properties: Json
-          description: string
-          id: string
-          name: string
-          org_id: string
-          status: string
-          timeout_seconds: number
-          updated_at: string
-        }
+          created_at: string | null;
+          custom_properties: Json;
+          description: string;
+          id: string;
+          name: string;
+          org_id: string;
+          status: string;
+          timeout_seconds: number;
+          updated_at: string;
+        };
         Insert: {
-          created_at?: string | null
-          custom_properties: Json
-          description: string
-          id: string
-          name: string
-          org_id: string
-          status?: string
-          timeout_seconds?: number
-          updated_at?: string
-        }
+          created_at?: string | null;
+          custom_properties: Json;
+          description: string;
+          id: string;
+          name: string;
+          org_id: string;
+          status?: string;
+          timeout_seconds?: number;
+          updated_at?: string;
+        };
         Update: {
-          created_at?: string | null
-          custom_properties?: Json
-          description?: string
-          id?: string
-          name?: string
-          org_id?: string
-          status?: string
-          timeout_seconds?: number
-          updated_at?: string
-        }
+          created_at?: string | null;
+          custom_properties?: Json;
+          description?: string;
+          id?: string;
+          name?: string;
+          org_id?: string;
+          status?: string;
+          timeout_seconds?: number;
+          updated_at?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "job_org_id_fkey"
-            columns: ["org_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "job_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       job_node: {
         Row: {
-          created_at: string | null
-          custom_properties: Json
-          description: string
-          id: string
-          job: string
-          name: string
-          node_type: string
-          org_id: string
-          resource_data: string | null
-          resource_data_type: string | null
-          status: string
-          timeout_seconds: number
-          updated_at: string
-        }
+          created_at: string | null;
+          custom_properties: Json;
+          description: string;
+          id: string;
+          job: string;
+          name: string;
+          node_type: string;
+          org_id: string;
+          resource_data: string | null;
+          resource_data_type: string | null;
+          status: string;
+          timeout_seconds: number;
+          updated_at: string;
+        };
         Insert: {
-          created_at?: string | null
-          custom_properties: Json
-          description?: string
-          id: string
-          job: string
-          name?: string
-          node_type?: string
-          org_id: string
-          resource_data?: string | null
-          resource_data_type?: string | null
-          status?: string
-          timeout_seconds?: number
-          updated_at: string
-        }
+          created_at?: string | null;
+          custom_properties: Json;
+          description?: string;
+          id: string;
+          job: string;
+          name?: string;
+          node_type?: string;
+          org_id: string;
+          resource_data?: string | null;
+          resource_data_type?: string | null;
+          status?: string;
+          timeout_seconds?: number;
+          updated_at: string;
+        };
         Update: {
-          created_at?: string | null
-          custom_properties?: Json
-          description?: string
-          id?: string
-          job?: string
-          name?: string
-          node_type?: string
-          org_id?: string
-          resource_data?: string | null
-          resource_data_type?: string | null
-          status?: string
-          timeout_seconds?: number
-          updated_at?: string
-        }
+          created_at?: string | null;
+          custom_properties?: Json;
+          description?: string;
+          id?: string;
+          job?: string;
+          name?: string;
+          node_type?: string;
+          org_id?: string;
+          resource_data?: string | null;
+          resource_data_type?: string | null;
+          status?: string;
+          timeout_seconds?: number;
+          updated_at?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "job_node_job_fkey"
-            columns: ["job"]
-            isOneToOne: false
-            referencedRelation: "job"
-            referencedColumns: ["id"]
+            foreignKeyName: "job_node_job_fkey";
+            columns: ["job"];
+            isOneToOne: false;
+            referencedRelation: "job";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "job_node_org_id_fkey"
-            columns: ["org_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "job_node_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       job_node_relationships: {
         Row: {
-          job_id: string | null
-          node_id: string
-          parent_node_id: string
-        }
+          job_id: string | null;
+          node_id: string;
+          parent_node_id: string;
+        };
         Insert: {
-          job_id?: string | null
-          node_id: string
-          parent_node_id: string
-        }
+          job_id?: string | null;
+          node_id: string;
+          parent_node_id: string;
+        };
         Update: {
-          job_id?: string | null
-          node_id?: string
-          parent_node_id?: string
-        }
+          job_id?: string | null;
+          node_id?: string;
+          parent_node_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "job_node_relationships_job_id_fkey"
-            columns: ["job_id"]
-            isOneToOne: false
-            referencedRelation: "job"
-            referencedColumns: ["id"]
+            foreignKeyName: "job_node_relationships_job_id_fkey";
+            columns: ["job_id"];
+            isOneToOne: false;
+            referencedRelation: "job";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "job_node_relationships_node_id_fkey"
-            columns: ["node_id"]
-            isOneToOne: false
-            referencedRelation: "job_node"
-            referencedColumns: ["id"]
+            foreignKeyName: "job_node_relationships_node_id_fkey";
+            columns: ["node_id"];
+            isOneToOne: false;
+            referencedRelation: "job_node";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "job_node_relationships_parent_node_id_fkey"
-            columns: ["parent_node_id"]
-            isOneToOne: false
-            referencedRelation: "job_node"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "job_node_relationships_parent_node_id_fkey";
+            columns: ["parent_node_id"];
+            isOneToOne: false;
+            referencedRelation: "job_node";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       job_node_request: {
         Row: {
-          created_at: string
-          job_id: string
-          node_id: string
-          request_id: string
-        }
+          created_at: string;
+          job_id: string;
+          node_id: string;
+          request_id: string;
+        };
         Insert: {
-          created_at?: string
-          job_id: string
-          node_id: string
-          request_id: string
-        }
+          created_at?: string;
+          job_id: string;
+          node_id: string;
+          request_id: string;
+        };
         Update: {
-          created_at?: string
-          job_id?: string
-          node_id?: string
-          request_id?: string
-        }
+          created_at?: string;
+          job_id?: string;
+          node_id?: string;
+          request_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "job_node_request_job_id_fkey"
-            columns: ["job_id"]
-            isOneToOne: false
-            referencedRelation: "job"
-            referencedColumns: ["id"]
+            foreignKeyName: "job_node_request_job_id_fkey";
+            columns: ["job_id"];
+            isOneToOne: false;
+            referencedRelation: "job";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "job_node_request_node_id_fkey"
-            columns: ["node_id"]
-            isOneToOne: false
-            referencedRelation: "job_node"
-            referencedColumns: ["id"]
+            foreignKeyName: "job_node_request_node_id_fkey";
+            columns: ["node_id"];
+            isOneToOne: false;
+            referencedRelation: "job_node";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "job_node_request_request_id_fkey"
-            columns: ["request_id"]
-            isOneToOne: false
-            referencedRelation: "request"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "job_node_request_request_id_fkey";
+            columns: ["request_id"];
+            isOneToOne: false;
+            referencedRelation: "request";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       layout: {
         Row: {
-          columns: Json | null
-          created_at: string | null
-          filters: Json | null
-          id: number
-          name: string
-          user_id: string
-        }
+          columns: Json | null;
+          created_at: string | null;
+          filters: Json | null;
+          id: number;
+          name: string;
+          user_id: string;
+        };
         Insert: {
-          columns?: Json | null
-          created_at?: string | null
-          filters?: Json | null
-          id?: number
-          name: string
-          user_id: string
-        }
+          columns?: Json | null;
+          created_at?: string | null;
+          filters?: Json | null;
+          id?: number;
+          name: string;
+          user_id: string;
+        };
         Update: {
-          columns?: Json | null
-          created_at?: string | null
-          filters?: Json | null
-          id?: number
-          name?: string
-          user_id?: string
-        }
+          columns?: Json | null;
+          created_at?: string | null;
+          filters?: Json | null;
+          id?: number;
+          name?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "layout_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: "layout_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "layout_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users_view"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "layout_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users_view";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       online_evaluators: {
         Row: {
-          config: Json | null
-          created_at: string
-          evaluator: string
-          id: number
-          organization: string
-        }
+          config: Json | null;
+          created_at: string;
+          evaluator: string;
+          id: number;
+          organization: string;
+        };
         Insert: {
-          config?: Json | null
-          created_at?: string
-          evaluator: string
-          id?: number
-          organization: string
-        }
+          config?: Json | null;
+          created_at?: string;
+          evaluator: string;
+          id?: number;
+          organization: string;
+        };
         Update: {
-          config?: Json | null
-          created_at?: string
-          evaluator?: string
-          id?: number
-          organization?: string
-        }
+          config?: Json | null;
+          created_at?: string;
+          evaluator?: string;
+          id?: number;
+          organization?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "public_online_evaluators_evaluator_fkey"
-            columns: ["evaluator"]
-            isOneToOne: false
-            referencedRelation: "evaluator"
-            referencedColumns: ["id"]
+            foreignKeyName: "public_online_evaluators_evaluator_fkey";
+            columns: ["evaluator"];
+            isOneToOne: false;
+            referencedRelation: "evaluator";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_online_evaluators_organization_fkey"
-            columns: ["organization"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "public_online_evaluators_organization_fkey";
+            columns: ["organization"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       org_rate_limit_tracker: {
         Row: {
-          created_at: string | null
-          id: string
-          org_id: string
-          total_count: number
-        }
+          created_at: string | null;
+          id: string;
+          org_id: string;
+          total_count: number;
+        };
         Insert: {
-          created_at?: string | null
-          id?: string
-          org_id: string
-          total_count?: number
-        }
+          created_at?: string | null;
+          id?: string;
+          org_id: string;
+          total_count?: number;
+        };
         Update: {
-          created_at?: string | null
-          id?: string
-          org_id?: string
-          total_count?: number
-        }
+          created_at?: string | null;
+          id?: string;
+          org_id?: string;
+          total_count?: number;
+        };
         Relationships: [
           {
-            foreignKeyName: "org_rate_limit_tracker_org_id_fkey"
-            columns: ["org_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "org_rate_limit_tracker_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       organization: {
         Row: {
-          color: string
-          created_at: string | null
-          domain: string | null
-          governance_settings: Json | null
-          has_onboarded: boolean
-          icon: string
-          id: string
-          is_personal: boolean
-          limits: Json | null
-          logo_path: string | null
-          name: string
-          org_provider_key: string | null
-          organization_type: string
-          owner: string
-          percent_to_log: number | null
-          referral: string | null
-          request_limit: number | null
-          reseller_id: string | null
-          size: string | null
-          soft_delete: boolean
-          stripe_customer_id: string | null
-          stripe_metadata: Json
-          stripe_subscription_id: string | null
-          stripe_subscription_item_id: string | null
-          subscription_status: string | null
-          tier: string | null
-        }
+          color: string;
+          created_at: string | null;
+          domain: string | null;
+          governance_settings: Json | null;
+          has_onboarded: boolean;
+          icon: string;
+          id: string;
+          is_personal: boolean;
+          limits: Json | null;
+          logo_path: string | null;
+          name: string;
+          org_provider_key: string | null;
+          organization_type: string;
+          owner: string;
+          percent_to_log: number | null;
+          referral: string | null;
+          request_limit: number | null;
+          reseller_id: string | null;
+          size: string | null;
+          soft_delete: boolean;
+          stripe_customer_id: string | null;
+          stripe_metadata: Json;
+          stripe_subscription_id: string | null;
+          stripe_subscription_item_id: string | null;
+          subscription_status: string | null;
+          tier: string | null;
+        };
         Insert: {
-          color?: string
-          created_at?: string | null
-          domain?: string | null
-          governance_settings?: Json | null
-          has_onboarded?: boolean
-          icon?: string
-          id?: string
-          is_personal?: boolean
-          limits?: Json | null
-          logo_path?: string | null
-          name: string
-          org_provider_key?: string | null
-          organization_type?: string
-          owner: string
-          percent_to_log?: number | null
-          referral?: string | null
-          request_limit?: number | null
-          reseller_id?: string | null
-          size?: string | null
-          soft_delete?: boolean
-          stripe_customer_id?: string | null
-          stripe_metadata?: Json
-          stripe_subscription_id?: string | null
-          stripe_subscription_item_id?: string | null
-          subscription_status?: string | null
-          tier?: string | null
-        }
+          color?: string;
+          created_at?: string | null;
+          domain?: string | null;
+          governance_settings?: Json | null;
+          has_onboarded?: boolean;
+          icon?: string;
+          id?: string;
+          is_personal?: boolean;
+          limits?: Json | null;
+          logo_path?: string | null;
+          name: string;
+          org_provider_key?: string | null;
+          organization_type?: string;
+          owner: string;
+          percent_to_log?: number | null;
+          referral?: string | null;
+          request_limit?: number | null;
+          reseller_id?: string | null;
+          size?: string | null;
+          soft_delete?: boolean;
+          stripe_customer_id?: string | null;
+          stripe_metadata?: Json;
+          stripe_subscription_id?: string | null;
+          stripe_subscription_item_id?: string | null;
+          subscription_status?: string | null;
+          tier?: string | null;
+        };
         Update: {
-          color?: string
-          created_at?: string | null
-          domain?: string | null
-          governance_settings?: Json | null
-          has_onboarded?: boolean
-          icon?: string
-          id?: string
-          is_personal?: boolean
-          limits?: Json | null
-          logo_path?: string | null
-          name?: string
-          org_provider_key?: string | null
-          organization_type?: string
-          owner?: string
-          percent_to_log?: number | null
-          referral?: string | null
-          request_limit?: number | null
-          reseller_id?: string | null
-          size?: string | null
-          soft_delete?: boolean
-          stripe_customer_id?: string | null
-          stripe_metadata?: Json
-          stripe_subscription_id?: string | null
-          stripe_subscription_item_id?: string | null
-          subscription_status?: string | null
-          tier?: string | null
-        }
+          color?: string;
+          created_at?: string | null;
+          domain?: string | null;
+          governance_settings?: Json | null;
+          has_onboarded?: boolean;
+          icon?: string;
+          id?: string;
+          is_personal?: boolean;
+          limits?: Json | null;
+          logo_path?: string | null;
+          name?: string;
+          org_provider_key?: string | null;
+          organization_type?: string;
+          owner?: string;
+          percent_to_log?: number | null;
+          referral?: string | null;
+          request_limit?: number | null;
+          reseller_id?: string | null;
+          size?: string | null;
+          soft_delete?: boolean;
+          stripe_customer_id?: string | null;
+          stripe_metadata?: Json;
+          stripe_subscription_id?: string | null;
+          stripe_subscription_item_id?: string | null;
+          subscription_status?: string | null;
+          tier?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "organization_org_provider_key_fkey"
-            columns: ["org_provider_key"]
-            isOneToOne: false
-            referencedRelation: "decrypted_provider_keys"
-            referencedColumns: ["id"]
+            foreignKeyName: "organization_org_provider_key_fkey";
+            columns: ["org_provider_key"];
+            isOneToOne: false;
+            referencedRelation: "decrypted_provider_keys";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "organization_org_provider_key_fkey"
-            columns: ["org_provider_key"]
-            isOneToOne: false
-            referencedRelation: "provider_keys"
-            referencedColumns: ["id"]
+            foreignKeyName: "organization_org_provider_key_fkey";
+            columns: ["org_provider_key"];
+            isOneToOne: false;
+            referencedRelation: "provider_keys";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "organization_owner_fkey"
-            columns: ["owner"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: "organization_owner_fkey";
+            columns: ["owner"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "organization_owner_fkey"
-            columns: ["owner"]
-            isOneToOne: false
-            referencedRelation: "users_view"
-            referencedColumns: ["id"]
+            foreignKeyName: "organization_owner_fkey";
+            columns: ["owner"];
+            isOneToOne: false;
+            referencedRelation: "users_view";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "organization_reseller_id_fkey"
-            columns: ["reseller_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "organization_reseller_id_fkey";
+            columns: ["reseller_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       organization_layout: {
         Row: {
-          created_at: string
-          filters: Json
-          id: string
-          organization_id: string
-          type: string
-        }
+          created_at: string;
+          filters: Json;
+          id: string;
+          organization_id: string;
+          type: string;
+        };
         Insert: {
-          created_at?: string
-          filters: Json
-          id?: string
-          organization_id: string
-          type: string
-        }
+          created_at?: string;
+          filters: Json;
+          id?: string;
+          organization_id: string;
+          type: string;
+        };
         Update: {
-          created_at?: string
-          filters?: Json
-          id?: string
-          organization_id?: string
-          type?: string
-        }
+          created_at?: string;
+          filters?: Json;
+          id?: string;
+          organization_id?: string;
+          type?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "organization_layout_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "organization_layout_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       organization_member: {
         Row: {
-          created_at: string | null
-          governance_limits: Json | null
-          member: string
-          org_role: string
-          organization: string
-        }
+          created_at: string | null;
+          governance_limits: Json | null;
+          member: string;
+          org_role: string;
+          organization: string;
+        };
         Insert: {
-          created_at?: string | null
-          governance_limits?: Json | null
-          member: string
-          org_role?: string
-          organization: string
-        }
+          created_at?: string | null;
+          governance_limits?: Json | null;
+          member: string;
+          org_role?: string;
+          organization: string;
+        };
         Update: {
-          created_at?: string | null
-          governance_limits?: Json | null
-          member?: string
-          org_role?: string
-          organization?: string
-        }
+          created_at?: string | null;
+          governance_limits?: Json | null;
+          member?: string;
+          org_role?: string;
+          organization?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "organization_member_member_fkey"
-            columns: ["member"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: "organization_member_member_fkey";
+            columns: ["member"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "organization_member_member_fkey"
-            columns: ["member"]
-            isOneToOne: false
-            referencedRelation: "users_view"
-            referencedColumns: ["id"]
+            foreignKeyName: "organization_member_member_fkey";
+            columns: ["member"];
+            isOneToOne: false;
+            referencedRelation: "users_view";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "organization_member_organization_fkey"
-            columns: ["organization"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "organization_member_organization_fkey";
+            columns: ["organization"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       organization_usage: {
         Row: {
-          created_at: string
-          end_date: string
-          error_message: string | null
-          id: string
-          organization_id: string
-          quantity: number
-          recorded: boolean | null
-          start_date: string
-          stripe_record: Json | null
-          type: string
-          updated_at: string
-        }
+          created_at: string;
+          end_date: string;
+          error_message: string | null;
+          id: string;
+          organization_id: string;
+          quantity: number;
+          recorded: boolean | null;
+          start_date: string;
+          stripe_record: Json | null;
+          type: string;
+          updated_at: string;
+        };
         Insert: {
-          created_at?: string
-          end_date: string
-          error_message?: string | null
-          id?: string
-          organization_id: string
-          quantity: number
-          recorded?: boolean | null
-          start_date: string
-          stripe_record?: Json | null
-          type: string
-          updated_at?: string
-        }
+          created_at?: string;
+          end_date: string;
+          error_message?: string | null;
+          id?: string;
+          organization_id: string;
+          quantity: number;
+          recorded?: boolean | null;
+          start_date: string;
+          stripe_record?: Json | null;
+          type: string;
+          updated_at?: string;
+        };
         Update: {
-          created_at?: string
-          end_date?: string
-          error_message?: string | null
-          id?: string
-          organization_id?: string
-          quantity?: number
-          recorded?: boolean | null
-          start_date?: string
-          stripe_record?: Json | null
-          type?: string
-          updated_at?: string
-        }
+          created_at?: string;
+          end_date?: string;
+          error_message?: string | null;
+          id?: string;
+          organization_id?: string;
+          quantity?: number;
+          recorded?: boolean | null;
+          start_date?: string;
+          stripe_record?: Json | null;
+          type?: string;
+          updated_at?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "organization_usage_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "organization_usage_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       pi_session: {
         Row: {
-          created_at: string
-          id: number
-          organization_id: string
-          session_id: string
-        }
+          created_at: string;
+          id: number;
+          organization_id: string;
+          session_id: string;
+        };
         Insert: {
-          created_at?: string
-          id?: number
-          organization_id: string
-          session_id: string
-        }
+          created_at?: string;
+          id?: number;
+          organization_id: string;
+          session_id: string;
+        };
         Update: {
-          created_at?: string
-          id?: number
-          organization_id?: string
-          session_id?: string
-        }
+          created_at?: string;
+          id?: number;
+          organization_id?: string;
+          session_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "public_pi_session_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "public_pi_session_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       prompt_input_keys: {
         Row: {
-          created_at: string | null
-          id: string
-          key: string
-          prompt_version: string
-        }
+          created_at: string | null;
+          id: string;
+          key: string;
+          prompt_version: string;
+        };
         Insert: {
-          created_at?: string | null
-          id?: string
-          key: string
-          prompt_version: string
-        }
+          created_at?: string | null;
+          id?: string;
+          key: string;
+          prompt_version: string;
+        };
         Update: {
-          created_at?: string | null
-          id?: string
-          key?: string
-          prompt_version?: string
-        }
+          created_at?: string | null;
+          id?: string;
+          key?: string;
+          prompt_version?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "fk_prompt_version"
-            columns: ["prompt_version"]
-            isOneToOne: false
-            referencedRelation: "prompts_versions"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "fk_prompt_version";
+            columns: ["prompt_version"];
+            isOneToOne: false;
+            referencedRelation: "prompts_versions";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       prompt_input_record: {
         Row: {
-          auto_prompt_inputs: Json
-          created_at: string | null
-          experiment_id: string | null
-          id: string
-          inputs: Json
-          prompt_version: string
-          source_request: string | null
-        }
+          auto_prompt_inputs: Json;
+          created_at: string | null;
+          experiment_id: string | null;
+          id: string;
+          inputs: Json;
+          prompt_version: string;
+          source_request: string | null;
+        };
         Insert: {
-          auto_prompt_inputs?: Json
-          created_at?: string | null
-          experiment_id?: string | null
-          id?: string
-          inputs: Json
-          prompt_version: string
-          source_request?: string | null
-        }
+          auto_prompt_inputs?: Json;
+          created_at?: string | null;
+          experiment_id?: string | null;
+          id?: string;
+          inputs: Json;
+          prompt_version: string;
+          source_request?: string | null;
+        };
         Update: {
-          auto_prompt_inputs?: Json
-          created_at?: string | null
-          experiment_id?: string | null
-          id?: string
-          inputs?: Json
-          prompt_version?: string
-          source_request?: string | null
-        }
+          auto_prompt_inputs?: Json;
+          created_at?: string | null;
+          experiment_id?: string | null;
+          id?: string;
+          inputs?: Json;
+          prompt_version?: string;
+          source_request?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "fk_prompt_version"
-            columns: ["prompt_version"]
-            isOneToOne: false
-            referencedRelation: "prompts_versions"
-            referencedColumns: ["id"]
+            foreignKeyName: "fk_prompt_version";
+            columns: ["prompt_version"];
+            isOneToOne: false;
+            referencedRelation: "prompts_versions";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "fk_source_request"
-            columns: ["source_request"]
-            isOneToOne: false
-            referencedRelation: "request"
-            referencedColumns: ["id"]
+            foreignKeyName: "fk_source_request";
+            columns: ["source_request"];
+            isOneToOne: false;
+            referencedRelation: "request";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_prompt_input_record_experiment_id_fkey"
-            columns: ["experiment_id"]
-            isOneToOne: false
-            referencedRelation: "experiment_v3"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "public_prompt_input_record_experiment_id_fkey";
+            columns: ["experiment_id"];
+            isOneToOne: false;
+            referencedRelation: "experiment_v3";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       prompt_v2: {
         Row: {
-          created_at: string | null
-          description: string | null
-          id: string
-          metadata: Json | null
-          organization: string
-          pretty_name: string | null
-          soft_delete: boolean | null
-          user_defined_id: string
-        }
+          created_at: string | null;
+          description: string | null;
+          id: string;
+          metadata: Json | null;
+          organization: string;
+          pretty_name: string | null;
+          soft_delete: boolean | null;
+          user_defined_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          description?: string | null
-          id?: string
-          metadata?: Json | null
-          organization: string
-          pretty_name?: string | null
-          soft_delete?: boolean | null
-          user_defined_id: string
-        }
+          created_at?: string | null;
+          description?: string | null;
+          id?: string;
+          metadata?: Json | null;
+          organization: string;
+          pretty_name?: string | null;
+          soft_delete?: boolean | null;
+          user_defined_id: string;
+        };
         Update: {
-          created_at?: string | null
-          description?: string | null
-          id?: string
-          metadata?: Json | null
-          organization?: string
-          pretty_name?: string | null
-          soft_delete?: boolean | null
-          user_defined_id?: string
-        }
+          created_at?: string | null;
+          description?: string | null;
+          id?: string;
+          metadata?: Json | null;
+          organization?: string;
+          pretty_name?: string | null;
+          soft_delete?: boolean | null;
+          user_defined_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "fk_organization"
-            columns: ["organization"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "fk_organization";
+            columns: ["organization"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       prompts_versions: {
         Row: {
-          created_at: string | null
-          experiment_id: string | null
-          helicone_template: Json | null
-          id: string
-          major_version: number
-          metadata: Json | null
-          minor_version: number
-          model: string | null
-          organization: string
-          parent_prompt_version: string | null
-          prompt_v2: string
-          soft_delete: boolean | null
-          updated_at: string
-        }
+          created_at: string | null;
+          experiment_id: string | null;
+          helicone_template: Json | null;
+          id: string;
+          major_version: number;
+          metadata: Json | null;
+          minor_version: number;
+          model: string | null;
+          organization: string;
+          parent_prompt_version: string | null;
+          prompt_v2: string;
+          soft_delete: boolean | null;
+          updated_at: string;
+        };
         Insert: {
-          created_at?: string | null
-          experiment_id?: string | null
-          helicone_template?: Json | null
-          id?: string
-          major_version: number
-          metadata?: Json | null
-          minor_version: number
-          model?: string | null
-          organization: string
-          parent_prompt_version?: string | null
-          prompt_v2: string
-          soft_delete?: boolean | null
-          updated_at?: string
-        }
+          created_at?: string | null;
+          experiment_id?: string | null;
+          helicone_template?: Json | null;
+          id?: string;
+          major_version: number;
+          metadata?: Json | null;
+          minor_version: number;
+          model?: string | null;
+          organization: string;
+          parent_prompt_version?: string | null;
+          prompt_v2: string;
+          soft_delete?: boolean | null;
+          updated_at?: string;
+        };
         Update: {
-          created_at?: string | null
-          experiment_id?: string | null
-          helicone_template?: Json | null
-          id?: string
-          major_version?: number
-          metadata?: Json | null
-          minor_version?: number
-          model?: string | null
-          organization?: string
-          parent_prompt_version?: string | null
-          prompt_v2?: string
-          soft_delete?: boolean | null
-          updated_at?: string
-        }
+          created_at?: string | null;
+          experiment_id?: string | null;
+          helicone_template?: Json | null;
+          id?: string;
+          major_version?: number;
+          metadata?: Json | null;
+          minor_version?: number;
+          model?: string | null;
+          organization?: string;
+          parent_prompt_version?: string | null;
+          prompt_v2?: string;
+          soft_delete?: boolean | null;
+          updated_at?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "fk_organization"
-            columns: ["organization"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
+            foreignKeyName: "fk_organization";
+            columns: ["organization"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "fk_prompt"
-            columns: ["prompt_v2"]
-            isOneToOne: false
-            referencedRelation: "prompt_v2"
-            referencedColumns: ["id"]
+            foreignKeyName: "fk_prompt";
+            columns: ["prompt_v2"];
+            isOneToOne: false;
+            referencedRelation: "prompt_v2";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_prompts_versions_experiment_id_fkey"
-            columns: ["experiment_id"]
-            isOneToOne: false
-            referencedRelation: "experiment_v3"
-            referencedColumns: ["id"]
+            foreignKeyName: "public_prompts_versions_experiment_id_fkey";
+            columns: ["experiment_id"];
+            isOneToOne: false;
+            referencedRelation: "experiment_v3";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_prompts_versions_parent_prompt_version_fkey"
-            columns: ["parent_prompt_version"]
-            isOneToOne: false
-            referencedRelation: "prompts_versions"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "public_prompts_versions_parent_prompt_version_fkey";
+            columns: ["parent_prompt_version"];
+            isOneToOne: false;
+            referencedRelation: "prompts_versions";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       properties: {
         Row: {
-          auth_hash: string | null
-          created_at: string
-          id: number
-          key: string
-          request_id: string | null
-          user_id: string | null
-          value: string
-        }
+          auth_hash: string | null;
+          created_at: string;
+          id: number;
+          key: string;
+          request_id: string | null;
+          user_id: string | null;
+          value: string;
+        };
         Insert: {
-          auth_hash?: string | null
-          created_at?: string
-          id?: number
-          key: string
-          request_id?: string | null
-          user_id?: string | null
-          value: string
-        }
+          auth_hash?: string | null;
+          created_at?: string;
+          id?: number;
+          key: string;
+          request_id?: string | null;
+          user_id?: string | null;
+          value: string;
+        };
         Update: {
-          auth_hash?: string | null
-          created_at?: string
-          id?: number
-          key?: string
-          request_id?: string | null
-          user_id?: string | null
-          value?: string
-        }
+          auth_hash?: string | null;
+          created_at?: string;
+          id?: number;
+          key?: string;
+          request_id?: string | null;
+          user_id?: string | null;
+          value?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "properties_request_id_fkey"
-            columns: ["request_id"]
-            isOneToOne: false
-            referencedRelation: "request"
-            referencedColumns: ["id"]
+            foreignKeyName: "properties_request_id_fkey";
+            columns: ["request_id"];
+            isOneToOne: false;
+            referencedRelation: "request";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "properties_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: "properties_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "properties_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users_view"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "properties_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users_view";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       provider_keys: {
         Row: {
-          created_at: string | null
-          id: string
-          key_id: string
-          nonce: string
-          org_id: string
-          provider_key: string
-          provider_key_name: string
-          provider_name: string
-          soft_delete: boolean
-          vault_key_id: string | null
-        }
+          created_at: string | null;
+          id: string;
+          key_id: string;
+          nonce: string;
+          org_id: string;
+          provider_key: string;
+          provider_key_name: string;
+          provider_name: string;
+          soft_delete: boolean;
+          vault_key_id: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          id?: string
-          key_id?: string
-          nonce?: string
-          org_id: string
-          provider_key: string
-          provider_key_name: string
-          provider_name: string
-          soft_delete?: boolean
-          vault_key_id?: string | null
-        }
+          created_at?: string | null;
+          id?: string;
+          key_id?: string;
+          nonce?: string;
+          org_id: string;
+          provider_key: string;
+          provider_key_name: string;
+          provider_name: string;
+          soft_delete?: boolean;
+          vault_key_id?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          id?: string
-          key_id?: string
-          nonce?: string
-          org_id?: string
-          provider_key?: string
-          provider_key_name?: string
-          provider_name?: string
-          soft_delete?: boolean
-          vault_key_id?: string | null
-        }
+          created_at?: string | null;
+          id?: string;
+          key_id?: string;
+          nonce?: string;
+          org_id?: string;
+          provider_key?: string;
+          provider_key_name?: string;
+          provider_name?: string;
+          soft_delete?: boolean;
+          vault_key_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "provider_keys_key_id_fkey"
-            columns: ["key_id"]
-            isOneToOne: false
-            referencedRelation: "decrypted_key"
-            referencedColumns: ["id"]
+            foreignKeyName: "provider_keys_key_id_fkey";
+            columns: ["key_id"];
+            isOneToOne: false;
+            referencedRelation: "decrypted_key";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "provider_keys_key_id_fkey"
-            columns: ["key_id"]
-            isOneToOne: false
-            referencedRelation: "key"
-            referencedColumns: ["id"]
+            foreignKeyName: "provider_keys_key_id_fkey";
+            columns: ["key_id"];
+            isOneToOne: false;
+            referencedRelation: "key";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "provider_keys_key_id_fkey"
-            columns: ["key_id"]
-            isOneToOne: false
-            referencedRelation: "valid_key"
-            referencedColumns: ["id"]
+            foreignKeyName: "provider_keys_key_id_fkey";
+            columns: ["key_id"];
+            isOneToOne: false;
+            referencedRelation: "valid_key";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "provider_keys_org_id_fkey"
-            columns: ["org_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "provider_keys_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       referrals: {
         Row: {
-          created_at: string | null
-          id: string
-          referred_user_id: string | null
-          referrer_user_id: string | null
-          status: string | null
-        }
+          created_at: string | null;
+          id: string;
+          referred_user_id: string | null;
+          referrer_user_id: string | null;
+          status: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          id?: string
-          referred_user_id?: string | null
-          referrer_user_id?: string | null
-          status?: string | null
-        }
+          created_at?: string | null;
+          id?: string;
+          referred_user_id?: string | null;
+          referrer_user_id?: string | null;
+          status?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          id?: string
-          referred_user_id?: string | null
-          referrer_user_id?: string | null
-          status?: string | null
-        }
+          created_at?: string | null;
+          id?: string;
+          referred_user_id?: string | null;
+          referrer_user_id?: string | null;
+          status?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "referrals_referred_user_id_fkey"
-            columns: ["referred_user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: "referrals_referred_user_id_fkey";
+            columns: ["referred_user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "referrals_referred_user_id_fkey"
-            columns: ["referred_user_id"]
-            isOneToOne: false
-            referencedRelation: "users_view"
-            referencedColumns: ["id"]
+            foreignKeyName: "referrals_referred_user_id_fkey";
+            columns: ["referred_user_id"];
+            isOneToOne: false;
+            referencedRelation: "users_view";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "referrals_referrer_user_id_fkey"
-            columns: ["referrer_user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: "referrals_referrer_user_id_fkey";
+            columns: ["referrer_user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "referrals_referrer_user_id_fkey"
-            columns: ["referrer_user_id"]
-            isOneToOne: false
-            referencedRelation: "users_view"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "referrals_referrer_user_id_fkey";
+            columns: ["referrer_user_id"];
+            isOneToOne: false;
+            referencedRelation: "users_view";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       request: {
         Row: {
-          auth_hash: string
-          body: Json
-          country_code: string | null
-          created_at: string
-          formatted_prompt_id: string | null
-          helicone_api_key_id: number | null
-          helicone_org_id: string | null
-          helicone_proxy_key_id: string | null
-          helicone_user: string | null
-          id: string
-          model: string | null
-          model_override: string | null
-          path: string
-          prompt_id: string | null
-          prompt_values: Json | null
-          properties: Json | null
-          provider: string
-          request_ip: string | null
-          target_url: string | null
-          threat: boolean | null
-          user_id: string | null
-          version: number
-        }
+          auth_hash: string;
+          body: Json;
+          country_code: string | null;
+          created_at: string;
+          formatted_prompt_id: string | null;
+          helicone_api_key_id: number | null;
+          helicone_org_id: string | null;
+          helicone_proxy_key_id: string | null;
+          helicone_user: string | null;
+          id: string;
+          model: string | null;
+          model_override: string | null;
+          path: string;
+          prompt_id: string | null;
+          prompt_values: Json | null;
+          properties: Json | null;
+          provider: string;
+          request_ip: string | null;
+          target_url: string | null;
+          threat: boolean | null;
+          user_id: string | null;
+          version: number;
+        };
         Insert: {
-          auth_hash: string
-          body: Json
-          country_code?: string | null
-          created_at?: string
-          formatted_prompt_id?: string | null
-          helicone_api_key_id?: number | null
-          helicone_org_id?: string | null
-          helicone_proxy_key_id?: string | null
-          helicone_user?: string | null
-          id?: string
-          model?: string | null
-          model_override?: string | null
-          path: string
-          prompt_id?: string | null
-          prompt_values?: Json | null
-          properties?: Json | null
-          provider?: string
-          request_ip?: string | null
-          target_url?: string | null
-          threat?: boolean | null
-          user_id?: string | null
-          version?: number
-        }
+          auth_hash: string;
+          body: Json;
+          country_code?: string | null;
+          created_at?: string;
+          formatted_prompt_id?: string | null;
+          helicone_api_key_id?: number | null;
+          helicone_org_id?: string | null;
+          helicone_proxy_key_id?: string | null;
+          helicone_user?: string | null;
+          id?: string;
+          model?: string | null;
+          model_override?: string | null;
+          path: string;
+          prompt_id?: string | null;
+          prompt_values?: Json | null;
+          properties?: Json | null;
+          provider?: string;
+          request_ip?: string | null;
+          target_url?: string | null;
+          threat?: boolean | null;
+          user_id?: string | null;
+          version?: number;
+        };
         Update: {
-          auth_hash?: string
-          body?: Json
-          country_code?: string | null
-          created_at?: string
-          formatted_prompt_id?: string | null
-          helicone_api_key_id?: number | null
-          helicone_org_id?: string | null
-          helicone_proxy_key_id?: string | null
-          helicone_user?: string | null
-          id?: string
-          model?: string | null
-          model_override?: string | null
-          path?: string
-          prompt_id?: string | null
-          prompt_values?: Json | null
-          properties?: Json | null
-          provider?: string
-          request_ip?: string | null
-          target_url?: string | null
-          threat?: boolean | null
-          user_id?: string | null
-          version?: number
-        }
+          auth_hash?: string;
+          body?: Json;
+          country_code?: string | null;
+          created_at?: string;
+          formatted_prompt_id?: string | null;
+          helicone_api_key_id?: number | null;
+          helicone_org_id?: string | null;
+          helicone_proxy_key_id?: string | null;
+          helicone_user?: string | null;
+          id?: string;
+          model?: string | null;
+          model_override?: string | null;
+          path?: string;
+          prompt_id?: string | null;
+          prompt_values?: Json | null;
+          properties?: Json | null;
+          provider?: string;
+          request_ip?: string | null;
+          target_url?: string | null;
+          threat?: boolean | null;
+          user_id?: string | null;
+          version?: number;
+        };
         Relationships: [
           {
-            foreignKeyName: "request_helicone_api_key_id_fkey"
-            columns: ["helicone_api_key_id"]
-            isOneToOne: false
-            referencedRelation: "helicone_api_keys"
-            referencedColumns: ["id"]
+            foreignKeyName: "request_helicone_api_key_id_fkey";
+            columns: ["helicone_api_key_id"];
+            isOneToOne: false;
+            referencedRelation: "helicone_api_keys";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "request_helicone_org_id_fkey"
-            columns: ["helicone_org_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
+            foreignKeyName: "request_helicone_org_id_fkey";
+            columns: ["helicone_org_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "request_helicone_proxy_key_id_fkey"
-            columns: ["helicone_proxy_key_id"]
-            isOneToOne: false
-            referencedRelation: "helicone_proxy_keys"
-            referencedColumns: ["id"]
+            foreignKeyName: "request_helicone_proxy_key_id_fkey";
+            columns: ["helicone_proxy_key_id"];
+            isOneToOne: false;
+            referencedRelation: "helicone_proxy_keys";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "request_helicone_user_fkey"
-            columns: ["helicone_user"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: "request_helicone_user_fkey";
+            columns: ["helicone_user"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "request_helicone_user_fkey"
-            columns: ["helicone_user"]
-            isOneToOne: false
-            referencedRelation: "users_view"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "request_helicone_user_fkey";
+            columns: ["helicone_user"];
+            isOneToOne: false;
+            referencedRelation: "users_view";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       request_job_task: {
         Row: {
-          job_id: string
-          request_id: string
-          task_id: string
-        }
+          job_id: string;
+          request_id: string;
+          task_id: string;
+        };
         Insert: {
-          job_id: string
-          request_id: string
-          task_id: string
-        }
+          job_id: string;
+          request_id: string;
+          task_id: string;
+        };
         Update: {
-          job_id?: string
-          request_id?: string
-          task_id?: string
-        }
+          job_id?: string;
+          request_id?: string;
+          task_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "request_job_task_job_id_fkey"
-            columns: ["job_id"]
-            isOneToOne: false
-            referencedRelation: "job"
-            referencedColumns: ["id"]
+            foreignKeyName: "request_job_task_job_id_fkey";
+            columns: ["job_id"];
+            isOneToOne: false;
+            referencedRelation: "job";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "request_job_task_request_id_fkey"
-            columns: ["request_id"]
-            isOneToOne: false
-            referencedRelation: "request"
-            referencedColumns: ["id"]
+            foreignKeyName: "request_job_task_request_id_fkey";
+            columns: ["request_id"];
+            isOneToOne: false;
+            referencedRelation: "request";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "request_job_task_task_id_fkey"
-            columns: ["task_id"]
-            isOneToOne: false
-            referencedRelation: "job_node"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "request_job_task_task_id_fkey";
+            columns: ["task_id"];
+            isOneToOne: false;
+            referencedRelation: "job_node";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       request_response_search: {
         Row: {
-          created_at: string
-          id: string
-          organization_id: string
-          request_body_vector: unknown | null
-          request_id: string
-          response_body_vector: unknown | null
-        }
+          created_at: string;
+          id: string;
+          organization_id: string;
+          request_body_vector: unknown | null;
+          request_id: string;
+          response_body_vector: unknown | null;
+        };
         Insert: {
-          created_at?: string
-          id?: string
-          organization_id: string
-          request_body_vector?: unknown | null
-          request_id: string
-          response_body_vector?: unknown | null
-        }
+          created_at?: string;
+          id?: string;
+          organization_id: string;
+          request_body_vector?: unknown | null;
+          request_id: string;
+          response_body_vector?: unknown | null;
+        };
         Update: {
-          created_at?: string
-          id?: string
-          organization_id?: string
-          request_body_vector?: unknown | null
-          request_id?: string
-          response_body_vector?: unknown | null
-        }
+          created_at?: string;
+          id?: string;
+          organization_id?: string;
+          request_body_vector?: unknown | null;
+          request_id?: string;
+          response_body_vector?: unknown | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "request_response_search_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
+            foreignKeyName: "request_response_search_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "request_response_search_request_id_fkey"
-            columns: ["request_id"]
-            isOneToOne: false
-            referencedRelation: "request"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "request_response_search_request_id_fkey";
+            columns: ["request_id"];
+            isOneToOne: false;
+            referencedRelation: "request";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       response: {
         Row: {
-          body: Json
-          completion_tokens: number | null
-          created_at: string
-          delay_ms: number | null
-          feedback: Json | null
-          helicone_org_id: string | null
-          id: string
-          model: string | null
-          prompt_tokens: number | null
-          request: string
-          status: number | null
-          time_to_first_token: number | null
-        }
+          body: Json;
+          completion_tokens: number | null;
+          created_at: string;
+          delay_ms: number | null;
+          feedback: Json | null;
+          helicone_org_id: string | null;
+          id: string;
+          model: string | null;
+          prompt_tokens: number | null;
+          request: string;
+          status: number | null;
+          time_to_first_token: number | null;
+        };
         Insert: {
-          body: Json
-          completion_tokens?: number | null
-          created_at?: string
-          delay_ms?: number | null
-          feedback?: Json | null
-          helicone_org_id?: string | null
-          id?: string
-          model?: string | null
-          prompt_tokens?: number | null
-          request: string
-          status?: number | null
-          time_to_first_token?: number | null
-        }
+          body: Json;
+          completion_tokens?: number | null;
+          created_at?: string;
+          delay_ms?: number | null;
+          feedback?: Json | null;
+          helicone_org_id?: string | null;
+          id?: string;
+          model?: string | null;
+          prompt_tokens?: number | null;
+          request: string;
+          status?: number | null;
+          time_to_first_token?: number | null;
+        };
         Update: {
-          body?: Json
-          completion_tokens?: number | null
-          created_at?: string
-          delay_ms?: number | null
-          feedback?: Json | null
-          helicone_org_id?: string | null
-          id?: string
-          model?: string | null
-          prompt_tokens?: number | null
-          request?: string
-          status?: number | null
-          time_to_first_token?: number | null
-        }
-        Relationships: []
-      }
+          body?: Json;
+          completion_tokens?: number | null;
+          created_at?: string;
+          delay_ms?: number | null;
+          feedback?: Json | null;
+          helicone_org_id?: string | null;
+          id?: string;
+          model?: string | null;
+          prompt_tokens?: number | null;
+          request?: string;
+          status?: number | null;
+          time_to_first_token?: number | null;
+        };
+        Relationships: [];
+      };
       rosetta_mappers: {
         Row: {
-          code: string
-          created_at: string
-          id: string
-          ignored_fields: string[] | null
-          input_json: Json
-          key: string
-          mapped_fields: string[] | null
-          output_schema: Json
-          output_schema_hash: string
-          status: Database["public"]["Enums"]["mapper_status"]
-          updated_at: string
-          version: number
-        }
+          code: string;
+          created_at: string;
+          id: string;
+          ignored_fields: string[] | null;
+          input_json: Json;
+          key: string;
+          mapped_fields: string[] | null;
+          output_schema: Json;
+          output_schema_hash: string;
+          status: Database["public"]["Enums"]["mapper_status"];
+          updated_at: string;
+          version: number;
+        };
         Insert: {
-          code: string
-          created_at?: string
-          id?: string
-          ignored_fields?: string[] | null
-          input_json: Json
-          key: string
-          mapped_fields?: string[] | null
-          output_schema: Json
-          output_schema_hash: string
-          status: Database["public"]["Enums"]["mapper_status"]
-          updated_at?: string
-          version: number
-        }
+          code: string;
+          created_at?: string;
+          id?: string;
+          ignored_fields?: string[] | null;
+          input_json: Json;
+          key: string;
+          mapped_fields?: string[] | null;
+          output_schema: Json;
+          output_schema_hash: string;
+          status: Database["public"]["Enums"]["mapper_status"];
+          updated_at?: string;
+          version: number;
+        };
         Update: {
-          code?: string
-          created_at?: string
-          id?: string
-          ignored_fields?: string[] | null
-          input_json?: Json
-          key?: string
-          mapped_fields?: string[] | null
-          output_schema?: Json
-          output_schema_hash?: string
-          status?: Database["public"]["Enums"]["mapper_status"]
-          updated_at?: string
-          version?: number
-        }
-        Relationships: []
-      }
+          code?: string;
+          created_at?: string;
+          id?: string;
+          ignored_fields?: string[] | null;
+          input_json?: Json;
+          key?: string;
+          mapped_fields?: string[] | null;
+          output_schema?: Json;
+          output_schema_hash?: string;
+          status?: Database["public"]["Enums"]["mapper_status"];
+          updated_at?: string;
+          version?: number;
+        };
+        Relationships: [];
+      };
       score_attribute: {
         Row: {
-          created_at: string | null
-          evaluator_id: string | null
-          id: string
-          organization: string
-          score_key: string
-          value_type: string | null
-        }
+          created_at: string | null;
+          evaluator_id: string | null;
+          id: string;
+          organization: string;
+          score_key: string;
+          value_type: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          evaluator_id?: string | null
-          id?: string
-          organization: string
-          score_key: string
-          value_type?: string | null
-        }
+          created_at?: string | null;
+          evaluator_id?: string | null;
+          id?: string;
+          organization: string;
+          score_key: string;
+          value_type?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          evaluator_id?: string | null
-          id?: string
-          organization?: string
-          score_key?: string
-          value_type?: string | null
-        }
+          created_at?: string | null;
+          evaluator_id?: string | null;
+          id?: string;
+          organization?: string;
+          score_key?: string;
+          value_type?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "fk_organization"
-            columns: ["organization"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
+            foreignKeyName: "fk_organization";
+            columns: ["organization"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "public_score_attribute_evaluator_id_fkey"
-            columns: ["evaluator_id"]
-            isOneToOne: false
-            referencedRelation: "evaluator"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "public_score_attribute_evaluator_id_fkey";
+            columns: ["evaluator_id"];
+            isOneToOne: false;
+            referencedRelation: "evaluator";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       score_value: {
         Row: {
-          created_at: string | null
-          id: string
-          int_value: number | null
-          request_id: string
-          score_attribute: string
-        }
+          created_at: string | null;
+          id: string;
+          int_value: number | null;
+          request_id: string;
+          score_attribute: string;
+        };
         Insert: {
-          created_at?: string | null
-          id?: string
-          int_value?: number | null
-          request_id: string
-          score_attribute: string
-        }
+          created_at?: string | null;
+          id?: string;
+          int_value?: number | null;
+          request_id: string;
+          score_attribute: string;
+        };
         Update: {
-          created_at?: string | null
-          id?: string
-          int_value?: number | null
-          request_id?: string
-          score_attribute?: string
-        }
+          created_at?: string | null;
+          id?: string;
+          int_value?: number | null;
+          request_id?: string;
+          score_attribute?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "fk_request_id"
-            columns: ["request_id"]
-            isOneToOne: false
-            referencedRelation: "request"
-            referencedColumns: ["id"]
+            foreignKeyName: "fk_request_id";
+            columns: ["request_id"];
+            isOneToOne: false;
+            referencedRelation: "request";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "fk_score_attribute"
-            columns: ["score_attribute"]
-            isOneToOne: false
-            referencedRelation: "score_attribute"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "fk_score_attribute";
+            columns: ["score_attribute"];
+            isOneToOne: false;
+            referencedRelation: "score_attribute";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       user_api_keys: {
         Row: {
-          api_key_hash: string
-          api_key_preview: string
-          created_at: string
-          key_name: string | null
-          user_id: string
-        }
+          api_key_hash: string;
+          api_key_preview: string;
+          created_at: string;
+          key_name: string | null;
+          user_id: string;
+        };
         Insert: {
-          api_key_hash: string
-          api_key_preview: string
-          created_at?: string
-          key_name?: string | null
-          user_id: string
-        }
+          api_key_hash: string;
+          api_key_preview: string;
+          created_at?: string;
+          key_name?: string | null;
+          user_id: string;
+        };
         Update: {
-          api_key_hash?: string
-          api_key_preview?: string
-          created_at?: string
-          key_name?: string | null
-          user_id?: string
-        }
+          api_key_hash?: string;
+          api_key_preview?: string;
+          created_at?: string;
+          key_name?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_api_keys_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: "user_api_keys_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "user_api_keys_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users_view"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "user_api_keys_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users_view";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       user_feedback: {
         Row: {
-          created_at: string
-          feedback: string
-          id: number
-          organization_id: string
-          tag: string
-        }
+          created_at: string;
+          feedback: string;
+          id: number;
+          organization_id: string;
+          tag: string;
+        };
         Insert: {
-          created_at?: string
-          feedback: string
-          id?: number
-          organization_id: string
-          tag: string
-        }
+          created_at?: string;
+          feedback: string;
+          id?: number;
+          organization_id: string;
+          tag: string;
+        };
         Update: {
-          created_at?: string
-          feedback?: string
-          id?: number
-          organization_id?: string
-          tag?: string
-        }
+          created_at?: string;
+          feedback?: string;
+          id?: number;
+          organization_id?: string;
+          tag?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_feedback_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "user_feedback_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       user_settings: {
         Row: {
-          created_at: string | null
-          referral_code: string
-          request_limit: number
-          tier: string
-          user: string
-        }
+          created_at: string | null;
+          referral_code: string;
+          request_limit: number;
+          tier: string;
+          user: string;
+        };
         Insert: {
-          created_at?: string | null
-          referral_code?: string
-          request_limit?: number
-          tier?: string
-          user: string
-        }
+          created_at?: string | null;
+          referral_code?: string;
+          request_limit?: number;
+          tier?: string;
+          user: string;
+        };
         Update: {
-          created_at?: string | null
-          referral_code?: string
-          request_limit?: number
-          tier?: string
-          user?: string
-        }
+          created_at?: string | null;
+          referral_code?: string;
+          request_limit?: number;
+          tier?: string;
+          user?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_settings_user_fkey"
-            columns: ["user"]
-            isOneToOne: true
-            referencedRelation: "users"
-            referencedColumns: ["id"]
+            foreignKeyName: "user_settings_user_fkey";
+            columns: ["user"];
+            isOneToOne: true;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "user_settings_user_fkey"
-            columns: ["user"]
-            isOneToOne: true
-            referencedRelation: "users_view"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "user_settings_user_fkey";
+            columns: ["user"];
+            isOneToOne: true;
+            referencedRelation: "users_view";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       webhook_subscriptions: {
         Row: {
-          created_at: string | null
-          event: string
-          id: number
-          payload_type: Json
-          webhook_id: number
-        }
+          created_at: string | null;
+          event: string;
+          id: number;
+          payload_type: Json;
+          webhook_id: number;
+        };
         Insert: {
-          created_at?: string | null
-          event: string
-          id?: number
-          payload_type: Json
-          webhook_id: number
-        }
+          created_at?: string | null;
+          event: string;
+          id?: number;
+          payload_type: Json;
+          webhook_id: number;
+        };
         Update: {
-          created_at?: string | null
-          event?: string
-          id?: number
-          payload_type?: Json
-          webhook_id?: number
-        }
+          created_at?: string | null;
+          event?: string;
+          id?: number;
+          payload_type?: Json;
+          webhook_id?: number;
+        };
         Relationships: [
           {
-            foreignKeyName: "webhook_subscriptions_webhook_id_fkey"
-            columns: ["webhook_id"]
-            isOneToOne: false
-            referencedRelation: "webhooks"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "webhook_subscriptions_webhook_id_fkey";
+            columns: ["webhook_id"];
+            isOneToOne: false;
+            referencedRelation: "webhooks";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       webhooks: {
         Row: {
-          config: Json | null
-          created_at: string | null
-          destination: string
-          hmac_key: string | null
-          id: number
-          is_verified: boolean
-          org_id: string
-          txt_record: string
-          version: string
-        }
+          config: Json | null;
+          created_at: string | null;
+          destination: string;
+          hmac_key: string | null;
+          id: number;
+          is_verified: boolean;
+          org_id: string;
+          txt_record: string;
+          version: string;
+        };
         Insert: {
-          config?: Json | null
-          created_at?: string | null
-          destination: string
-          hmac_key?: string | null
-          id?: number
-          is_verified?: boolean
-          org_id: string
-          txt_record: string
-          version?: string
-        }
+          config?: Json | null;
+          created_at?: string | null;
+          destination: string;
+          hmac_key?: string | null;
+          id?: number;
+          is_verified?: boolean;
+          org_id: string;
+          txt_record: string;
+          version?: string;
+        };
         Update: {
-          config?: Json | null
-          created_at?: string | null
-          destination?: string
-          hmac_key?: string | null
-          id?: number
-          is_verified?: boolean
-          org_id?: string
-          txt_record?: string
-          version?: string
-        }
+          config?: Json | null;
+          created_at?: string | null;
+          destination?: string;
+          hmac_key?: string | null;
+          id?: number;
+          is_verified?: boolean;
+          org_id?: string;
+          txt_record?: string;
+          version?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "webhooks_org_id_fkey"
-            columns: ["org_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-    }
+            foreignKeyName: "webhooks_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+    };
     Views: {
       decrypted_provider_keys: {
         Row: {
-          created_at: string | null
-          decrypted_provider_key: string | null
-          id: string | null
-          key_id: string | null
-          nonce: string | null
-          org_id: string | null
-          provider_key: string | null
-          provider_key_name: string | null
-          provider_name: string | null
-          soft_delete: boolean | null
-          vault_key_id: string | null
-        }
+          created_at: string | null;
+          decrypted_provider_key: string | null;
+          id: string | null;
+          key_id: string | null;
+          nonce: string | null;
+          org_id: string | null;
+          provider_key: string | null;
+          provider_key_name: string | null;
+          provider_name: string | null;
+          soft_delete: boolean | null;
+          vault_key_id: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          decrypted_provider_key?: never
-          id?: string | null
-          key_id?: string | null
-          nonce?: string | null
-          org_id?: string | null
-          provider_key?: string | null
-          provider_key_name?: string | null
-          provider_name?: string | null
-          soft_delete?: boolean | null
-          vault_key_id?: string | null
-        }
+          created_at?: string | null;
+          decrypted_provider_key?: never;
+          id?: string | null;
+          key_id?: string | null;
+          nonce?: string | null;
+          org_id?: string | null;
+          provider_key?: string | null;
+          provider_key_name?: string | null;
+          provider_name?: string | null;
+          soft_delete?: boolean | null;
+          vault_key_id?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          decrypted_provider_key?: never
-          id?: string | null
-          key_id?: string | null
-          nonce?: string | null
-          org_id?: string | null
-          provider_key?: string | null
-          provider_key_name?: string | null
-          provider_name?: string | null
-          soft_delete?: boolean | null
-          vault_key_id?: string | null
-        }
+          created_at?: string | null;
+          decrypted_provider_key?: never;
+          id?: string | null;
+          key_id?: string | null;
+          nonce?: string | null;
+          org_id?: string | null;
+          provider_key?: string | null;
+          provider_key_name?: string | null;
+          provider_name?: string | null;
+          soft_delete?: boolean | null;
+          vault_key_id?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "provider_keys_key_id_fkey"
-            columns: ["key_id"]
-            isOneToOne: false
-            referencedRelation: "key"
-            referencedColumns: ["id"]
+            foreignKeyName: "provider_keys_key_id_fkey";
+            columns: ["key_id"];
+            isOneToOne: false;
+            referencedRelation: "key";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "provider_keys_key_id_fkey"
-            columns: ["key_id"]
-            isOneToOne: false
-            referencedRelation: "decrypted_key"
-            referencedColumns: ["id"]
+            foreignKeyName: "provider_keys_key_id_fkey";
+            columns: ["key_id"];
+            isOneToOne: false;
+            referencedRelation: "decrypted_key";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "provider_keys_key_id_fkey"
-            columns: ["key_id"]
-            isOneToOne: false
-            referencedRelation: "valid_key"
-            referencedColumns: ["id"]
+            foreignKeyName: "provider_keys_key_id_fkey";
+            columns: ["key_id"];
+            isOneToOne: false;
+            referencedRelation: "valid_key";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "provider_keys_org_id_fkey"
-            columns: ["org_id"]
-            isOneToOne: false
-            referencedRelation: "organization"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "provider_keys_org_id_fkey";
+            columns: ["org_id"];
+            isOneToOne: false;
+            referencedRelation: "organization";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       users_view: {
         Row: {
-          created_at: string | null
-          email: string | null
-          id: string | null
-          last_sign_in_at: string | null
-        }
+          created_at: string | null;
+          email: string | null;
+          id: string | null;
+          last_sign_in_at: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          email?: string | null
-          id?: string | null
-          last_sign_in_at?: string | null
-        }
+          created_at?: string | null;
+          email?: string | null;
+          id?: string | null;
+          last_sign_in_at?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          email?: string | null
-          id?: string | null
-          last_sign_in_at?: string | null
-        }
-        Relationships: []
-      }
-    }
+          created_at?: string | null;
+          email?: string | null;
+          id?: string | null;
+          last_sign_in_at?: string | null;
+        };
+        Relationships: [];
+      };
+    };
     Functions: {
       check_request_access: {
         Args: {
-          this_auth_hash: string
-          this_user_id: string
-        }
-        Returns: boolean
-      }
+          this_auth_hash: string;
+          this_user_id: string;
+        };
+        Returns: boolean;
+      };
       check_response_access:
         | {
             Args: {
-              this_associated_request_id: string
-            }
-            Returns: boolean
+              this_associated_request_id: string;
+            };
+            Returns: boolean;
           }
         | {
             Args: {
-              this_associated_request_id: string
-              this_user_id: string
-            }
-            Returns: boolean
-          }
+              this_associated_request_id: string;
+              this_user_id: string;
+            };
+            Returns: boolean;
+          };
       date_count:
         | {
             Args: {
-              time_increment: string
-            }
-            Returns: Record<string, unknown>[]
+              time_increment: string;
+            };
+            Returns: Record<string, unknown>[];
           }
         | {
             Args: {
-              time_increment: string
-              prev_period: string
-            }
-            Returns: Record<string, unknown>[]
-          }
+              time_increment: string;
+              prev_period: string;
+            };
+            Returns: Record<string, unknown>[];
+          };
       ensure_one_demo_org: {
         Args: {
-          user_id: string
-        }
+          user_id: string;
+        };
         Returns: {
-          organization_id: string
-        }[]
-      }
+          organization_id: string;
+        }[];
+      };
       ensure_personal: {
-        Args: Record<PropertyKey, never>
-        Returns: undefined
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: undefined;
+      };
       get_org_id: {
         Args: {
-          request_id: string
-        }
-        Returns: string
-      }
+          request_id: string;
+        };
+        Returns: string;
+      };
       insert_feedback_and_update_response: {
         Args: {
-          response_id: string
-          feedback_metric_id: number
-          boolean_value: boolean
-          numerical_value: number
-          string_value: string
-          categorical_value: string
-          created_by: string
-          name: string
-        }
-        Returns: number
-      }
+          response_id: string;
+          feedback_metric_id: number;
+          boolean_value: boolean;
+          numerical_value: number;
+          string_value: string;
+          categorical_value: string;
+          created_by: string;
+          name: string;
+        };
+        Returns: number;
+      };
       verify_helicone_proxy_key: {
         Args: {
-          api_key: string
-          stored_hashed_key: string
-        }
-        Returns: boolean
-      }
-    }
+          api_key: string;
+          stored_hashed_key: string;
+        };
+        Returns: boolean;
+      };
+    };
     Enums: {
       mapper_status:
         | "PENDING_CREATION"
@@ -2982,330 +2982,330 @@ export type Database = {
         | "ACTIVE"
         | "INACTIVE"
         | "DECLINED"
-        | "FAILED"
-    }
+        | "FAILED";
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
+      [_ in never]: never;
+    };
+  };
   storage: {
     Tables: {
       buckets: {
         Row: {
-          allowed_mime_types: string[] | null
-          avif_autodetection: boolean | null
-          created_at: string | null
-          file_size_limit: number | null
-          id: string
-          name: string
-          owner: string | null
-          owner_id: string | null
-          public: boolean | null
-          updated_at: string | null
-        }
+          allowed_mime_types: string[] | null;
+          avif_autodetection: boolean | null;
+          created_at: string | null;
+          file_size_limit: number | null;
+          id: string;
+          name: string;
+          owner: string | null;
+          owner_id: string | null;
+          public: boolean | null;
+          updated_at: string | null;
+        };
         Insert: {
-          allowed_mime_types?: string[] | null
-          avif_autodetection?: boolean | null
-          created_at?: string | null
-          file_size_limit?: number | null
-          id: string
-          name: string
-          owner?: string | null
-          owner_id?: string | null
-          public?: boolean | null
-          updated_at?: string | null
-        }
+          allowed_mime_types?: string[] | null;
+          avif_autodetection?: boolean | null;
+          created_at?: string | null;
+          file_size_limit?: number | null;
+          id: string;
+          name: string;
+          owner?: string | null;
+          owner_id?: string | null;
+          public?: boolean | null;
+          updated_at?: string | null;
+        };
         Update: {
-          allowed_mime_types?: string[] | null
-          avif_autodetection?: boolean | null
-          created_at?: string | null
-          file_size_limit?: number | null
-          id?: string
-          name?: string
-          owner?: string | null
-          owner_id?: string | null
-          public?: boolean | null
-          updated_at?: string | null
-        }
-        Relationships: []
-      }
+          allowed_mime_types?: string[] | null;
+          avif_autodetection?: boolean | null;
+          created_at?: string | null;
+          file_size_limit?: number | null;
+          id?: string;
+          name?: string;
+          owner?: string | null;
+          owner_id?: string | null;
+          public?: boolean | null;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
       migrations: {
         Row: {
-          executed_at: string | null
-          hash: string
-          id: number
-          name: string
-        }
+          executed_at: string | null;
+          hash: string;
+          id: number;
+          name: string;
+        };
         Insert: {
-          executed_at?: string | null
-          hash: string
-          id: number
-          name: string
-        }
+          executed_at?: string | null;
+          hash: string;
+          id: number;
+          name: string;
+        };
         Update: {
-          executed_at?: string | null
-          hash?: string
-          id?: number
-          name?: string
-        }
-        Relationships: []
-      }
+          executed_at?: string | null;
+          hash?: string;
+          id?: number;
+          name?: string;
+        };
+        Relationships: [];
+      };
       objects: {
         Row: {
-          bucket_id: string | null
-          created_at: string | null
-          id: string
-          last_accessed_at: string | null
-          metadata: Json | null
-          name: string | null
-          owner: string | null
-          owner_id: string | null
-          path_tokens: string[] | null
-          updated_at: string | null
-          user_metadata: Json | null
-          version: string | null
-        }
+          bucket_id: string | null;
+          created_at: string | null;
+          id: string;
+          last_accessed_at: string | null;
+          metadata: Json | null;
+          name: string | null;
+          owner: string | null;
+          owner_id: string | null;
+          path_tokens: string[] | null;
+          updated_at: string | null;
+          user_metadata: Json | null;
+          version: string | null;
+        };
         Insert: {
-          bucket_id?: string | null
-          created_at?: string | null
-          id?: string
-          last_accessed_at?: string | null
-          metadata?: Json | null
-          name?: string | null
-          owner?: string | null
-          owner_id?: string | null
-          path_tokens?: string[] | null
-          updated_at?: string | null
-          user_metadata?: Json | null
-          version?: string | null
-        }
+          bucket_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          last_accessed_at?: string | null;
+          metadata?: Json | null;
+          name?: string | null;
+          owner?: string | null;
+          owner_id?: string | null;
+          path_tokens?: string[] | null;
+          updated_at?: string | null;
+          user_metadata?: Json | null;
+          version?: string | null;
+        };
         Update: {
-          bucket_id?: string | null
-          created_at?: string | null
-          id?: string
-          last_accessed_at?: string | null
-          metadata?: Json | null
-          name?: string | null
-          owner?: string | null
-          owner_id?: string | null
-          path_tokens?: string[] | null
-          updated_at?: string | null
-          user_metadata?: Json | null
-          version?: string | null
-        }
+          bucket_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          last_accessed_at?: string | null;
+          metadata?: Json | null;
+          name?: string | null;
+          owner?: string | null;
+          owner_id?: string | null;
+          path_tokens?: string[] | null;
+          updated_at?: string | null;
+          user_metadata?: Json | null;
+          version?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "objects_bucketId_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "objects_bucketId_fkey";
+            columns: ["bucket_id"];
+            isOneToOne: false;
+            referencedRelation: "buckets";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       s3_multipart_uploads: {
         Row: {
-          bucket_id: string
-          created_at: string
-          id: string
-          in_progress_size: number
-          key: string
-          owner_id: string | null
-          upload_signature: string
-          user_metadata: Json | null
-          version: string
-        }
+          bucket_id: string;
+          created_at: string;
+          id: string;
+          in_progress_size: number;
+          key: string;
+          owner_id: string | null;
+          upload_signature: string;
+          user_metadata: Json | null;
+          version: string;
+        };
         Insert: {
-          bucket_id: string
-          created_at?: string
-          id: string
-          in_progress_size?: number
-          key: string
-          owner_id?: string | null
-          upload_signature: string
-          user_metadata?: Json | null
-          version: string
-        }
+          bucket_id: string;
+          created_at?: string;
+          id: string;
+          in_progress_size?: number;
+          key: string;
+          owner_id?: string | null;
+          upload_signature: string;
+          user_metadata?: Json | null;
+          version: string;
+        };
         Update: {
-          bucket_id?: string
-          created_at?: string
-          id?: string
-          in_progress_size?: number
-          key?: string
-          owner_id?: string | null
-          upload_signature?: string
-          user_metadata?: Json | null
-          version?: string
-        }
+          bucket_id?: string;
+          created_at?: string;
+          id?: string;
+          in_progress_size?: number;
+          key?: string;
+          owner_id?: string | null;
+          upload_signature?: string;
+          user_metadata?: Json | null;
+          version?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "s3_multipart_uploads_bucket_id_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
+            foreignKeyName: "s3_multipart_uploads_bucket_id_fkey";
+            columns: ["bucket_id"];
+            isOneToOne: false;
+            referencedRelation: "buckets";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
       s3_multipart_uploads_parts: {
         Row: {
-          bucket_id: string
-          created_at: string
-          etag: string
-          id: string
-          key: string
-          owner_id: string | null
-          part_number: number
-          size: number
-          upload_id: string
-          version: string
-        }
+          bucket_id: string;
+          created_at: string;
+          etag: string;
+          id: string;
+          key: string;
+          owner_id: string | null;
+          part_number: number;
+          size: number;
+          upload_id: string;
+          version: string;
+        };
         Insert: {
-          bucket_id: string
-          created_at?: string
-          etag: string
-          id?: string
-          key: string
-          owner_id?: string | null
-          part_number: number
-          size?: number
-          upload_id: string
-          version: string
-        }
+          bucket_id: string;
+          created_at?: string;
+          etag: string;
+          id?: string;
+          key: string;
+          owner_id?: string | null;
+          part_number: number;
+          size?: number;
+          upload_id: string;
+          version: string;
+        };
         Update: {
-          bucket_id?: string
-          created_at?: string
-          etag?: string
-          id?: string
-          key?: string
-          owner_id?: string | null
-          part_number?: number
-          size?: number
-          upload_id?: string
-          version?: string
-        }
+          bucket_id?: string;
+          created_at?: string;
+          etag?: string;
+          id?: string;
+          key?: string;
+          owner_id?: string | null;
+          part_number?: number;
+          size?: number;
+          upload_id?: string;
+          version?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "s3_multipart_uploads_parts_bucket_id_fkey"
-            columns: ["bucket_id"]
-            isOneToOne: false
-            referencedRelation: "buckets"
-            referencedColumns: ["id"]
+            foreignKeyName: "s3_multipart_uploads_parts_bucket_id_fkey";
+            columns: ["bucket_id"];
+            isOneToOne: false;
+            referencedRelation: "buckets";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "s3_multipart_uploads_parts_upload_id_fkey"
-            columns: ["upload_id"]
-            isOneToOne: false
-            referencedRelation: "s3_multipart_uploads"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-    }
+            foreignKeyName: "s3_multipart_uploads_parts_upload_id_fkey";
+            columns: ["upload_id"];
+            isOneToOne: false;
+            referencedRelation: "s3_multipart_uploads";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
       can_insert_object: {
         Args: {
-          bucketid: string
-          name: string
-          owner: string
-          metadata: Json
-        }
-        Returns: undefined
-      }
+          bucketid: string;
+          name: string;
+          owner: string;
+          metadata: Json;
+        };
+        Returns: undefined;
+      };
       extension: {
         Args: {
-          name: string
-        }
-        Returns: string
-      }
+          name: string;
+        };
+        Returns: string;
+      };
       filename: {
         Args: {
-          name: string
-        }
-        Returns: string
-      }
+          name: string;
+        };
+        Returns: string;
+      };
       foldername: {
         Args: {
-          name: string
-        }
-        Returns: unknown
-      }
+          name: string;
+        };
+        Returns: unknown;
+      };
       get_size_by_bucket: {
-        Args: Record<PropertyKey, never>
+        Args: Record<PropertyKey, never>;
         Returns: {
-          size: number
-          bucket_id: string
-        }[]
-      }
+          size: number;
+          bucket_id: string;
+        }[];
+      };
       list_multipart_uploads_with_delimiter: {
         Args: {
-          bucket_id: string
-          prefix_param: string
-          delimiter_param: string
-          max_keys?: number
-          next_key_token?: string
-          next_upload_token?: string
-        }
+          bucket_id: string;
+          prefix_param: string;
+          delimiter_param: string;
+          max_keys?: number;
+          next_key_token?: string;
+          next_upload_token?: string;
+        };
         Returns: {
-          key: string
-          id: string
-          created_at: string
-        }[]
-      }
+          key: string;
+          id: string;
+          created_at: string;
+        }[];
+      };
       list_objects_with_delimiter: {
         Args: {
-          bucket_id: string
-          prefix_param: string
-          delimiter_param: string
-          max_keys?: number
-          start_after?: string
-          next_token?: string
-        }
+          bucket_id: string;
+          prefix_param: string;
+          delimiter_param: string;
+          max_keys?: number;
+          start_after?: string;
+          next_token?: string;
+        };
         Returns: {
-          name: string
-          id: string
-          metadata: Json
-          updated_at: string
-        }[]
-      }
+          name: string;
+          id: string;
+          metadata: Json;
+          updated_at: string;
+        }[];
+      };
       operation: {
-        Args: Record<PropertyKey, never>
-        Returns: string
-      }
+        Args: Record<PropertyKey, never>;
+        Returns: string;
+      };
       search: {
         Args: {
-          prefix: string
-          bucketname: string
-          limits?: number
-          levels?: number
-          offsets?: number
-          search?: string
-          sortcolumn?: string
-          sortorder?: string
-        }
+          prefix: string;
+          bucketname: string;
+          limits?: number;
+          levels?: number;
+          offsets?: number;
+          search?: string;
+          sortcolumn?: string;
+          sortorder?: string;
+        };
         Returns: {
-          name: string
-          id: string
-          updated_at: string
-          created_at: string
-          last_accessed_at: string
-          metadata: Json
-        }[]
-      }
-    }
+          name: string;
+          id: string;
+          updated_at: string;
+          created_at: string;
+          last_accessed_at: string;
+          metadata: Json;
+        }[];
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type PublicSchema = Database[Extract<keyof Database, "public">]
+type PublicSchema = Database[Extract<keyof Database, "public">];
 
 export type Tables<
   PublicTableNameOrOptions extends
@@ -3314,23 +3314,23 @@ export type Tables<
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
         Database[PublicTableNameOrOptions["schema"]]["Views"])
-    : never = never,
+    : never = never
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
       Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+      Row: infer R;
     }
     ? R
     : never
   : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
-        PublicSchema["Views"])
-    ? (PublicSchema["Tables"] &
-        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
-        Row: infer R
-      }
-      ? R
-      : never
+      PublicSchema["Views"])
+  ? (PublicSchema["Tables"] &
+      PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+      Row: infer R;
+    }
+    ? R
     : never
+  : never;
 
 export type TablesInsert<
   PublicTableNameOrOptions extends
@@ -3338,20 +3338,20 @@ export type TablesInsert<
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+    : never = never
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+      Insert: infer I;
     }
     ? I
     : never
   : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-        Insert: infer I
-      }
-      ? I
-      : never
+  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+      Insert: infer I;
+    }
+    ? I
     : never
+  : never;
 
 export type TablesUpdate<
   PublicTableNameOrOptions extends
@@ -3359,20 +3359,20 @@ export type TablesUpdate<
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+    : never = never
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+      Update: infer U;
     }
     ? U
     : never
   : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-        Update: infer U
-      }
-      ? U
-      : never
+  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+      Update: infer U;
+    }
+    ? U
     : never
+  : never;
 
 export type Enums<
   PublicEnumNameOrOptions extends
@@ -3380,10 +3380,9 @@ export type Enums<
     | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
-    : never = never,
+    : never = never
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
-    : never
-
+  ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+  : never;

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -66,6 +66,7 @@ routes = [
 	{ pattern = "nebius.helicone.ai", custom_domain = true, zone_name = "helicone.ai" },
 	{ pattern = "perplexity.helicone.ai", custom_domain = true, zone_name = "helicone.ai" },
 	{ pattern = "novita.helicone.ai", custom_domain = true, zone_name = "helicone.ai" },
+	{ pattern = "generate.helicone.ai", custom_domain = true, zone_name = "helicone.ai" },
 
 	{ pattern = "oai.us.helicone.ai", custom_domain = true, zone_name = "helicone.ai" },
 	{ pattern = "anthropic.us.helicone.ai", custom_domain = true, zone_name = "helicone.ai" },
@@ -169,6 +170,7 @@ kv_namespaces = [
 	{ binding = "REQUEST_AND_RESPONSE_QUEUE_KV", id = "cf75f1c978d14eaeabc4483662688ab4", preview_id = "cf75f1c978d14eaeabc4483662688ab4" },
 	{ binding = "SECURE_CACHE", id = "23d7b3cb44254e0eb0b824a310abe155" },
 	{ binding = "EU_SECURE_CACHE", id = "a0243398352c4ea996e5bf4008938285" },
+	# TODO: Add prompts table
 ]
 
 durable_objects.bindings = [


### PR DESCRIPTION
Example usage:
```
payload = {
          # Prompt Info
          "promptId": "new-prompt",
          "version": "production",
          "inputs": {
              "num": "10",
          },
          # Helicone Properties
          "userId": "test-user",
          "sessionId": SESSION_ID,
}
headers = {
    # Helicone Auth
    "Helicone-Auth": f"Bearer {os.getenv('HELICONE_API_KEY')}",
    # Provider Keys
    "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY"),
    "ANTHROPIC_API_KEY": os.getenv("ANTHROPIC_API_KEY"),
    "GOOGLE_API_KEY": os.getenv("GOOGLE_GENERATIVE_API_KEY"),
    "COHERE_API_KEY": os.getenv("COHERE_API_KEY"),
    "MISTRAL_API_KEY": os.getenv("MISTRAL_API_KEY"),
}
response = requests.post(generate_url, json=payload, headers=headers)
```

Planned in next version:
- Add reverse mapper for anthropic, and other api paths
- Add support for anthropic, and other api paths