### PR TITLE
hotfix: making exponential backoff for KV store

### DIFF
--- a/worker/src/lib/clients/KVRateLimiterClient.ts
+++ b/worker/src/lib/clients/KVRateLimiterClient.ts
@@ -1,4 +1,5 @@
 import { HeliconeProperties } from "../models/HeliconeProxyRequest";
+import { safePut } from "../safePut";
 
 export interface RateLimitOptions {
   time_window: number;
@@ -161,7 +162,12 @@ export async function updateRateLimitCounter(
     });
   }
 
-  await rateLimitKV.put(kvKey, JSON.stringify(prunedTimestamps), {
-    expirationTtl: Math.ceil(timeWindowMillis / 1000), // Convert timeWindowMillis to seconds for expirationTtl
+  await safePut({
+    key: rateLimitKV,
+    keyName: kvKey,
+    value: JSON.stringify(prunedTimestamps),
+    options: {
+      expirationTtl: Math.ceil(timeWindowMillis / 1000), // Convert timeWindowMillis to seconds for expirationTtl
+    },
   });
 }

--- a/worker/src/lib/managers/AlertManager.ts
+++ b/worker/src/lib/managers/AlertManager.ts
@@ -1,6 +1,7 @@
 import { Env } from "../..";
 import { Result, err, ok } from "../util/results";
 import { Alert, AlertState, AlertStore } from "../db/AlertStore";
+import { safePut } from "../safePut";
 
 type AlertStateUpdate = {
   alert: Alert;
@@ -313,11 +314,12 @@ export class AlertManager {
   }
 
   async setCooldownStart(alertId: string, timestamp: number): Promise<void> {
-    await this.utilityKv.put(
-      this.getCooldownStartTimestamp(alertId),
-      timestamp.toString(),
-      { expirationTtl: 600 }
-    );
+    await safePut({
+      key: this.utilityKv,
+      keyName: this.getCooldownStartTimestamp(alertId),
+      value: timestamp.toString(),
+      options: { expirationTtl: 600 },
+    });
   }
 
   private getCooldownStartTimestamp = (alertId: string) =>

--- a/worker/src/lib/managers/LoopsManager.ts
+++ b/worker/src/lib/managers/LoopsManager.ts
@@ -1,6 +1,7 @@
 import { SupabaseClient, createClient } from "@supabase/supabase-js";
 import { Env } from "../..";
 import { Database } from "../../../supabase/database.types";
+import { safePut } from "../safePut";
 
 const MAX_REQUESTS_PER_SECOND = 10;
 const MAX_USERS_PER_PAGE = 1000;
@@ -161,8 +162,11 @@ export async function updateLoopUsers(env: Env) {
     );
     console.log(`adding back cached emails`, newCache.length);
 
-    await env.UTILITY_KV.put("loop_user_emails_v10", JSON.stringify(newCache), {
-      expirationTtl: 60 * 60 * 24, // 1 day
+    await safePut({
+      key: env.UTILITY_KV,
+      keyName: "loop_user_emails_v10",
+      value: JSON.stringify(newCache),
+      options: { expirationTtl: 60 * 60 * 24 }, // 1 day
     });
   }
 }

--- a/worker/src/lib/managers/UsageLimitManager.ts.ts
+++ b/worker/src/lib/managers/UsageLimitManager.ts.ts
@@ -3,6 +3,7 @@ import { Database } from "../../../supabase/database.types";
 import { clickhousePriceCalc } from "../../packages/cost";
 import { Result, err, ok } from "../util/results";
 import { ClickhouseClientWrapper } from "../db/ClickhouseWrapper";
+import { safePut } from "../safePut";
 
 // uses Dat trunc
 export async function checkLimitsSingle(
@@ -130,6 +131,11 @@ export async function checkLimits(
     }
   });
 
-  await env.CACHE_KV.put(cacheKey, result.toString(), { expirationTtl: 60 });
+  await safePut({
+    key: env.CACHE_KV,
+    keyName: cacheKey,
+    value: result.toString(),
+    options: { expirationTtl: 60 },
+  });
   return result;
 }

--- a/worker/src/lib/safePut.ts
+++ b/worker/src/lib/safePut.ts
@@ -1,0 +1,49 @@
+export async function safePut({
+  key,
+  keyName,
+  value,
+  options,
+  maxRetries = 3,
+  currentRetry = 0,
+  baseDelay = 1_000,
+}: {
+  key: KVNamespace;
+  keyName: string;
+  value: string;
+  options?: KVNamespacePutOptions;
+  maxRetries?: number;
+  currentRetry?: number;
+  baseDelay?: number;
+}): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    await key.put(keyName, value, options);
+    return { success: true };
+  } catch (e) {
+    console.log(
+      `Error putting in cache (attempt ${currentRetry + 1}/${maxRetries})`,
+      e
+    );
+    if (currentRetry >= maxRetries) {
+      return { success: false, error: JSON.stringify(e) };
+    }
+
+    const delay = Math.floor(
+      baseDelay * Math.pow(2, currentRetry) * (0.5 + Math.random())
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, delay));
+
+    return safePut({
+      key,
+      keyName,
+      value,
+      options,
+      maxRetries,
+      currentRetry: currentRetry + 1,
+      baseDelay,
+    });
+  }
+}

