### PR TITLE
Add Google to the list of Approved Domains in the docs

### DIFF
--- a/docs/getting-started/integration-method/gateway.mdx
+++ b/docs/getting-started/integration-method/gateway.mdx
@@ -314,6 +314,8 @@ curl --request POST \
 | Provider    | Domain Name                       | Cost Support | Dedicated Domain         |
 | ----------- | --------------------------------- | ------------ | ------------------------ |
 | OpenAI      | `api.openai.com`                  | ✅           | `oai.helicone.ai`        |
+| Google Gemini | `generativelanguage.googleapis.com| ✅         | ❌                       |
+| Google Vertex AI | `<LOCATION>-aiplatform.googleapis.com| ✅   | ❌                       |
 | Anthropic   | `api.anthropic.com`               | ✅           | `anthropic.helicone.ai`  |
 | Together-AI | `api.together.xyz`                | ✅           | `together.helicone.ai`   |
 | OpenRouter  | `openrouter.ai`                   | ✅           | `openrouter.helicone.ai` |


### PR DESCRIPTION
Based on my usage of the Platform, Google apis are supported, including the Cost support. I'm not sure about the Dedicated domain part though.

The columns seem broken in raw markdown but they should be displayed fine when rendered by a markdown table component. I haven't tested the display part manually but I can do it if needed.