### PR TITLE
hotfix: invalid prompt template

### DIFF
--- a/valhalla/jawn/src/lib/handlers/LoggingHandler.ts
+++ b/valhalla/jawn/src/lib/handlers/LoggingHandler.ts
@@ -447,6 +447,12 @@ export class LoggingHandler extends AbstractLogHandler {
     ) {
       return null;
     }
+    if (Array.isArray(context.processedLog.request.heliconeTemplate.template)) {
+      context.processedLog.request.heliconeTemplate.template = {
+        error: "Invalid helicone template",
+        message: "Helicone template is an array",
+      };
+    }
 
     const promptRecord: PromptRecord = {
       promptId: context.message.log.request.promptId,


### PR DESCRIPTION
We are getting into some situations where the template (for some reason) is the messages array and ends up looking something like 

`['<helicone-auto-prompt-input idx=0 />', '<helicone-auto-prompt-input idx=1 />', '<helicone-auto-prompt-input idx=2 />']`

Where the input variables are like this
```json
{role: 'user', content: "What's the weather SF\n\n", id: 0}
```

U think we should just throw this as an unhandled template type since it should be in a JSONB as 
```json
{
    "messages": ['<helicone-auto-prompt-input idx=0 />', '<helicone-auto-prompt-input idx=1 />', '<helicone-auto-prompt-input idx=2 />']
}
```