### PR TITLE
Requests: Smart Loading

### DIFF
--- a/bifrost/lib/clients/jawnTypes/private.ts
+++ b/bifrost/lib/clients/jawnTypes/private.ts
@@ -1090,6 +1090,8 @@ Json: JsonObject;
       includeInputs?: boolean;
       isPartOfExperiment?: boolean;
       isScored?: boolean;
+      /** Format: double */
+      bodySubstringLength?: number;
     };
     ResultSuccess_HeliconeRequest_: {
       data: components["schemas"]["HeliconeRequest"];
@@ -2972,7 +2974,8 @@ export interface operations {
          *   },
          *   "includeInputs": false,
          *   "isScored": false,
-         *   "isPartOfExperiment": false
+         *   "isPartOfExperiment": false,
+         *   "bodySubstringLength": 500
          * }
          */
         "application/json": components["schemas"]["RequestQueryParams"];

--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -1468,6 +1468,8 @@ Json: JsonObject;
       includeInputs?: boolean;
       isPartOfExperiment?: boolean;
       isScored?: boolean;
+      /** Format: double */
+      bodySubstringLength?: number;
     };
     ResultSuccess_HeliconeRequest_: {
       data: components["schemas"]["HeliconeRequest"];
@@ -3708,7 +3710,8 @@ export interface operations {
          *   },
          *   "includeInputs": false,
          *   "isScored": false,
-         *   "isPartOfExperiment": false
+         *   "isPartOfExperiment": false,
+         *   "bodySubstringLength": 500
          * }
          */
         "application/json": components["schemas"]["RequestQueryParams"];

--- a/bifrost/packages/llm-mapper/mappers/gemini/chat.ts
+++ b/bifrost/packages/llm-mapper/mappers/gemini/chat.ts
@@ -246,8 +246,8 @@ export const mapGeminiPro: MapperFn<any, any> = ({
   return {
     schema,
     preview: {
-      request: getRequestText(request),
-      response: getResponseText(response, statusCode),
+      request: getRequestText(request) || String(request),
+      response: getResponseText(response, statusCode) || String(response),
       concatenatedMessages: [
         ...requestMessages,
         ...(responseMessages ? [responseMessages] : []),

--- a/bifrost/packages/llm-mapper/utils/getMappedContent.ts
+++ b/bifrost/packages/llm-mapper/utils/getMappedContent.ts
@@ -217,7 +217,9 @@ const sanitizeMappedContent = (
           2
         );
       }
-    } catch (e) {}
+    } catch (e) {
+      // continue;
+    }
   }
 
   return {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3772,6 +3772,10 @@
 					},
 					"isScored": {
 						"type": "boolean"
+					},
+					"bodySubstringLength": {
+						"type": "number",
+						"format": "double"
 					}
 				},
 				"required": [
@@ -10965,7 +10969,8 @@
 												"created_at": "desc"
 											},
 											"isScored": false,
-											"isPartOfExperiment": false
+											"isPartOfExperiment": false,
+											"bodySubstringLength": 500
 										}
 									}
 								}
@@ -11001,7 +11006,8 @@
 								},
 								"includeInputs": false,
 								"isScored": false,
-								"isPartOfExperiment": false
+								"isPartOfExperiment": false,
+								"bodySubstringLength": 500
 							}
 						}
 					}

