### PR TITLE
improve text extract for search

### DIFF
--- a/packages/llm-mapper/types.ts
+++ b/packages/llm-mapper/types.ts
@@ -74,6 +74,8 @@ export interface LlmSchema {
 }
 
 export type LLMPreview = {
+  fullRequestText: () => string;
+  fullResponseText: () => string;
   request: string;
   response: string;
   concatenatedMessages: Message[];

--- a/packages/llm-mapper/utils/getMappedContent.ts
+++ b/packages/llm-mapper/utils/getMappedContent.ts
@@ -147,6 +147,26 @@ const getUnsanitizedMappedContent = ({
   };
 };
 
+const messageToText = (message: Message): string => {
+  let text = "";
+  message.contentArray?.forEach((message) => {
+    text += messageToText(message).trim();
+  });
+  text += message.content?.trim() ?? "";
+  message.tool_calls?.forEach((toolCall) => {
+    text += JSON.stringify(toolCall.arguments).trim();
+    text += JSON.stringify(toolCall.name).trim();
+  });
+  text += message.role ?? "";
+  text += message.name ?? "";
+  text += message.tool_call_id ?? "";
+  return text.trim();
+};
+
+const messagesToText = (messages: Message[]): string => {
+  return messages.map(messageToText).join("\n").trim();
+};
+
 const sanitizeMappedContent = (
   mappedContent: MappedLLMRequest
 ): MappedLLMRequest => {
@@ -212,6 +232,12 @@ const sanitizeMappedContent = (
       response: mappedContent.preview.response?.slice(0, 30),
       concatenatedMessages:
         sanitizeMessages(mappedContent.preview.concatenatedMessages) ?? [],
+      fullRequestText: () => {
+        return messagesToText(mappedContent.schema.request.messages ?? []);
+      },
+      fullResponseText: () => {
+        return messagesToText(mappedContent.schema.response?.messages ?? []);
+      },
     },
     model: mappedContent.model,
     raw: mappedContent.raw,

--- a/valhalla/jawn/src/lib/handlers/LoggingHandler.ts
+++ b/valhalla/jawn/src/lib/handlers/LoggingHandler.ts
@@ -46,6 +46,12 @@ export type BatchPayload = {
   }[];
 };
 
+const avgTokenLength = 4;
+const maxContentLength = 2_000_000;
+const maxResponseLength = 100_000;
+const MAX_CONTENT_LENGTH = maxContentLength * avgTokenLength; // 2 MB
+const MAX_RESPONSE_LENGTH = maxResponseLength * avgTokenLength; // 100k
+
 export class LoggingHandler extends AbstractLogHandler {
   private batchPayload: BatchPayload;
   private logStore: LogStore;
@@ -442,10 +448,15 @@ export class LoggingHandler extends AbstractLogHandler {
     let responseText = "";
 
     try {
-      const heliconeRequest = toHeliconeRequest(context);
-      const mappedContent = heliconeRequestToMappedContent(heliconeRequest);
-      requestText = mappedContent.preview.request;
-      responseText = mappedContent.preview.response;
+      const mappedContent = heliconeRequestToMappedContent(
+        toHeliconeRequest(context)
+      );
+      requestText = mappedContent.preview
+        .fullRequestText()
+        .slice(0, MAX_CONTENT_LENGTH);
+      responseText = mappedContent.preview
+        .fullResponseText()
+        .slice(0, MAX_RESPONSE_LENGTH);
     } catch (error) {
       console.error("Error mapping request/response for preview:", error);
       // Fallback to empty strings if mapping fails

--- a/valhalla/jawn/src/packages/llm-mapper/types.ts
+++ b/valhalla/jawn/src/packages/llm-mapper/types.ts
@@ -74,6 +74,8 @@ export interface LlmSchema {
 }
 
 export type LLMPreview = {
+  fullRequestText: () => string;
+  fullResponseText: () => string;
   request: string;
   response: string;
   concatenatedMessages: Message[];

--- a/valhalla/jawn/src/packages/llm-mapper/utils/getMappedContent.ts
+++ b/valhalla/jawn/src/packages/llm-mapper/utils/getMappedContent.ts
@@ -147,6 +147,26 @@ const getUnsanitizedMappedContent = ({
   };
 };
 
+const messageToText = (message: Message): string => {
+  let text = "";
+  message.contentArray?.forEach((message) => {
+    text += messageToText(message).trim();
+  });
+  text += message.content?.trim() ?? "";
+  message.tool_calls?.forEach((toolCall) => {
+    text += JSON.stringify(toolCall.arguments).trim();
+    text += JSON.stringify(toolCall.name).trim();
+  });
+  text += message.role ?? "";
+  text += message.name ?? "";
+  text += message.tool_call_id ?? "";
+  return text.trim();
+};
+
+const messagesToText = (messages: Message[]): string => {
+  return messages.map(messageToText).join("\n").trim();
+};
+
 const sanitizeMappedContent = (
   mappedContent: MappedLLMRequest
 ): MappedLLMRequest => {
@@ -212,6 +232,12 @@ const sanitizeMappedContent = (
       response: mappedContent.preview.response?.slice(0, 30),
       concatenatedMessages:
         sanitizeMessages(mappedContent.preview.concatenatedMessages) ?? [],
+      fullRequestText: () => {
+        return messagesToText(mappedContent.schema.request.messages ?? []);
+      },
+      fullResponseText: () => {
+        return messagesToText(mappedContent.schema.response?.messages ?? []);
+      },
     },
     model: mappedContent.model,
     raw: mappedContent.raw,

--- a/web/packages/llm-mapper/types.ts
+++ b/web/packages/llm-mapper/types.ts
@@ -74,6 +74,8 @@ export interface LlmSchema {
 }
 
 export type LLMPreview = {
+  fullRequestText: () => string;
+  fullResponseText: () => string;
   request: string;
   response: string;
   concatenatedMessages: Message[];

--- a/web/packages/llm-mapper/utils/getMappedContent.ts
+++ b/web/packages/llm-mapper/utils/getMappedContent.ts
@@ -147,6 +147,26 @@ const getUnsanitizedMappedContent = ({
   };
 };
 
+const messageToText = (message: Message): string => {
+  let text = "";
+  message.contentArray?.forEach((message) => {
+    text += messageToText(message).trim();
+  });
+  text += message.content?.trim() ?? "";
+  message.tool_calls?.forEach((toolCall) => {
+    text += JSON.stringify(toolCall.arguments).trim();
+    text += JSON.stringify(toolCall.name).trim();
+  });
+  text += message.role ?? "";
+  text += message.name ?? "";
+  text += message.tool_call_id ?? "";
+  return text.trim();
+};
+
+const messagesToText = (messages: Message[]): string => {
+  return messages.map(messageToText).join("\n").trim();
+};
+
 const sanitizeMappedContent = (
   mappedContent: MappedLLMRequest
 ): MappedLLMRequest => {
@@ -212,6 +232,12 @@ const sanitizeMappedContent = (
       response: mappedContent.preview.response?.slice(0, 30),
       concatenatedMessages:
         sanitizeMessages(mappedContent.preview.concatenatedMessages) ?? [],
+      fullRequestText: () => {
+        return messagesToText(mappedContent.schema.request.messages ?? []);
+      },
+      fullResponseText: () => {
+        return messagesToText(mappedContent.schema.response?.messages ?? []);
+      },
     },
     model: mappedContent.model,
     raw: mappedContent.raw,


### PR DESCRIPTION
# Add Full Text Preview for LLM Messages

Adds functions to generate complete text previews of LLM requests/responses, replacing 30-char truncated previews.

```ts
// Before: Limited 30-char previews
preview: {
  request: mappedContent.preview.request?.slice(0, 30),
  response: mappedContent.preview.response?.slice(0, 30),
}

// After: Full text with size limits
preview: {
  fullRequestText: () => messagesToText(request.messages).slice(0, MAX_CONTENT_LENGTH),
  fullResponseText: () => messagesToText(response.messages).slice(0, MAX_RESPONSE_LENGTH)
}
```

Key changes:
- Added `fullRequestText()` and `fullResponseText()` to `LLMPreview` type
- Implemented message concatenation with all components (content, tool calls, roles)
- Added size limits (2MB request, 100KB response) to prevent memory issues
- Fixed type errors in preview generation

Testing:
- Verify full message content is correctly concatenated
- Check size limits work for large messages
- Ensure all message components are included in output