--- a/worker/src/lib/util/cache/cacheFunctions.ts
+++ b/worker/src/lib/util/cache/cacheFunctions.ts
@@ -3,6 +3,7 @@ import { Env, hash } from "../../..";
 import { HeliconeProxyRequest } from "../../models/HeliconeProxyRequest";
 import { ClickhouseClientWrapper } from "../../db/ClickhouseWrapper";
 import { Database } from "../../../../supabase/database.types";
+import { safePut } from "../../safePut";
 const CACHE_BACKOFF_RETRIES = 5;
 export async function kvKeyFromRequest(
   request: HeliconeProxyRequest,
@@ -62,20 +63,24 @@ async function trySaveToCache(options: SaveToCacheOptions) {
       cacheSeed
     );
     if (freeIndexes.length > 0) {
-      await cacheKv.put(
-        await kvKeyFromRequest(request, freeIndexes[0], cacheSeed),
-        JSON.stringify({
+      const result = await safePut({
+        key: cacheKv,
+        keyName: await kvKeyFromRequest(request, freeIndexes[0], cacheSeed),
+        value: JSON.stringify({
           headers: Object.fromEntries(response.headers.entries()),
           body: responseBody,
         }),
-        {
+        options: {
           expirationTtl,
-        }
-      );
+        },
+      });
+      if (!result.success) {
+        console.error("Error saving to cache:", result.error);
+      }
+      return result.success;
     } else {
       return false;
     }
-    return true;
   } catch (error) {
     console.error("Error saving to cache:", error);
     return false;

--- a/worker/src/routers/gatewayRouter.ts
+++ b/worker/src/routers/gatewayRouter.ts
@@ -64,6 +64,11 @@ async function rateLimitUnapprovedDomains(
           options: { expirationTtl: 365 * 24 * 60 * 60 }, // 1 year
         });
       }
+    await safePut({
+        key: rateLimitKV,
+        keyName: rlKey,
+        value: "1",
+      });
     }
   }
   return {

--- a/worker/src/routers/gatewayRouter.ts
+++ b/worker/src/routers/gatewayRouter.ts
@@ -8,6 +8,7 @@ import {
 } from "../packages/cost/providers/mappings";
 import { Result, err, ok } from "../lib/util/results";
 import { BaseRouter } from "./routerFactory";
+import { safePut } from "../lib/safePut";
 
 function validateURL(url: string) {
   try {
@@ -39,20 +40,29 @@ async function rateLimitUnapprovedDomains(
         rateLimited: true,
       };
     } else if (count) {
-      await rateLimitKV.put(rlKey, (parseInt(count) + 1).toString());
+      await safePut({
+        key: rateLimitKV,
+        keyName: rlKey,
+        value: (parseInt(count) + 1).toString(),
+      });
     } else {
       const gatewayRlList = await rateLimitKV.get(`gateway-rl-list`);
       if (!gatewayRlList) {
-        await rateLimitKV.put(`gateway-rl-list`, JSON.stringify([rlKey]), {
-          expirationTtl: 365 * 24 * 60 * 60, // 1 year
+        await safePut({
+          key: rateLimitKV,
+          keyName: `gateway-rl-list`,
+          value: JSON.stringify([rlKey]),
+          options: { expirationTtl: 365 * 24 * 60 * 60 }, // 1 year
         });
       } else {
         const list = JSON.parse(gatewayRlList);
         list.push(url);
-        await rateLimitKV.put(`gateway-rl-list`, JSON.stringify(list), {
-          expirationTtl: 365 * 24 * 60 * 60, // 1 year
+        await safePut({
+          key: rateLimitKV,
+          keyName: `gateway-rl-list`,
+          value: JSON.stringify(list),
+          options: { expirationTtl: 365 * 24 * 60 * 60 }, // 1 year
         });
-        await rateLimitKV.put(rlKey, "1");
       }
     }
   }


### PR DESCRIPTION
In rare cases the KV put will cause the current process to crash if users have cache enabled or rate limits enabled. 

We are replacing all our puts to wrap them in `safePut` which does and exponential backoff when writing cache keys