### PR TITLE
fix: Evaluator stats distribution query

### DIFF
--- a/valhalla/jawn/src/managers/evaluator/EvaluatorManager.ts
+++ b/valhalla/jawn/src/managers/evaluator/EvaluatorManager.ts
@@ -21,6 +21,7 @@ import { runLastMileEvaluator } from "./lastmile/run";
 import { pythonEvaluator } from "./pythonEvaluator";
 import { LastMileConfigForm } from "./types";
 import { dbQueryClickhouse } from "../../lib/shared/db/dbExecute";
+import { ceil, floor, range } from "lodash";
 
 export function placeAssetIdValues(
   inputValues: Record<string, string>,
@@ -758,7 +759,7 @@ export class EvaluatorManager extends BaseManager {
       // Query score distribution - 5 buckets
       const distributionQuery = `
         SELECT
-          concat(toString(floor(bucket * 20)), '-', toString(ceil(bucket * 20))) as range,
+          concat(toString(bucket * 20), '-', toString((bucket + 1) * 20)) as range,
           count(*) as count
         FROM (
           SELECT

--- a/valhalla/jawn/src/managers/evaluator/EvaluatorManager.ts
+++ b/valhalla/jawn/src/managers/evaluator/EvaluatorManager.ts
@@ -21,7 +21,6 @@ import { runLastMileEvaluator } from "./lastmile/run";
 import { pythonEvaluator } from "./pythonEvaluator";
 import { LastMileConfigForm } from "./types";
 import { dbQueryClickhouse } from "../../lib/shared/db/dbExecute";
-import { ceil, floor, range } from "lodash";
 
 export function placeAssetIdValues(
   inputValues: Record<string, string>,


### PR DESCRIPTION
Fixes an issue in how the range labels were being calculated. The original query had:

- ceil(bucket * 20) for the end of the range
- floor(bucket * 20) for the start of the range

When bucket = 0 (for scores 0-19), both of these would evaluate to 0, resulting in a range of "0-0".

The fix changes this to bucket * 20 for the start of the range, and (bucket + 1) * 20 for the end of the range.

This creates proper bucket ranges like "0-20", "20-40", etc.

