### PR TITLE
Fix: Update Docs and min node version in package.json

### DIFF
--- a/docs/getting-started/self-host/manual.mdx
+++ b/docs/getting-started/self-host/manual.mdx
@@ -39,8 +39,8 @@ brew install supabase/tap/supabase
 ### Install Wrangler and Yarn
 
 ```bash
-nvm install 18.11.0
-nvm use 18.11.0
+nvm install 20
+nvm use 20
 npm install -g wrangler
 npm install -g yarn
 ```
@@ -79,9 +79,10 @@ npx wrangler dev --local --var WORKER_TYPE:OPENAI_PROXY --port 8787 --test-sched
 
 ### Start Jawn (Serves Web)
 
-I a new terminal tab, run the following:
+In a new terminal tab, run the following:
 
 ```bash
+nvm use 20
 cd valhalla/jawn
 cp .env.example .env
 yarn && yarn dev
@@ -89,9 +90,10 @@ yarn && yarn dev
 
 ### Start Web
 
-I a new terminal tab, run the following:
+In a new terminal tab, run the following:
 
 ```bash
+nvm use 20
 cp .env.example web/.env
 cd web
 yarn

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,9 @@
   "name": "helicone",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "=20"
+  },
   "scripts": {
     "dev:local": "next dev --turbo -p 3000",
     "dev": "vercel env pull .env && next dev --turbo -p 3000",
@@ -120,7 +123,7 @@
     "@tailwindcss/typography": "^0.5.12",
     "@types/dateformat": "^5.0.0",
     "@types/js-cookie": "^3.0.3",
-    "@types/node": "18.11.9",
+    "@types/node": "^20.17.24",
     "@types/papaparse": "^5.3.15",
     "@types/pg": "^8.6.6",
     "@types/prismjs": "^1.26.4",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -4341,17 +4341,19 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@18.11.9":
-  version "18.11.9"
-  resolved "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz"
-  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
-
 "@types/node@^18.11.18":
   version "18.19.39"
   resolved "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz"
   integrity sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==
   dependencies:
     undici-types "~5.26.4"
+
+"@types/node@^20":
+  version "20.17.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.24.tgz#2325476954e6fc8c2f11b9c61e26ba6eb7d3f5b6"
+  integrity sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==
+  dependencies:
+    undici-types "~6.19.2"
 
 "@types/papaparse@^5.3.15":
   version "5.3.15"
@@ -9994,6 +9996,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 unified@^11.0.0:
   version "11.0.5"


### PR DESCRIPTION
- Updates the [setup instructions](https://docs.helicone.ai/getting-started/self-host/manual) to avoid the following error:

```
Error: Failed to load external module react-lottie: ReferenceError: document is not defined
```

As seen in the screenshot:

<img width="1470" alt="Screenshot 2025-03-08 at 4 43 02 PM" src="https://github.com/user-attachments/assets/1ebcad90-e348-4647-aba2-a5e047d0099e" />

If not using the correct version of Node. Also set the `engines` property in the `package.json` to reflect this required version

