### PR TITLE
fix association properties not showing request data on async logger

### DIFF
--- a/sdk/python/async/helicone_async/async_logger.py
+++ b/sdk/python/async/helicone_async/async_logger.py
@@ -34,7 +34,7 @@ class HeliconeAsyncLogger:
             headers={"Authorization": f"Bearer {self.api_key}"},
         )
 
-        os.environ["TRACELOOP_TRACE_CONTENT"] = "false"
+        os.environ["TRACELOOP_TRACE_CONTENT"] = "true"
 
         Traceloop.init(
             exporter=exporter,

--- a/sdk/python/async/helicone_async/async_logger.py
+++ b/sdk/python/async/helicone_async/async_logger.py
@@ -36,8 +36,6 @@ class HeliconeAsyncLogger:
 
         os.environ["TRACELOOP_TRACE_CONTENT"] = "false"
 
-        attach(set_value("override_enable_content_tracing", True))
-
         Traceloop.init(
             exporter=exporter,
             disable_batch=True,
@@ -46,10 +44,10 @@ class HeliconeAsyncLogger:
         )
 
     def disable_content_tracing(self) -> None:
-        attach(set_value("override_enable_content_tracing", False))
+        os.environ["TRACELOOP_TRACE_CONTENT"] = "false"
 
     def enable_content_tracing(self) -> None:
-        attach(set_value("override_enable_content_tracing", True))
+        os.environ["TRACELOOP_TRACE_CONTENT"] = "true"
 
     def set_properties(self, properties: dict) -> None:
         Traceloop.set_association_properties(properties)


### PR DESCRIPTION
Due to the way OpenLLMetry is checking for "tracing enabled" or not in the set_association_properties function, the traceloop content enable/disable has to be using the global env variable. This should be fine since we were setting it to false globally before anyways.

OpenLLMetry code reference:
https://github.com/traceloop/openllmetry/blob/4c59eb3f13eaa16346965602fc893f4e00a4c98b/packages/traceloop-sdk/traceloop/sdk/tracing/tracing.py#L166-L174

https://github.com/traceloop/openllmetry/blob/4c59eb3f13eaa16346965602fc893f4e00a4c98b/packages/traceloop-sdk/traceloop/sdk/config/__init__.py#L12-L13

The `__content_allow_list` cannot be changed because it is automatically loading the `associationPropertyAllowList` which is only available if using traceloop's dashboard