### PR TITLE
fix (python-sdk): correct logger initialization and renaming

### DIFF
--- a/sdk/python/async/helicone_async/async_logger.py
+++ b/sdk/python/async/helicone_async/async_logger.py
@@ -72,6 +72,16 @@ class HeliconeAsyncLogger:
         This reinitializes the Traceloop SDK with a fresh exporter instance.
         """
         if not self._logging_enabled:
-            # Create a new exporter instance
-            self.exporter.__init__(endpoint=self.base_url, headers={
-                                   "Authorization": f"Bearer {self.api_key}"})
+            self.exporter = OTLPSpanExporter(
+                endpoint=self.base_url,
+                headers={"Authorization": f"Bearer {self.api_key}"}
+            )
+
+            Traceloop.init(
+                exporter=self.exporter,
+                disable_batch=True,
+                should_enrich_metrics=False,
+                instruments=SUPPORTED_INSTRUMENTS,
+            )
+            
+            self._logging_enabled = True

--- a/sdk/python/helpers/helicone_helpers/manual_logger.py
+++ b/sdk/python/helpers/helicone_helpers/manual_logger.py
@@ -119,7 +119,7 @@ class HeliconeManualLogger:
                 "seconds": int(end_time),
                 "milliseconds": int((end_time - int(end_time)) * 1000)
             },
-            "timeToFirstToken": options.get("time_to_first_token") if options.get("time_to_first_token") is not None else None
+            "timeToFirstToken": options.get("time_to_first_token_ms") if options.get("time_to_first_token_ms") is not None else None
         }
 
         fetch_options = {


### PR DESCRIPTION
## Fix: only changes to the python SDK:

- Replace incorrect `exporter.__init__()` call with proper OTLPSpanExporter instantiation
- Rename time_to_first_token to time_to_first_token_ms to match expected parameter name as defined in `LoggingOptions`