--- a/packages/llm-mapper/mappers/gemini/chat.ts
+++ b/packages/llm-mapper/mappers/gemini/chat.ts
@@ -246,8 +246,8 @@ export const mapGeminiPro: MapperFn<any, any> = ({
   return {
     schema,
     preview: {
-      request: getRequestText(request),
-      response: getResponseText(response, statusCode),
+      request: getRequestText(request) || String(request),
+      response: getResponseText(response, statusCode) || String(response),
       concatenatedMessages: [
         ...requestMessages,
         ...(responseMessages ? [responseMessages] : []),

--- a/packages/llm-mapper/utils/getMappedContent.ts
+++ b/packages/llm-mapper/utils/getMappedContent.ts
@@ -217,7 +217,9 @@ const sanitizeMappedContent = (
           2
         );
       }
-    } catch (e) {}
+    } catch (e) {
+      // continue;
+    }
   }
 
   return {

--- a/valhalla/jawn/src/controllers/public/requestController.ts
+++ b/valhalla/jawn/src/controllers/public/requestController.ts
@@ -63,6 +63,7 @@ export interface RequestQueryParams {
   includeInputs?: boolean;
   isPartOfExperiment?: boolean;
   isScored?: boolean;
+  bodySubstringLength?: number;
 }
 
 @Route("v1/request")
@@ -126,7 +127,8 @@ export class RequestController extends Controller {
    *  },
    *  "includeInputs": false,
    *  "isScored": false,
-   *  "isPartOfExperiment": false
+   *  "isPartOfExperiment": false,
+   *  "bodySubstringLength": 500
    * }
    * @param request
    * @returns
@@ -142,6 +144,7 @@ export class RequestController extends Controller {
     },
     isScored: false,
     isPartOfExperiment: false,
+    bodySubstringLength: 500,
   })
   public async getRequestsClickhouse(
     @Body()

--- a/valhalla/jawn/src/managers/request/RequestManager.ts
+++ b/valhalla/jawn/src/managers/request/RequestManager.ts
@@ -1,8 +1,9 @@
 // src/users/usersService.ts
 import { RequestQueryParams } from "../../controllers/public/requestController";
-import { FREQUENT_PRECENT_LOGGING } from "../../lib/db/DBQueryTimer";
-import { AuthParams, supabaseServer } from "../../lib/db/supabase";
-import { dbExecute, dbQueryClickhouse } from "../../lib/shared/db/dbExecute";
+import { KVCache } from "../../lib/cache/kvCache";
+import { AuthParams } from "../../lib/db/supabase";
+import { HeliconeScoresMessage } from "../../lib/handlers/HandlerContext";
+import { dbExecute } from "../../lib/shared/db/dbExecute";
 import { S3Client } from "../../lib/shared/db/s3Client";
 import { FilterNode } from "../../lib/shared/filters/filterDefs";
 import { Result, err, ok, resultMap } from "../../lib/shared/result";
@@ -16,13 +17,11 @@ import {
   getRequestsClickhouse,
   getRequestsClickhouseNoSort,
 } from "../../lib/stores/request/request";
-import { HeliconeRequest } from "../../packages/llm-mapper/types";
 import { costOfPrompt } from "../../packages/cost";
+import { HeliconeRequest } from "../../packages/llm-mapper/types";
+import { cacheResultCustom } from "../../utils/cacheResult";
 import { BaseManager } from "../BaseManager";
 import { ScoreManager } from "../score/ScoreManager";
-import { HeliconeScoresMessage } from "../../lib/handlers/HandlerContext";
-import { cacheResultCustom } from "../../utils/cacheResult";
-import { KVCache } from "../../lib/cache/kvCache";
 export const getModelFromPath = (path: string) => {
   const regex1 = /\/engines\/([^/]+)/;
   const regex2 = /models\/([^/:]+)/;
@@ -455,6 +454,7 @@ export class RequestManager extends BaseManager {
       isCached,
       isPartOfExperiment,
       isScored,
+      bodySubstringLength,
     } = params;
 
     let newFilter = filter;
@@ -471,21 +471,24 @@ export class RequestManager extends BaseManager {
           limit,
           sort,
           isPartOfExperiment,
-          isScored
+          isScored,
+          bodySubstringLength
         )
       : sort.created_at === "desc"
       ? await getRequestsClickhouseNoSort(
           this.authParams.organizationId,
           newFilter,
           offset,
-          limit
+          limit,
+          bodySubstringLength
         )
       : await getRequestsClickhouse(
           this.authParams.organizationId,
           newFilter,
           offset,
           limit,
-          sort
+          sort,
+          bodySubstringLength
         );
 
     return resultMap(requests, (req) => {

--- a/valhalla/jawn/src/packages/llm-mapper/mappers/gemini/chat.ts
+++ b/valhalla/jawn/src/packages/llm-mapper/mappers/gemini/chat.ts
@@ -246,8 +246,8 @@ export const mapGeminiPro: MapperFn<any, any> = ({
   return {
     schema,
     preview: {
-      request: getRequestText(request),
-      response: getResponseText(response, statusCode),
+      request: getRequestText(request) || String(request),
+      response: getResponseText(response, statusCode) || String(response),
       concatenatedMessages: [
         ...requestMessages,
         ...(responseMessages ? [responseMessages] : []),

--- a/valhalla/jawn/src/packages/llm-mapper/utils/getMappedContent.ts
+++ b/valhalla/jawn/src/packages/llm-mapper/utils/getMappedContent.ts
@@ -217,7 +217,9 @@ const sanitizeMappedContent = (
           2
         );
       }
-    } catch (e) {}
+    } catch (e) {
+      // continue;
+    }
   }
 
   return {

--- a/valhalla/jawn/src/tsoa-build/private/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/private/routes.ts
@@ -849,6 +849,7 @@ const models: TsoaRoute.Models = {
             "includeInputs": {"dataType":"boolean"},
             "isPartOfExperiment": {"dataType":"boolean"},
             "isScored": {"dataType":"boolean"},
+            "bodySubstringLength": {"dataType":"double"},
         },
         "additionalProperties": false,
     },

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -2713,6 +2713,10 @@
 					},
 					"isScored": {
 						"type": "boolean"
+					},
+					"bodySubstringLength": {
+						"type": "number",
+						"format": "double"
 					}
 				},
 				"required": [
@@ -8019,7 +8023,8 @@
 												"created_at": "desc"
 											},
 											"isScored": false,
-											"isPartOfExperiment": false
+											"isPartOfExperiment": false,
+											"bodySubstringLength": 500
 										}
 									}
 								}
