### PR TITLE
TogetherAI SDK support Helicone Async

### DIFF
--- a/sdk/typescript/async/.gitignore
+++ b/sdk/typescript/async/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 .yarn/
 
 /dist
+
+.yalc/

--- a/sdk/typescript/async/README.md
+++ b/sdk/typescript/async/README.md
@@ -1,0 +1,145 @@
+# @helicone/async
+
+A Node.js wrapper for logging LLM traces directly to Helicone, bypassing the proxy, with OpenLLMetry. This package enables you to monitor and analyze your OpenAI API usage without requiring a proxy server.
+
+## Features
+
+- Direct logging to Helicone without proxy
+- OpenLLMetry support for standardized LLM telemetry
+- Custom property tracking
+- Environment variable configuration
+- TypeScript support
+
+## Installation
+
+### Stable Version
+
+```bash
+npm install @helicone/async
+```
+
+## Quick Start
+
+1. Create a Helicone account and get your API key from [helicone.ai/developer](https://helicone.ai/developer)
+
+2. Set up your environment variables:
+
+```bash
+export HELICONE_API_KEY=<your API key>
+export OPENAI_API_KEY=<your OpenAI API key>
+```
+
+3. Basic usage:
+
+```typescript
+const { HeliconeAsyncOpenAI } = require("helicone");
+
+const openai = new HeliconeAsyncOpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+  heliconeMeta: {
+    apiKey: process.env.HELICONE_API_KEY,
+  },
+});
+
+const chatCompletion = await openai.chat.completion.create({
+  model: "gpt-3.5-turbo",
+  messages: [{ role: "user", content: "Hello world" }],
+});
+
+console.log(chatCompletion.data.choices[0].message);
+```
+
+## Configuration Options
+
+### HeliconeMeta Options
+
+The `heliconeMeta` object supports several configuration options:
+
+```typescript
+interface HeliconeMeta {
+  apiKey?: string; // Your Helicone API key
+  custom_properties?: Record<string, any>; // Custom properties to track
+  cache?: boolean; // Enable/disable caching
+  retry?: boolean; // Enable/disable retries
+  user_id?: string; // Track requests by user
+}
+```
+
+### Example with Custom Properties
+
+```typescript
+const openai = new HeliconeAsyncOpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+  heliconeMeta: {
+    apiKey: process.env.HELICONE_API_KEY,
+    custom_properties: {
+      project: "my-project",
+      environment: "production",
+    },
+    user_id: "user-123",
+  },
+});
+```
+
+## Advanced Usage
+
+### With Async/Await
+
+```typescript
+async function generateResponse() {
+  try {
+    const response = await openai.chat.completion.create({
+      model: "gpt-4",
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "What is the capital of France?" },
+      ],
+      max_tokens: 150,
+    });
+
+    return response.data.choices[0].message;
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}
+```
+
+### Error Handling
+
+```typescript
+try {
+  const completion = await openai.chat.completion.create({
+    model: "gpt-3.5-turbo",
+    messages: [{ role: "user", content: "Hello" }],
+  });
+} catch (error) {
+  if (error.response) {
+    console.error(error.response.status);
+    console.error(error.response.data);
+  } else {
+    console.error(error.message);
+  }
+}
+```
+
+## Best Practices
+
+1. Always store API keys in environment variables
+2. Implement proper error handling
+3. Use custom properties to track important metadata
+4. Set appropriate timeout values for your use case
+5. Consider implementing retry logic for production environments
+
+## Contributing
+
+We welcome contributions! Please see our [contributing guidelines](CONTRIBUTING.md) for details.
+
+## License
+
+[Add your license information here]
+
+## Support
+
+- Documentation: [https://docs.helicone.ai](https://docs.helicone.ai)
+- Issues: [GitHub Issues](https://github.com/helicone/helicone/issues)
+- Discord: [Join our community](https://discord.gg/zsSTcH2qhG)

--- a/sdk/typescript/async/README.md
+++ b/sdk/typescript/async/README.md
@@ -136,7 +136,7 @@ We welcome contributions! Please see our [contributing guidelines](CONTRIBUTING.
 
 ## License
 
-[Add your license information here]
+Apache-2.0
 
 ## Support
 

--- a/sdk/typescript/async/async_logger/HeliconeAsyncLogger.ts
+++ b/sdk/typescript/async/async_logger/HeliconeAsyncLogger.ts
@@ -7,6 +7,7 @@ import * as azureOpenAI from "@azure/openai";
 import * as cohere from "cohere-ai";
 import * as bedrock from "@aws-sdk/client-bedrock-runtime";
 import * as google_aiplatform from "@google-cloud/aiplatform";
+import Together from "together-ai";
 import * as ChainsModule from "langchain/chains";
 import * as AgentsModule from "langchain/agents";
 import * as ToolsModule from "langchain/tools";
@@ -21,6 +22,7 @@ type IHeliconeAsyncLoggerOptions = {
     cohere?: typeof cohere;
     bedrock?: typeof bedrock;
     google_aiplatform?: typeof google_aiplatform;
+    together?: typeof Together;
     langchain?: {
       chainsModule?: typeof ChainsModule;
       agentsModule?: typeof AgentsModule;
@@ -36,6 +38,7 @@ export class HeliconeAsyncLogger {
   private openAI?: typeof OpenAI;
   private anthropic?: typeof anthropic;
   private azureOpenAI?: typeof azureOpenAI;
+  private together?: typeof Together;
   private cohere?: typeof cohere;
   private bedrock?: typeof bedrock;
   private google_aiplatform?: typeof google_aiplatform;
@@ -53,6 +56,7 @@ export class HeliconeAsyncLogger {
     this.cohere = opts.providers?.cohere ?? undefined;
     this.bedrock = opts.providers?.bedrock ?? undefined;
     this.google_aiplatform = opts.providers?.google_aiplatform ?? undefined;
+    this.together = opts.providers?.together ?? undefined;
     this.chainsModule = opts.providers?.langchain?.chainsModule ?? undefined;
     this.agentsModule = opts.providers?.langchain?.agentsModule ?? undefined;
     this.toolsModule = opts.providers?.langchain?.toolsModule ?? undefined;
@@ -78,6 +82,7 @@ export class HeliconeAsyncLogger {
         cohere: this.cohere ?? undefined,
         bedrock: this.bedrock ?? undefined,
         google_aiplatform: this.google_aiplatform ?? undefined,
+        together: this.together ?? undefined,
         langchain: {
           chainsModule: this.chainsModule ?? undefined,
           agentsModule: this.agentsModule ?? undefined,

--- a/sdk/typescript/async/package-lock.json
+++ b/sdk/typescript/async/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@helicone/async",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helicone/async",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@traceloop/node-server-sdk": "^0.11.2"
+        "@traceloop/node-server-sdk": "file:.yalc/@traceloop/node-server-sdk"
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.22.0",
@@ -35,8 +35,65 @@
         "nock": "^13.5.4",
         "openai": "^4.48.3",
         "prettier": "^2.8.8",
+        "together-ai": "^0.13.0",
         "ts-jest": "^29.1.0",
         "typescript": "^5.2.2"
+      }
+    },
+    ".yalc/@traceloop/node-server-sdk": {
+      "version": "0.12.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.56.0",
+        "@opentelemetry/sdk-node": "^0.56.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
+        "@traceloop/instrumentation-anthropic": "^0.12.0",
+        "@traceloop/instrumentation-azure": "^0.12.0",
+        "@traceloop/instrumentation-bedrock": "^0.12.0",
+        "@traceloop/instrumentation-chromadb": "^0.12.0",
+        "@traceloop/instrumentation-cohere": "^0.12.0",
+        "@traceloop/instrumentation-langchain": "^0.12.0",
+        "@traceloop/instrumentation-llamaindex": "^0.12.0",
+        "@traceloop/instrumentation-openai": "^0.12.0",
+        "@traceloop/instrumentation-pinecone": "^0.12.0",
+        "@traceloop/instrumentation-qdrant": "^0.12.0",
+        "@traceloop/instrumentation-vertexai": "^0.12.0",
+        "@types/nunjucks": "^3.2.6",
+        "cross-fetch": "^4.0.0",
+        "fetch-retry": "^5.0.6",
+        "nunjucks": "^3.2.4",
+        "posthog-node": "^3.6.3",
+        "supports-color": "^8.1.1",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    ".yalc/@traceloop/node-server-sdk/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    ".yalc/@traceloop/node-server-sdk/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2967,22 +3024,20 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
-      "license": "Apache-2.0",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.56.0.tgz",
+      "integrity": "sha512-Wr39+94UNNG3Ei9nv3pHd4AJ63gq5nSemMRpCd8fPwDL9rN3vK26lzxfH27mw16XzOSO+TpyQwBAMaLxaPWG0g==",
       "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.26.0.tgz",
-      "integrity": "sha512-HedpXXYzzbaoutw6DFLWLDket2FwLkLpil4hGCZ1xYEIMTcivdfwEOISgdbLEWyG3HW52gTq2V9mOVJrONgiwg==",
-      "license": "Apache-2.0",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.29.0.tgz",
+      "integrity": "sha512-TKT91jcFXgHyIDF1lgJF3BHGIakn6x0Xp7Tq3zoS3TMPzT9IlP0xEavWP8C1zGjU9UmZP2VR1tJhW9Az1A3w8Q==",
       "engines": {
         "node": ">=14"
       },
@@ -2991,12 +3046,11 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
-      "integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
-      "license": "Apache-2.0",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.29.0.tgz",
+      "integrity": "sha512-gmT7vAreXl0DTHD2rVZcw3+l2g84+5XiHIqdBUxXbExymPCvSsGOpiwMmn8nkiJur28STV31wnhIDrzWDPzjfA==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -3006,132 +3060,125 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.53.0.tgz",
-      "integrity": "sha512-x5ygAQgWAQOI+UOhyV3z9eW7QU2dCfnfOuIBiyYmC2AWr74f6x/3JBnP27IAcEx6aihpqBYWKnpoUTztkVPAZw==",
-      "license": "Apache-2.0",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.56.0.tgz",
+      "integrity": "sha512-/ef8wcphVKZ0uI7A1oqQI/gEMiBUlkeBkM9AGx6AviQFIbgPVSdNK3+bHBkyq5qMkyWgkeQCSJ0uhc5vJpf0dw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.53.0",
-        "@opentelemetry/otlp-transformer": "0.53.0",
-        "@opentelemetry/sdk-logs": "0.53.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/sdk-logs": "0.56.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.53.0.tgz",
-      "integrity": "sha512-cSRKgD/n8rb+Yd+Cif6EnHEL/VZg1o8lEcEwFji1lwene6BdH51Zh3feAD9p2TyVoBKrl6Q9Zm2WltSp2k9gWQ==",
-      "license": "Apache-2.0",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.56.0.tgz",
+      "integrity": "sha512-gN/itg2B30pa+yAqiuIHBCf3E77sSBlyWVzb+U/MDLzEMOwfnexlMvOWULnIO1l2xR2MNLEuPCQAOrL92JHEJg==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.53.0",
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/otlp-exporter-base": "0.53.0",
-        "@opentelemetry/otlp-transformer": "0.53.0",
-        "@opentelemetry/sdk-logs": "0.53.0"
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/sdk-logs": "0.56.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.53.0.tgz",
-      "integrity": "sha512-jhEcVL1deeWNmTUP05UZMriZPSWUBcfg94ng7JuBb1q2NExgnADQFl1VQQ+xo62/JepK+MxQe4xAwlsDQFbISA==",
-      "license": "Apache-2.0",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.56.0.tgz",
+      "integrity": "sha512-MaO+eGrdksd8MpEbDDLbWegHc3w6ualZV6CENxNOm3wqob0iOx78/YL2NVIKyP/0ktTUIs7xIppUYqfY3ogFLQ==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.53.0",
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/otlp-exporter-base": "0.53.0",
-        "@opentelemetry/otlp-transformer": "0.53.0",
-        "@opentelemetry/resources": "1.26.0",
-        "@opentelemetry/sdk-logs": "0.53.0",
-        "@opentelemetry/sdk-trace-base": "1.26.0"
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-logs": "0.56.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.53.0.tgz",
-      "integrity": "sha512-m6KSh6OBDwfDjpzPVbuJbMgMbkoZfpxYH2r262KckgX9cMYvooWXEKzlJYsNDC6ADr28A1rtRoUVRwNfIN4tUg==",
-      "license": "Apache-2.0",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.56.0.tgz",
+      "integrity": "sha512-9hRHue78CV2XShAt30HadBK8XEtOBiQmnkYquR1RQyf2RYIdJvhiypEZ+Jh3NGW8Qi14icTII/1oPTQlhuyQdQ==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.53.0",
-        "@opentelemetry/otlp-transformer": "0.53.0",
-        "@opentelemetry/resources": "1.26.0",
-        "@opentelemetry/sdk-trace-base": "1.26.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.53.0.tgz",
-      "integrity": "sha512-m7F5ZTq+V9mKGWYpX8EnZ7NjoqAU7VemQ1E2HAG+W/u0wpY1x0OmbxAXfGKFHCspdJk8UKlwPGrpcB8nay3P8A==",
-      "license": "Apache-2.0",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.56.0.tgz",
+      "integrity": "sha512-vqVuJvcwameA0r0cNrRzrZqPLB0otS+95g0XkZdiKOXUo81wYdY6r4kyrwz4nSChqTBEFm0lqi/H2OWGboOa6g==",
       "dependencies": {
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/otlp-exporter-base": "0.53.0",
-        "@opentelemetry/otlp-transformer": "0.53.0",
-        "@opentelemetry/resources": "1.26.0",
-        "@opentelemetry/sdk-trace-base": "1.26.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.53.0.tgz",
-      "integrity": "sha512-T/bdXslwRKj23S96qbvGtaYOdfyew3TjPEKOk5mHjkCmkVl1O9C/YMdejwSsdLdOq2YW30KjR9kVi0YMxZushQ==",
-      "license": "Apache-2.0",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.56.0.tgz",
+      "integrity": "sha512-UYVtz8Kp1QZpZFg83ZrnwRIxF2wavNyi1XaIKuQNFjlYuGCh8JH4+GOuHUU4G8cIzOkWdjNR559vv0Q+MCz+1w==",
       "dependencies": {
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/otlp-exporter-base": "0.53.0",
-        "@opentelemetry/otlp-transformer": "0.53.0",
-        "@opentelemetry/resources": "1.26.0",
-        "@opentelemetry/sdk-trace-base": "1.26.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.26.0.tgz",
-      "integrity": "sha512-PW5R34n3SJHO4t0UetyHKiXL6LixIqWN6lWncg3eRXhKuT30x+b7m5sDJS0kEWRfHeS+kG7uCw2vBzmB2lk3Dw==",
-      "license": "Apache-2.0",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.29.0.tgz",
+      "integrity": "sha512-9wNUxbl/sju2AvA3UhL2kLF1nfhJ4dVJgvktc3hx80Bg/fWHvF6ik4R3woZ/5gYFqZ97dcuik0dWPQEzLPNBtg==",
       "dependencies": {
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/resources": "1.26.0",
-        "@opentelemetry/sdk-trace-base": "1.26.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -3141,12 +3188,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
-      "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
-      "license": "Apache-2.0",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.56.0.tgz",
+      "integrity": "sha512-2KkGBKE+FPXU1F0zKww+stnlUxUTlBvLCiWdP63Z9sqXYeNI/ziNzsxAp4LAdUcTQmXjw1IWgvm5CAb/BHy99w==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/api-logs": "0.56.0",
         "@types/shimmer": "^1.2.0",
         "import-in-the-middle": "^1.8.1",
         "require-in-the-middle": "^7.1.1",
@@ -3161,10 +3207,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3173,51 +3218,48 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.53.0.tgz",
-      "integrity": "sha512-UCWPreGQEhD6FjBaeDuXhiMf6kkBODF0ZQzrk/tuQcaVDJ+dDQ/xhJp192H9yWnKxVpEjFrSSLnpqmX4VwX+eA==",
-      "license": "Apache-2.0",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.56.0.tgz",
+      "integrity": "sha512-eURvv0fcmBE+KE1McUeRo+u0n18ZnUeSc7lDlW/dzlqFYasEbsztTK4v0Qf8C4vEY+aMTjPKUxBG0NX2Te3Pmw==",
       "dependencies": {
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/otlp-transformer": "0.53.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-transformer": "0.56.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.53.0.tgz",
-      "integrity": "sha512-F7RCN8VN+lzSa4fGjewit8Z5fEUpY/lmMVy5EWn2ZpbAabg3EE3sCLuTNfOiooNGnmvzimUPruoeqeko/5/TzQ==",
-      "license": "Apache-2.0",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.56.0.tgz",
+      "integrity": "sha512-QqM4si8Ew8CW5xVk4mYbfusJzMXyk6tkYA5SI0w/5NBxmiZZaYPwQQ2cu58XUH2IMPAsi71yLJVJQaWBBCta0A==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/otlp-exporter-base": "0.53.0",
-        "@opentelemetry/otlp-transformer": "0.53.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.53.0.tgz",
-      "integrity": "sha512-rM0sDA9HD8dluwuBxLetUmoqGJKSAbWenwD65KY9iZhUxdBHRLrIdrABfNDP7aiTjcgK8XFyTn5fhDz7N+W6DA==",
-      "license": "Apache-2.0",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.56.0.tgz",
+      "integrity": "sha512-kVkH/W2W7EpgWWpyU5VnnjIdSD7Y7FljQYObAQSKdRcejiwMj2glypZtUdfq1LTJcv4ht0jyTrw1D3CCxssNtQ==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.53.0",
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/resources": "1.26.0",
-        "@opentelemetry/sdk-logs": "0.53.0",
-        "@opentelemetry/sdk-metrics": "1.26.0",
-        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-logs": "0.56.0",
+        "@opentelemetry/sdk-metrics": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
         "protobufjs": "^7.3.0"
       },
       "engines": {
@@ -3228,12 +3270,11 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.26.0.tgz",
-      "integrity": "sha512-vvVkQLQ/lGGyEy9GT8uFnI047pajSOVnZI2poJqVGD3nJ+B9sFGdlHNnQKophE3lHfnIH0pw2ubrCTjZCgIj+Q==",
-      "license": "Apache-2.0",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.29.0.tgz",
+      "integrity": "sha512-ktsNDlqhu+/IPGEJRMj81upg2JupUp+SwW3n1ZVZTnrDiYUiMUW41vhaziA7Q6UDhbZvZ58skDpQhe2ZgNIPvg==",
       "dependencies": {
-        "@opentelemetry/core": "1.26.0"
+        "@opentelemetry/core": "1.29.0"
       },
       "engines": {
         "node": ">=14"
@@ -3243,12 +3284,11 @@
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.26.0.tgz",
-      "integrity": "sha512-DelFGkCdaxA1C/QA0Xilszfr0t4YbGd3DjxiCDPh34lfnFr+VkkrjV9S8ZTJvAzfdKERXhfOxIKBoGPJwoSz7Q==",
-      "license": "Apache-2.0",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.29.0.tgz",
+      "integrity": "sha512-EXIEYmFgybnFMijVgqx1mq/diWwSQcd0JWVksytAVQEnAiaDvP45WuncEVQkFIAC0gVxa2+Xr8wL5pF5jCVKbg==",
       "dependencies": {
-        "@opentelemetry/core": "1.26.0"
+        "@opentelemetry/core": "1.29.0"
       },
       "engines": {
         "node": ">=14"
@@ -3258,13 +3298,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.26.0.tgz",
-      "integrity": "sha512-CPNYchBE7MBecCSVy0HKpUISEeJOniWqcHaAHpmasZ3j9o6V3AyBzhRc90jdmemq0HOxDr6ylhUbDhBqqPpeNw==",
-      "license": "Apache-2.0",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.29.0.tgz",
+      "integrity": "sha512-s7mLXuHZE7RQr1wwweGcaRp3Q4UJJ0wazeGlc/N5/XSe6UyXfsh1UQGMADYeg7YwD+cEdMtU1yJAUXdnFzYzyQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -3274,14 +3313,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.53.0.tgz",
-      "integrity": "sha512-dhSisnEgIj/vJZXZV6f6KcTnyLDx/VuQ6l3ejuZpMpPlh9S1qMHiZU9NMmOkVkwwHkMy3G6mEBwdP23vUZVr4g==",
-      "license": "Apache-2.0",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.56.0.tgz",
+      "integrity": "sha512-OS0WPBJF++R/cSl+terUjQH5PebloidB1Jbbecgg2rnCmQbTST9xsRes23bLfDQVRvmegmHqDh884h0aRdJyLw==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.53.0",
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/resources": "1.26.0"
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0"
       },
       "engines": {
         "node": ">=14"
@@ -3291,13 +3329,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.26.0.tgz",
-      "integrity": "sha512-0SvDXmou/JjzSDOjUmetAAvcKQW6ZrvosU0rkbDGpXvvZN+pQF6JbK/Kd4hNdK4q/22yeruqvukXEJyySTzyTQ==",
-      "license": "Apache-2.0",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.29.0.tgz",
+      "integrity": "sha512-MkVtuzDjXZaUJSuJlHn6BSXjcQlMvHcsDV7LjY4P6AJeffMa4+kIGDjzsCf6DkAh6Vqlwag5EWEam3KZOX5Drw==",
       "dependencies": {
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/resources": "1.26.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0"
       },
       "engines": {
         "node": ">=14"
@@ -3307,27 +3344,26 @@
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.53.0.tgz",
-      "integrity": "sha512-0hsxfq3BKy05xGktwG8YdGdxV978++x40EAKyKr1CaHZRh8uqVlXnclnl7OMi9xLMJEcXUw7lGhiRlArFcovyg==",
-      "license": "Apache-2.0",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.56.0.tgz",
+      "integrity": "sha512-FOY7tWboBBxqftLNHPJFmDXo9fRoPd2PlzfEvSd6058BJM9gY4pWCg8lbVlu03aBrQjcfCTAhXk/tz1Yqd/m6g==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.53.0",
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/exporter-logs-otlp-grpc": "0.53.0",
-        "@opentelemetry/exporter-logs-otlp-http": "0.53.0",
-        "@opentelemetry/exporter-logs-otlp-proto": "0.53.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.53.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.53.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.53.0",
-        "@opentelemetry/exporter-zipkin": "1.26.0",
-        "@opentelemetry/instrumentation": "0.53.0",
-        "@opentelemetry/resources": "1.26.0",
-        "@opentelemetry/sdk-logs": "0.53.0",
-        "@opentelemetry/sdk-metrics": "1.26.0",
-        "@opentelemetry/sdk-trace-base": "1.26.0",
-        "@opentelemetry/sdk-trace-node": "1.26.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.56.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.56.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.56.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.56.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.56.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.56.0",
+        "@opentelemetry/exporter-zipkin": "1.29.0",
+        "@opentelemetry/instrumentation": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-logs": "0.56.0",
+        "@opentelemetry/sdk-metrics": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
+        "@opentelemetry/sdk-trace-node": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -3337,14 +3373,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.26.0.tgz",
-      "integrity": "sha512-olWQldtvbK4v22ymrKLbIcBi9L2SpMO84sCPY54IVsJhP9fRsxJT194C/AVaAuJzLE30EdhhM1VmvVYR7az+cw==",
-      "license": "Apache-2.0",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.29.0.tgz",
+      "integrity": "sha512-hEOpAYLKXF3wGJpXOtWsxEtqBgde0SCv+w+jvr3/UusR4ll3QrENEGnSl1WDCyRrpqOQ5NCNOvZch9UFVa7MnQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/resources": "1.26.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -3354,16 +3389,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.26.0.tgz",
-      "integrity": "sha512-Fj5IVKrj0yeUwlewCRwzOVcr5avTuNnMHWf7GPc1t6WaT78J6CJyF3saZ/0RkZfdeNO8IcBl/bNcWMVZBMRW8Q==",
-      "license": "Apache-2.0",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.29.0.tgz",
+      "integrity": "sha512-ZpGYt+VnMu6O0SRKzhuIivr7qJm3GpWnTCMuJspu4kt3QWIpIenwixo5Vvjuu3R4h2Onl/8dtqAiPIs92xd5ww==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.26.0",
-        "@opentelemetry/core": "1.26.0",
-        "@opentelemetry/propagator-b3": "1.26.0",
-        "@opentelemetry/propagator-jaeger": "1.26.0",
-        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/context-async-hooks": "1.29.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/propagator-b3": "1.29.0",
+        "@opentelemetry/propagator-jaeger": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -3374,10 +3408,9 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3386,10 +3419,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "license": "Apache-2.0",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
       "engines": {
         "node": ">=14"
       }
@@ -4213,253 +4245,185 @@
       }
     },
     "node_modules/@traceloop/ai-semantic-conventions": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@traceloop/ai-semantic-conventions/-/ai-semantic-conventions-0.11.0.tgz",
-      "integrity": "sha512-KTnLq44GMj3dygUOrI+v2C2gwiICHqZPeTzazQxQOjsovlTRlpjNJnxu/PNrKwmlqqAg6UfJh8wXUObO5FFCMg==",
-      "license": "Apache-2.0",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/ai-semantic-conventions/-/ai-semantic-conventions-0.12.0.tgz",
+      "integrity": "sha512-wbdXK+q+gU6ciREe/0vdEz4cG0uyYC3WNZ2oOKFfU5o+60uIpVsc7A99Iu1iPvhPQAZXnniwih6qXo1SeCAE3A==",
       "dependencies": {
-        "@opentelemetry/api": "^1.7.0"
+        "@opentelemetry/api": "^1.9.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@traceloop/instrumentation-anthropic": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-anthropic/-/instrumentation-anthropic-0.11.1.tgz",
-      "integrity": "sha512-TsVPt8zn/4LnNZjcKzN4D2wxHWuOc0repMAPDm/iaQcT/cSffpwE6CcwNrh2iE+9rLYGGfe9Y5P+CU22r8N9+w==",
-      "license": "Apache-2.0",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-anthropic/-/instrumentation-anthropic-0.12.0.tgz",
+      "integrity": "sha512-LDlwpbuZ0n5M0uwX4RxxsgrifozJn/ULzOCzD7x2Idhsp1kus1lSAHquTL2htmd/BALMvI1As1INaWsYXXre8A==",
       "dependencies": {
-        "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/semantic-conventions": "^1.26.0",
-        "@traceloop/ai-semantic-conventions": "^0.11.0",
-        "tslib": "^2.3.0"
+        "@opentelemetry/core": "^1.29.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@traceloop/instrumentation-azure": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-azure/-/instrumentation-azure-0.11.1.tgz",
-      "integrity": "sha512-p9P2VBNCZyNcy0VidnnsduSuE/AVa5CHN2LMKNMczYS/VBLQ7kXE90zMV354HrRXvVOKAcC7kGViaB3dsARQ7A==",
-      "license": "Apache-2.0",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-azure/-/instrumentation-azure-0.12.0.tgz",
+      "integrity": "sha512-NYxqxOjDB/Xo/LdNC0cfozsXTtyTUou5Qta6wgtW4+cPeVBPMIrlhM4WD88pdwGGOQ9R+A4w9jlHbtRSHYjXug==",
       "dependencies": {
-        "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/semantic-conventions": "^1.26.0",
-        "@traceloop/ai-semantic-conventions": "^0.11.0",
-        "tslib": "^2.3.0"
+        "@opentelemetry/core": "^1.29.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@traceloop/instrumentation-bedrock": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-bedrock/-/instrumentation-bedrock-0.11.1.tgz",
-      "integrity": "sha512-Un7NcwLRUMvGDQTCGdHddOkpkyG+twSz+O82UdizTltZ/VO/CWIu1lHGGFBHVMcom9OrGpA2gXWZWu5/BxI61w==",
-      "license": "Apache-2.0",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-bedrock/-/instrumentation-bedrock-0.12.0.tgz",
+      "integrity": "sha512-RqV81Cg2rcZ2GzeGf+IHVQhB6FrLrROD+YFWMTYmMofg8VlDnx4Qc98XGbnxqnhKNTXyXGU5uVReniMbRx4g+A==",
       "dependencies": {
-        "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/semantic-conventions": "^1.26.0",
-        "@traceloop/ai-semantic-conventions": "^0.11.0",
-        "tslib": "^2.3.0"
+        "@opentelemetry/core": "^1.29.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@traceloop/instrumentation-chromadb": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-chromadb/-/instrumentation-chromadb-0.11.1.tgz",
-      "integrity": "sha512-XawgXJ3W7CtnLygQ9+CpDF27Ww8egLHhzUpTkkBn1dIgzPgRd9sTzm3lGe6PGRfiNJNta/v5lvb/rD+pmzj2Jw==",
-      "license": "Apache-2.0",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-chromadb/-/instrumentation-chromadb-0.12.0.tgz",
+      "integrity": "sha512-Pb11sARD3Fus0pYQHoOFQ2LCDoKmXc+q286+hqVayImfLQee1T8I7vSJ/lQNfmwpcusUe3QFtocYkboyB4tbkg==",
       "dependencies": {
-        "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/semantic-conventions": "^1.26.0",
-        "@traceloop/ai-semantic-conventions": "^0.11.0",
-        "tslib": "^2.3.0"
+        "@opentelemetry/core": "^1.29.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@traceloop/instrumentation-cohere": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-cohere/-/instrumentation-cohere-0.11.1.tgz",
-      "integrity": "sha512-S+bQGdKD8Aw+G04F/xGzpEmT5HHgnq4ApcEYQiCVxHCuky17bJ2pMAw/3psALzqR2F0B8wF7b8KU/3bKiu0tVw==",
-      "license": "Apache-2.0",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-cohere/-/instrumentation-cohere-0.12.0.tgz",
+      "integrity": "sha512-wp5yUgZ2Wos8AbuywOb4mQ2Izaomd9l7AA60hfk8WDLS0xh71E3P9HbuwRxOzp2uyRiAekdNRrZxzQ0WEX//XQ==",
       "dependencies": {
-        "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/semantic-conventions": "^1.26.0",
-        "@traceloop/ai-semantic-conventions": "^0.11.0",
-        "tslib": "^2.3.0"
+        "@opentelemetry/core": "^1.29.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@traceloop/instrumentation-langchain": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-langchain/-/instrumentation-langchain-0.11.1.tgz",
-      "integrity": "sha512-KUn8Sm/apjdU9xvmFJOPeWw+aXicHslS8FUUyAYCt6PsTp+LiWEa4uivXR8CX/6EGrA7Rbw/jEorg3Vx79/iNA==",
-      "license": "Apache-2.0",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-langchain/-/instrumentation-langchain-0.12.0.tgz",
+      "integrity": "sha512-lKsBkokmZXFsB8jF3tAFs2YMMuNFQR3EhR+LVZyq4rjynDU5UqPYjdqGfKIEmcyvnWjvtMe3jLKy8H57/y/Vow==",
       "dependencies": {
-        "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/semantic-conventions": "^1.26.0",
-        "@traceloop/ai-semantic-conventions": "^0.11.0",
-        "tslib": "^2.3.0"
+        "@opentelemetry/core": "^1.29.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@traceloop/instrumentation-llamaindex": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-llamaindex/-/instrumentation-llamaindex-0.11.1.tgz",
-      "integrity": "sha512-3YP3svb0VU9Q51Ggud8QxjKfn35l+3ha0dGYg4wPo8Q5GRUjNTWl306473x5KGinbqIHQS8ozG7WHIs4Hvn16A==",
-      "license": "Apache-2.0",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-llamaindex/-/instrumentation-llamaindex-0.12.0.tgz",
+      "integrity": "sha512-NdffQUxDQprgZvSV6cOynYXI9QslpVJEjMHn67hMc5rabZPSdqKXWpSW1QtNsh4aWRhzQ861wD9OadZzM89eVg==",
       "dependencies": {
-        "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/semantic-conventions": "^1.26.0",
-        "@traceloop/ai-semantic-conventions": "^0.11.0",
+        "@opentelemetry/core": "^1.29.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
         "lodash": "^4.17.21",
-        "tslib": "^2.3.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@traceloop/instrumentation-openai": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-openai/-/instrumentation-openai-0.11.1.tgz",
-      "integrity": "sha512-iEM1/sHRkRWZhDBzr2pDgXuyINDM2tTkHiGcYoP9g0tsnmvwM3oLv80cFOEgpMDxCAgiULLExjIiuLknDZj0OQ==",
-      "license": "Apache-2.0",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-openai/-/instrumentation-openai-0.12.0.tgz",
+      "integrity": "sha512-q3+PQCE3CmRDwlkEbTJ5FwpaJV93pTsXs39QRzOAW7nInOIMh7hCB4BsKiaX7sf/2UaAdBXpf7LcjciDs4oRng==",
       "dependencies": {
-        "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/semantic-conventions": "^1.26.0",
-        "@traceloop/ai-semantic-conventions": "^0.11.0",
-        "js-tiktoken": "^1.0.12",
-        "tslib": "^2.3.0"
+        "@opentelemetry/core": "^1.29.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
+        "js-tiktoken": "^1.0.15",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@traceloop/instrumentation-pinecone": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-pinecone/-/instrumentation-pinecone-0.11.1.tgz",
-      "integrity": "sha512-ivW74KeyAtpa/AINAgvRfUWmpN86mIYq1///sJJ1fiBa0ylV+fG1+UpTW7xCKkvEgM5mZUBh9wGZG+wN+FP0uA==",
-      "license": "Apache-2.0",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-pinecone/-/instrumentation-pinecone-0.12.0.tgz",
+      "integrity": "sha512-+rG5Nn1qu9EpgnGkxRgae1CXBBBOau+5aVVjZpGqnhZZ7I6EHuFN401IaRKPxaXagB12ZOBcpWI0LgSLgdwmlw==",
       "dependencies": {
-        "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/semantic-conventions": "^1.26.0",
-        "@traceloop/ai-semantic-conventions": "^0.11.0",
-        "tslib": "^2.3.0"
+        "@opentelemetry/core": "^1.29.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@traceloop/instrumentation-qdrant": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-qdrant/-/instrumentation-qdrant-0.11.1.tgz",
-      "integrity": "sha512-jgYUjT6MA9qhRGlGd3HAfbsFuisi9N6/1Ia/IxrxaN1bJbwrgge7rSwWCczXjeolFcVE9kxUoJOs/yMv6k+OCw==",
-      "license": "Apache-2.0",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-qdrant/-/instrumentation-qdrant-0.12.0.tgz",
+      "integrity": "sha512-733kNyO2aHz7juIw19RqElXnMJf3O16K9QY0UQ020vjNYF6koKUoxEeqzfcWMv0oTlzJr1C4H8iBybK9KGAw2A==",
       "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.53.0",
-        "@traceloop/ai-semantic-conventions": "^0.11.0",
-        "tslib": "^2.3.0"
+        "@opentelemetry/core": "^1.29.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@traceloop/instrumentation-vertexai": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-vertexai/-/instrumentation-vertexai-0.11.1.tgz",
-      "integrity": "sha512-mIbhUpQKclU3ys28HtT/pStdosFelc2XPMnULSChJz4xj5KgtSW6SUqPN3sOgNOoCwq9kfvfSvK7mqg8FzvYTg==",
-      "license": "Apache-2.0",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-vertexai/-/instrumentation-vertexai-0.12.0.tgz",
+      "integrity": "sha512-p9/orFV2uYtqOQOKvi3zA9j+xG7qlra3RfyDcD81k5sO+Znm9kYJrJ7608zelqdEdzr/sUeXme1gPV2oYOZJhA==",
       "dependencies": {
-        "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/semantic-conventions": "^1.26.0",
-        "@traceloop/ai-semantic-conventions": "^0.11.0",
-        "tslib": "^2.3.0"
+        "@opentelemetry/core": "^1.29.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@traceloop/node-server-sdk": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@traceloop/node-server-sdk/-/node-server-sdk-0.11.2.tgz",
-      "integrity": "sha512-CHuoA3mpbwGViZvUvCVwIOQfj6MLFqRu+rUkyJVPgesyjrtahnwIf7PWnl4NkU2Fa5ScA9EbVDMKr9D5rg4SIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.53.0",
-        "@opentelemetry/sdk-node": "^0.53.0",
-        "@traceloop/ai-semantic-conventions": "^0.11.0",
-        "@traceloop/instrumentation-anthropic": "^0.11.1",
-        "@traceloop/instrumentation-azure": "^0.11.1",
-        "@traceloop/instrumentation-bedrock": "^0.11.1",
-        "@traceloop/instrumentation-chromadb": "^0.11.1",
-        "@traceloop/instrumentation-cohere": "^0.11.1",
-        "@traceloop/instrumentation-langchain": "^0.11.1",
-        "@traceloop/instrumentation-llamaindex": "^0.11.1",
-        "@traceloop/instrumentation-openai": "^0.11.1",
-        "@traceloop/instrumentation-pinecone": "^0.11.1",
-        "@traceloop/instrumentation-qdrant": "^0.11.1",
-        "@traceloop/instrumentation-vertexai": "^0.11.1",
-        "@types/nunjucks": "^3.2.5",
-        "cross-fetch": "^4.0.0",
-        "fetch-retry": "^5.0.6",
-        "nunjucks": "^3.2.4",
-        "posthog-node": "^3.6.3",
-        "supports-color": "^8.1.1",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@traceloop/node-server-sdk/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@traceloop/node-server-sdk/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
+      "resolved": ".yalc/@traceloop/node-server-sdk",
+      "link": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4595,11 +4559,37 @@
         "form-data": "^4.0.0"
       }
     },
+    "node_modules/@types/node-int64": {
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@types/node-int64/-/node-int64-0.4.32.tgz",
+      "integrity": "sha512-xf/JsSlnXQ+mzvc0IpXemcrO4BrCfpgNpMco+GLcXkFk01k/gW9lGJu+Vof0ZSvHK6DsHJDPSbjFPs36QkWXqw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/nunjucks": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.6.tgz",
-      "integrity": "sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==",
-      "license": "MIT"
+      "integrity": "sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w=="
+    },
+    "node_modules/@types/parquetjs": {
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/@types/parquetjs/-/parquetjs-0.10.6.tgz",
+      "integrity": "sha512-ZCsD6j97YD0mGU8/VnVs3NjORXa7zeHvqlpJpCqy4jU8a1O21dalL+MFn9QNbdEfy8rszR1N7NHeT7/LdtHf+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node-int64": "*"
+      }
+    },
+    "node_modules/@types/progress-stream": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/progress-stream/-/progress-stream-2.0.5.tgz",
+      "integrity": "sha512-5YNriuEZkHlFHHepLIaxzq3atGeav1qCTGzB74HKWpo66qjfostF+rHc785YYYHeBytve8ZG3ejg42jEIfXNiQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/request": {
       "version": "2.48.12",
@@ -4639,8 +4629,7 @@
     "node_modules/@types/shimmer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
-      "license": "MIT"
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -4837,8 +4826,7 @@
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
-      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
-      "license": "MIT"
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -4854,10 +4842,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "license": "MIT",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4869,7 +4856,6 @@
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
       "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -5182,8 +5168,7 @@
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "license": "MIT"
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
@@ -5418,6 +5403,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha512-u4cBQNepWxYA55FunZSM7wMi55yQaN0otnhhilNoWHq0MfOfJeQx0v0mRRpolGOExPjZcl6FtB0BB8Xkb88F0g==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -5447,6 +5439,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "dev": true,
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -5503,6 +5504,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/buffer": {
@@ -5799,6 +5809,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -5822,12 +5838,11 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "license": "MIT",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "dependencies": {
-        "node-fetch": "^2.6.12"
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -7090,8 +7105,7 @@
     "node_modules/fetch-retry": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.6.tgz",
-      "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==",
-      "license": "MIT"
+      "integrity": "sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ=="
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -7837,12 +7851,11 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.11.0.tgz",
-      "integrity": "sha512-5DimNQGoe0pLUHbR9qK84iWaWjjbsxiqXnw6Qz64+azRgleqv9k2kTt5fw7QsOpmaGYtuxxursnPPsnTKEx10Q==",
-      "license": "Apache-2.0",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.13.0.tgz",
+      "integrity": "sha512-YG86SYDtrL/Yu8JgfWb7kjQ0myLeT1whw6fs/ZHFkXFcbk9zJU9lOCsSJHpvaPumU11nN3US7NW6x1YTk+HrUA==",
       "dependencies": {
-        "acorn": "^8.8.2",
+        "acorn": "^8.14.0",
         "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
@@ -7896,6 +7909,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/int53": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/int53/-/int53-0.2.4.tgz",
+      "integrity": "sha512-a5jlKftS7HUOhkUyYD7j2sJ/ZnvWiNlZS1ldR+g1ifQ+/UuZXIE+YTc/lK1qGj/GwAU5F8Z0e1eVq2t1J5Ob2g==",
+      "dev": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -9110,10 +9129,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/js-tiktoken": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.14.tgz",
-      "integrity": "sha512-Pk3l3WOgM9joguZY2k52+jH82RtABRgB5RdGFZNUGbOKGMVlNmafcPA3b0ITcCZPu1L9UclP1tne6aw7ZI4Myg==",
-      "license": "MIT",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.19.tgz",
+      "integrity": "sha512-XC63YQeEcS47Y53gg950xiZ4IWmkfMe4p2V9OSaBt26q+p47WHn18izuXzSclCI73B7yGqtfRsT6jcZQI0y08g==",
       "dependencies": {
         "base64-js": "^1.5.1"
       }
@@ -9645,8 +9663,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -9695,6 +9712,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lzo": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/lzo/-/lzo-0.4.11.tgz",
+      "integrity": "sha512-apQHNoW2Alg72FMqaC/7pn03I7umdgSVFt2KRkCXXils4Z9u3QBh1uOtl2O5WmZIDLd9g6Lu4lIdOLmiSTFVCQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "~1.2.1"
       }
     },
     "node_modules/make-dir": {
@@ -9831,8 +9859,7 @@
     "node_modules/module-details-from-path": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==",
-      "license": "MIT"
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -10019,7 +10046,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
       "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
-      "license": "BSD-2-Clause",
       "dependencies": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",
@@ -10044,7 +10070,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -10107,6 +10132,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-stream": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/object-stream/-/object-stream-0.0.1.tgz",
+      "integrity": "sha512-+NPJnRvX9RDMRY9mOWOo/NDppBjbZhXirNNSu2IBnuNboClC9h1ZGHXgHBLDbJMHsxeJDq922aVmG5xs24a/cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/object.assign": {
@@ -10399,6 +10433,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/parquetjs": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/parquetjs/-/parquetjs-0.11.2.tgz",
+      "integrity": "sha512-Y6FOc3Oi2AxY4TzJPz7fhICCR8tQNL3p+2xGQoUAMbmlJBR7+JJmMrwuyMjIpDiM7G8Wj/8oqOH4UDUmu4I5ZA==",
+      "dev": true,
+      "dependencies": {
+        "brotli": "^1.3.0",
+        "bson": "^1.0.4",
+        "int53": "^0.2.4",
+        "object-stream": "0.0.1",
+        "snappyjs": "^0.6.0",
+        "thrift": "^0.11.0",
+        "varint": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=7.6"
+      },
+      "optionalDependencies": {
+        "lzo": "^0.4.0"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -10606,7 +10661,6 @@
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-3.6.3.tgz",
       "integrity": "sha512-JB+ei0LkwE+rKHyW5z79Nd1jUaGxU6TvkfjFqY9vQaHxU5aU8dRl0UUaEmZdZbHwjp3WmXCBQQRNyimwbNQfCw==",
-      "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",
         "rusha": "^0.8.14"
@@ -10697,6 +10751,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/progress-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
+      "integrity": "sha512-xJwOWR46jcXUq6EH9yYyqp+I52skPySOeHfkxOZ2IY1AiBi/sFJhbhAKHoV3OTw/omQ45KTio9215dRJ2Yxd3Q==",
+      "dev": true,
+      "dependencies": {
+        "speedometer": "~1.0.0",
+        "through2": "~2.0.3"
       }
     },
     "node_modules/prompts": {
@@ -10824,6 +10894,17 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.11.2",
@@ -10966,10 +11047,9 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.4.0.tgz",
-      "integrity": "sha512-X34iHADNbNDfr6OTStIAHWSAvvKQRYgLO6duASaVf7J2VA3lvmNYboAHOuLC2huav1IwgZJtyEcJCKVzFxOSMQ==",
-      "license": "MIT",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.1.tgz",
+      "integrity": "sha512-fgZEz/t3FDrU9o7EhI+iNNq1pNNpJImOvX72HUd6RoFiw8MaKd8/gR5tLuc8A0G0e55LMbP6ImjnmXY6zrTmjw==",
       "dependencies": {
         "debug": "^4.3.5",
         "module-details-from-path": "^1.0.3",
@@ -11129,8 +11209,7 @@
     "node_modules/rusha": {
       "version": "0.8.14",
       "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.14.tgz",
-      "integrity": "sha512-cLgakCUf6PedEu15t8kbsjnwIFFR2D4RfL+W3iWFJ4iac7z4B0ZI8fxy4R3J956kAI68HclCFGL8MPoUVC3qVA==",
-      "license": "MIT"
+      "integrity": "sha512-cLgakCUf6PedEu15t8kbsjnwIFFR2D4RfL+W3iWFJ4iac7z4B0ZI8fxy4R3J956kAI68HclCFGL8MPoUVC3qVA=="
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
@@ -11271,8 +11350,7 @@
     "node_modules/shimmer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-      "license": "BSD-2-Clause"
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "node_modules/side-channel": {
       "version": "1.0.6",
@@ -11317,6 +11395,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/snappyjs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/snappyjs/-/snappyjs-0.6.1.tgz",
+      "integrity": "sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg==",
+      "dev": true
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11347,6 +11431,12 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/speedometer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
+      "integrity": "sha512-lgxErLl/7A5+vgIIXsh9MbeukOaCb2axgQ+bKCdIE+ibNT4XNYGNCR1qFEGq6F+YDASXK3Fh/c5FgtZchFolxw==",
+      "dev": true
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -11775,6 +11865,66 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/thrift": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.11.0.tgz",
+      "integrity": "sha512-UpsBhOC45a45TpeHOXE4wwYwL8uD2apbHTbtBvkwtUU4dNwCjC7DpQTjw2Q6eIdfNtw+dKthdwq94uLXTJPfFw==",
+      "dev": true,
+      "dependencies": {
+        "node-int64": "^0.4.0",
+        "q": "^1.5.0",
+        "ws": ">= 2.2.3"
+      },
+      "engines": {
+        "node": ">= 4.1.0"
+      }
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -11804,6 +11954,41 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/together-ai": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/together-ai/-/together-ai-0.13.0.tgz",
+      "integrity": "sha512-+A3gI0hJJ+7pqSQDemFKaH4khCDsMRXbK0tvYodNVYFIprR6QcC9JGF1pesw79x4Hb45yaohTFHxS9SqPXn02w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "@types/parquetjs": "^0.10.6",
+        "@types/progress-stream": "^2.0.5",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "axios": "^1.7.7",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7",
+        "parquetjs": "^0.11.2",
+        "progress-stream": "^2.0.0"
+      }
+    },
+    "node_modules/together-ai/node_modules/@types/node": {
+      "version": "18.19.76",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.76.tgz",
+      "integrity": "sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/together-ai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -11913,10 +12098,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -12151,6 +12335,12 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
+      "dev": true
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -12346,6 +12536,36 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/sdk/typescript/async/package-lock.json
+++ b/sdk/typescript/async/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@helicone/async",
-  "version": "1.0.1",
+  "version": "1.0.3-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helicone/async",
-      "version": "1.0.1",
+      "version": "1.0.3-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@traceloop/node-server-sdk": "file:.yalc/@traceloop/node-server-sdk"
+        "@traceloop/node-server-sdk": "^0.12.1"
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.22.0",
@@ -38,62 +38,6 @@
         "together-ai": "^0.13.0",
         "ts-jest": "^29.1.0",
         "typescript": "^5.2.2"
-      }
-    },
-    ".yalc/@traceloop/node-server-sdk": {
-      "version": "0.12.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.56.0",
-        "@opentelemetry/sdk-node": "^0.56.0",
-        "@traceloop/ai-semantic-conventions": "^0.12.0",
-        "@traceloop/instrumentation-anthropic": "^0.12.0",
-        "@traceloop/instrumentation-azure": "^0.12.0",
-        "@traceloop/instrumentation-bedrock": "^0.12.0",
-        "@traceloop/instrumentation-chromadb": "^0.12.0",
-        "@traceloop/instrumentation-cohere": "^0.12.0",
-        "@traceloop/instrumentation-langchain": "^0.12.0",
-        "@traceloop/instrumentation-llamaindex": "^0.12.0",
-        "@traceloop/instrumentation-openai": "^0.12.0",
-        "@traceloop/instrumentation-pinecone": "^0.12.0",
-        "@traceloop/instrumentation-qdrant": "^0.12.0",
-        "@traceloop/instrumentation-vertexai": "^0.12.0",
-        "@types/nunjucks": "^3.2.6",
-        "cross-fetch": "^4.0.0",
-        "fetch-retry": "^5.0.6",
-        "nunjucks": "^3.2.4",
-        "posthog-node": "^3.6.3",
-        "supports-color": "^8.1.1",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    ".yalc/@traceloop/node-server-sdk/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    ".yalc/@traceloop/node-server-sdk/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4406,6 +4350,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@traceloop/instrumentation-together": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-together/-/instrumentation-together-0.12.1.tgz",
+      "integrity": "sha512-8IZzd3RFHT2zmYlbtoZGynm5Aiw/sHloq7zMG0irqcexbbAbCCjwhyeb0wtmkm98OfZpEcpsjRQ5+EFIsIXuWQ==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.29.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
+        "js-tiktoken": "^1.0.15",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@traceloop/instrumentation-vertexai": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@traceloop/instrumentation-vertexai/-/instrumentation-vertexai-0.12.0.tgz",
@@ -4422,8 +4382,62 @@
       }
     },
     "node_modules/@traceloop/node-server-sdk": {
-      "resolved": ".yalc/@traceloop/node-server-sdk",
-      "link": true
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@traceloop/node-server-sdk/-/node-server-sdk-0.12.1.tgz",
+      "integrity": "sha512-fvygbZaf1N0Y/jG2pRVZ/gaFDHRoZ9mCqHs2YDcOTlYlXt8jaHtP0zx+iCvi5LmnY8X/OzrkUdr1ANgdKcJ4SQ==",
+      "dependencies": {
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.56.0",
+        "@opentelemetry/sdk-node": "^0.56.0",
+        "@traceloop/ai-semantic-conventions": "^0.12.0",
+        "@traceloop/instrumentation-anthropic": "^0.12.0",
+        "@traceloop/instrumentation-azure": "^0.12.0",
+        "@traceloop/instrumentation-bedrock": "^0.12.0",
+        "@traceloop/instrumentation-chromadb": "^0.12.0",
+        "@traceloop/instrumentation-cohere": "^0.12.0",
+        "@traceloop/instrumentation-langchain": "^0.12.0",
+        "@traceloop/instrumentation-llamaindex": "^0.12.0",
+        "@traceloop/instrumentation-openai": "^0.12.0",
+        "@traceloop/instrumentation-pinecone": "^0.12.0",
+        "@traceloop/instrumentation-qdrant": "^0.12.0",
+        "@traceloop/instrumentation-together": "^0.12.1",
+        "@traceloop/instrumentation-vertexai": "^0.12.0",
+        "@types/nunjucks": "^3.2.6",
+        "cross-fetch": "^4.0.0",
+        "fetch-retry": "^5.0.6",
+        "nunjucks": "^3.2.4",
+        "posthog-node": "^3.6.3",
+        "supports-color": "^8.1.1",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@traceloop/node-server-sdk/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@traceloop/node-server-sdk/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/sdk/typescript/async/package.json
+++ b/sdk/typescript/async/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "description": "A Node.js wrapper for logging llm traces directly to Helicone, by passing the proxy, with OpenLLMetry",
+  "description": "A Node.js wrapper for logging llm traces directly to Helicone, bypassing the proxy, with OpenLLMetry",
   "repository": {
     "type": "git",
     "url": "git@github.com:Helicone/helicone.git",

--- a/sdk/typescript/async/package.json
+++ b/sdk/typescript/async/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helicone/async",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "description": "A Node.js wrapper for logging llm traces directly to Helicone, bypassing the proxy, with OpenLLMetry",

--- a/sdk/typescript/async/package.json
+++ b/sdk/typescript/async/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helicone/async",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "description": "A Node.js wrapper for logging llm traces directly to Helicone, by passing the proxy, with OpenLLMetry",
@@ -57,11 +57,12 @@
     "nock": "^13.5.4",
     "openai": "^4.48.3",
     "prettier": "^2.8.8",
+    "together-ai": "^0.13.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@traceloop/node-server-sdk": "^0.11.2"
+    "@traceloop/node-server-sdk": "^0.12.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
> ⚠️ **BLOCKED**: This PR is blocked pending the merge of [openllmetry-js#545](https://github.com/traceloop/openllmetry-js/pull/545) which adds core TogetherAI instrumentation support.

# Add TogetherAI Support to @helicone/async

## Overview
Adds native TogetherAI support to enable monitoring and analyzing TogetherAI API usage with Helicone's observability features.

## Key Changes
- Added TogetherAI integration (`together-ai ^0.13.0`) 
- Extended logger and interfaces for TogetherAI support
- Bumped to v1.0.1
- Updated dependencies including `@traceloop/node-server-sdk@0.12.1`

## Usage
```typescript
import Together from "together-ai";
import { HeliconeAsyncLogger } from "@helicone/async";

export function createTogetherClient({ task }: { task?: string } = {}) {
  const logger = new HeliconeAsyncLogger({
    apiKey: process.env.HELICONE_API_KEY!,
    headers: {
      "Helicone-Property-appname": "TogetherChat",
      ...(task ? { "Helicone-Property-task": task } : {}),
    },
    providers: {
      together: Together,
    },
  });
  logger.init();

  return new Together();
}
```