### PR TITLE
Fix/range eval defaults

### DIFF
--- a/web/components/templates/evals/CreateNewEvaluator/LLMEvaluatorConfigForm.tsx
+++ b/web/components/templates/evals/CreateNewEvaluator/LLMEvaluatorConfigForm.tsx
@@ -415,6 +415,11 @@ const ScoringTypeSection = ({
                   { score: 5, description: "Excellent" },
                 ];
               }
+              
+              if (valueType === "range") {
+                updates.rangeMin = 0;
+                updates.rangeMax = 100;
+              }
 
               updateConfigFormParams(updates);
             }}


### PR DESCRIPTION
- Previously LLM-RANGE evaluators that used the default 0-100 range were
      created with the following tool:

    ```
    "tools": [
        {
          "type": "function",
          "function": {
            "name": "scorer",
            "description": "Given the inputs as shown in the system message and the output. Please call the scorer function.",
            "parameters": {
              "type": "object",
              "properties": {
                "fasdf": {
                  "description": "asdfa",
                  "type": "number"
                }
              },
              "required": [
                "fasdf"
              ]
            }
          }
        }
      ]
    ```

    Now, when the LLM scoring type is changed, we correctly initialize the
    default values, meaning we create tools like this (notice the
    minimum/maximum properties):

    ```
    "tools": [
        {
          "type": "function",
          "function": {
            "name": "scorer",
            "description": "Given the inputs as shown in the system message and the output. Please call the scorer function.",
            "parameters": {
              "type": "object",
              "properties": {
                "test": {
                  "description": "fasdfasdf",
                  "type": "number",
                  "minimum": 0,
                  "maximum": 75
                }
              },
              "required": [
                "test"
              ]
            }
          }
        }
      ]
    ```

    not the defaults.
    If the user customizes the values, then we send the updated custom values correctly