@@ -8055,7 +8060,8 @@
 								},
 								"includeInputs": false,
 								"isScored": false,
-								"isPartOfExperiment": false
+								"isPartOfExperiment": false,
+								"bodySubstringLength": 500
 							}
 						}
 					}

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -1302,6 +1302,7 @@ const models: TsoaRoute.Models = {
             "includeInputs": {"dataType":"boolean"},
             "isPartOfExperiment": {"dataType":"boolean"},
             "isScored": {"dataType":"boolean"},
+            "bodySubstringLength": {"dataType":"double"},
         },
         "additionalProperties": false,
     },

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -3772,6 +3772,10 @@
 					},
 					"isScored": {
 						"type": "boolean"
+					},
+					"bodySubstringLength": {
+						"type": "number",
+						"format": "double"
 					}
 				},
 				"required": [
@@ -10965,7 +10969,8 @@
 												"created_at": "desc"
 											},
 											"isScored": false,
-											"isPartOfExperiment": false
+											"isPartOfExperiment": false,
+											"bodySubstringLength": 500
 										}
 									}
 								}
@@ -11001,7 +11006,8 @@
 								},
 								"includeInputs": false,
 								"isScored": false,
-								"isPartOfExperiment": false
+								"isPartOfExperiment": false,
+								"bodySubstringLength": 500
 							}
 						}
 					}

--- a/web/components/templates/requests/requestsPageV2.tsx
+++ b/web/components/templates/requests/requestsPageV2.tsx
@@ -1,5 +1,6 @@
 import { ArrowPathIcon, PlusIcon } from "@heroicons/react/24/outline";
 
+import { Row } from "@/components/layout/common";
 import { Button } from "@/components/ui/button";
 import { HeliconeRequest, MappedLLMRequest } from "@/packages/llm-mapper/types";
 import { heliconeRequestToMappedContent } from "@/packages/llm-mapper/utils/getMappedContent";
@@ -42,23 +43,22 @@ import { clsx } from "../../shared/clsx";
 import ThemedTable from "../../shared/themed/table/themedTable";
 import ThemedModal from "../../shared/themed/themedModal";
 import useSearchParams from "../../shared/utils/useSearchParams";
+import OnboardingFloatingPrompt from "../dashboard/OnboardingFloatingPrompt";
 import NewDataset from "../datasets/NewDataset";
 import { getInitialColumns } from "./initialColumns";
-import RequestCard from "./requestCard";
-import RequestDiv from "./requestDiv";
-import StreamWarning from "./StreamWarning";
-import TableFooter from "./tableFooter";
-import UnauthorizedView from "./UnauthorizedView";
-import useRequestsPageV2 from "./useRequestsPageV2";
-import OnboardingFloatingPrompt from "../dashboard/OnboardingFloatingPrompt";
-import { Row } from "@/components/layout/common";
-import RequestsEmptyState from "./RequestsEmptyState";
 import {
   getMockFilterMap,
   getMockProperties,
   getMockRequestCount,
   getMockRequests,
 } from "./mockRequestsData";
+import RequestCard from "./requestCard";
+import RequestDiv from "./requestDiv";
+import RequestsEmptyState from "./RequestsEmptyState";
+import StreamWarning from "./StreamWarning";
+import TableFooter from "./tableFooter";
+import UnauthorizedView from "./UnauthorizedView";
+import useRequestsPageV2 from "./useRequestsPageV2";
 
 interface RequestsPageV2Props {
   currentPage: number;
@@ -322,7 +322,8 @@ const RequestsPageV2 = (props: RequestsPageV2Props) => {
     },
     sortLeaf,
     isCached,
-    isLive
+    isLive,
+    1000
   );
 
   const count = shouldShowMockData ? mockCount : realCount;

--- a/web/components/templates/requests/useRequestsPageV2.tsx
+++ b/web/components/templates/requests/useRequestsPageV2.tsx
@@ -23,7 +23,8 @@ const useRequestsPageV2 = (
   advancedFilter: FilterNode,
   sortLeaf: SortLeafRequest,
   isCached: boolean,
-  isLive: boolean
+  isLive: boolean,
+  bodySubstringLength: number = 500 // Default to 500 characters
 ) => {
   const [timeFilter] = useState<TimeFilter>({
     start: getTimeIntervalAgo("all"),
@@ -83,7 +84,8 @@ const useRequestsPageV2 = (
     filter,
     sortLeaf,
     isCached,
-    isLive
+    isLive,
+    bodySubstringLength
   );
 
   const isDataLoading = requests.isLoading || isPropertiesLoading;

--- a/web/lib/clients/jawnTypes/private.ts
+++ b/web/lib/clients/jawnTypes/private.ts
@@ -1090,6 +1090,8 @@ Json: JsonObject;
       includeInputs?: boolean;
       isPartOfExperiment?: boolean;
       isScored?: boolean;
+      /** Format: double */
+      bodySubstringLength?: number;
     };
     ResultSuccess_HeliconeRequest_: {
       data: components["schemas"]["HeliconeRequest"];
@@ -2972,7 +2974,8 @@ export interface operations {
          *   },
          *   "includeInputs": false,
          *   "isScored": false,
-         *   "isPartOfExperiment": false
+         *   "isPartOfExperiment": false,
+         *   "bodySubstringLength": 500
          * }
          */
         "application/json": components["schemas"]["RequestQueryParams"];

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -1468,6 +1468,8 @@ Json: JsonObject;
       includeInputs?: boolean;
       isPartOfExperiment?: boolean;
       isScored?: boolean;
+      /** Format: double */
+      bodySubstringLength?: number;
     };
     ResultSuccess_HeliconeRequest_: {
       data: components["schemas"]["HeliconeRequest"];
@@ -3708,7 +3710,8 @@ export interface operations {
          *   },
          *   "includeInputs": false,
          *   "isScored": false,
-         *   "isPartOfExperiment": false
+         *   "isPartOfExperiment": false,
+         *   "bodySubstringLength": 500
          * }
          */
         "application/json": components["schemas"]["RequestQueryParams"];

--- a/web/packages/llm-mapper/mappers/gemini/chat.ts
+++ b/web/packages/llm-mapper/mappers/gemini/chat.ts
@@ -246,8 +246,8 @@ export const mapGeminiPro: MapperFn<any, any> = ({
   return {
     schema,
     preview: {
-      request: getRequestText(request),
-      response: getResponseText(response, statusCode),
+      request: getRequestText(request) || String(request),
+      response: getResponseText(response, statusCode) || String(response),
       concatenatedMessages: [
         ...requestMessages,
         ...(responseMessages ? [responseMessages] : []),

--- a/web/packages/llm-mapper/utils/getMappedContent.ts
+++ b/web/packages/llm-mapper/utils/getMappedContent.ts
@@ -217,7 +217,9 @@ const sanitizeMappedContent = (
           2
         );
       }
-    } catch (e) {}
+    } catch (e) {
+      // continue;
+    }
   }
 
   return {

--- a/web/services/hooks/requests.tsx
+++ b/web/services/hooks/requests.tsx
@@ -87,7 +87,7 @@ export const useGetRequestsWithBodies = (
   sortLeaf: SortLeafRequest,
   isLive: boolean = false,
   isCached: boolean = false,
-  bodySubstringLength: number
+  bodySubstringLength?: number
 ) => {
   const org = useOrg();
 
@@ -227,7 +227,7 @@ const useGetRequests = (
   sortLeaf: SortLeafRequest,
   isCached: boolean = false,
   isLive: boolean = false,
-  bodySubstringLength: number
+  bodySubstringLength?: number
 ) => {
   return {
     requests: useGetRequestsWithBodies(

--- a/worker/src/packages/llm-mapper/mappers/gemini/chat.ts
+++ b/worker/src/packages/llm-mapper/mappers/gemini/chat.ts
@@ -246,8 +246,8 @@ export const mapGeminiPro: MapperFn<any, any> = ({
   return {
     schema,
     preview: {
-      request: getRequestText(request),
-      response: getResponseText(response, statusCode),
+      request: getRequestText(request) || String(request),
+      response: getResponseText(response, statusCode) || String(response),
       concatenatedMessages: [
         ...requestMessages,
         ...(responseMessages ? [responseMessages] : []),

--- a/worker/src/packages/llm-mapper/utils/getMappedContent.ts
+++ b/worker/src/packages/llm-mapper/utils/getMappedContent.ts
@@ -217,7 +217,9 @@ const sanitizeMappedContent = (
           2
         );
       }
-    } catch (e) {}
+    } catch (e) {
+      // continue;
+    }
   }
 
   return {


### PR DESCRIPTION
- Refactor: substrings of request_body and response_body from clickhouse are returned quickly to the frontend and used in place of llm-mapped s3 fetched raw objects
- Update: requestDiv now fetches full request with bodies



---

- Temporary: gemini-chat mapper preview compatibility - Is this something we want to keep?
<img width="764" alt="Screenshot 2025-03-16 at 16 34 11" src="https://github.com/user-attachments/assets/9af37698-e648-4ea6-adc6-56e5fe086c71" />
(Otherwise previews for response and request on the table would show up as empty)
