### PR TITLE
Fix: Unsafe realtime llm-mapper parse

### DIFF
--- a/bifrost/packages/llm-mapper/mappers/openai/realtime.ts
+++ b/bifrost/packages/llm-mapper/mappers/openai/realtime.ts
@@ -1,4 +1,5 @@
 import { LlmSchema, Message } from "../../types";
+import { isJSON } from "../../utils/contentHelpers";
 import { MapperFn } from "../types";
 
 export const mapRealtimeRequest: MapperFn<any, any> = ({
@@ -285,7 +286,9 @@ const mapRealtimeMessages = (messages: SocketMessage[]): Message[] => {
                 tool_calls: [
                   {
                     name: output.name,
-                    arguments: JSON.parse(output.arguments),
+                    arguments: isJSON(output.arguments)
+                      ? JSON.parse(output.arguments)
+                      : output.arguments,
                   },
                 ],
                 timestamp: msg.timestamp,
@@ -306,7 +309,9 @@ const mapRealtimeMessages = (messages: SocketMessage[]): Message[] => {
               tool_calls: [
                 {
                   name: undefined,
-                  arguments: JSON.parse(item.output),
+                  arguments: isJSON(item.output)
+                    ? JSON.parse(item.output)
+                    : item.output,
                 },
               ],
               timestamp: msg.timestamp,

--- a/examples/qawolf-ws/index.ts
+++ b/examples/qawolf-ws/index.ts
@@ -190,6 +190,34 @@ function stopRecording() {
 ws.on("open", function open() {
   console.log("Connected to server.");
 
+  /* -------------------------------------------------------------------------- */
+  /*               Simulate bug with Socket.IO socket.emit format               */
+  /* -------------------------------------------------------------------------- */
+  const callId = "simulated_call_" + Date.now();
+  // Original requested format: socket.emit("conversation.item.create", {...})
+  console.log("Simulating socket.emit with the following payload:");
+  console.log(`socket.emit("conversation.item.create", {
+    item: {
+      call_id: ${callId},
+      output: "success",
+      type: "function_call_output",
+    },
+  });`);
+
+  // Actually send using WebSocket
+  ws.send(
+    JSON.stringify({
+      type: "conversation.item.create",
+      item: {
+        call_id: callId,
+        output: "success",
+        type: "function_call_output",
+      },
+    })
+  );
+  console.log("Sent simulated function_call_output with call_id:", callId);
+  /* ------------------------------------------------------------------------- */
+
   // Send session update immediately
   console.log("Sending immediate session update...");
   ws.send(JSON.stringify(sessionUpdate));

--- a/packages/llm-mapper/mappers/openai/realtime.ts
+++ b/packages/llm-mapper/mappers/openai/realtime.ts
@@ -1,4 +1,5 @@
 import { LlmSchema, Message } from "../../types";
+import { isJSON } from "../../utils/contentHelpers";
 import { MapperFn } from "../types";
 
 export const mapRealtimeRequest: MapperFn<any, any> = ({
@@ -285,7 +286,9 @@ const mapRealtimeMessages = (messages: SocketMessage[]): Message[] => {
                 tool_calls: [
                   {
                     name: output.name,
-                    arguments: JSON.parse(output.arguments),
+                    arguments: isJSON(output.arguments)
+                      ? JSON.parse(output.arguments)
+                      : output.arguments,
                   },
                 ],
                 timestamp: msg.timestamp,
@@ -306,7 +309,9 @@ const mapRealtimeMessages = (messages: SocketMessage[]): Message[] => {
               tool_calls: [
                 {
                   name: undefined,
-                  arguments: JSON.parse(item.output),
+                  arguments: isJSON(item.output)
+                    ? JSON.parse(item.output)
+                    : item.output,
                 },
               ],
               timestamp: msg.timestamp,

--- a/valhalla/jawn/src/lib/proxy/WebSocketProxyRequestHandler.ts
+++ b/valhalla/jawn/src/lib/proxy/WebSocketProxyRequestHandler.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto";
 import { Headers, Response } from "node-fetch";
 import { SocketMessage } from "../../types/realtime";
+import { safeJSONStringify } from "../../utils/sanitize";
 import { RequestWrapper } from "../requestWrapper/requestWrapper";
 import { DBLoggable } from "./DBLoggable";
 
@@ -84,12 +85,12 @@ export async function handleSocketSession(
         country_code: null,
         experimentColumnId: null,
         experimentRowIndex: null,
-        bodyText: JSON.stringify(requestBody),
+        bodyText: safeJSONStringify(requestBody),
       },
       response: {
         responseId,
         getResponseBody: async () => ({
-          body: JSON.stringify(responseBody),
+          body: safeJSONStringify(responseBody),
           endTime,
         }),
         status: async () => 200,

--- a/valhalla/jawn/src/packages/llm-mapper/mappers/openai/realtime.ts
+++ b/valhalla/jawn/src/packages/llm-mapper/mappers/openai/realtime.ts
@@ -1,4 +1,5 @@
 import { LlmSchema, Message } from "../../types";
+import { isJSON } from "../../utils/contentHelpers";
 import { MapperFn } from "../types";
 
 export const mapRealtimeRequest: MapperFn<any, any> = ({
@@ -285,7 +286,9 @@ const mapRealtimeMessages = (messages: SocketMessage[]): Message[] => {
                 tool_calls: [
                   {
                     name: output.name,
-                    arguments: JSON.parse(output.arguments),
+                    arguments: isJSON(output.arguments)
+                      ? JSON.parse(output.arguments)
+                      : output.arguments,
                   },
                 ],
                 timestamp: msg.timestamp,
@@ -306,7 +309,9 @@ const mapRealtimeMessages = (messages: SocketMessage[]): Message[] => {
               tool_calls: [
                 {
                   name: undefined,
-                  arguments: JSON.parse(item.output),
+                  arguments: isJSON(item.output)
+                    ? JSON.parse(item.output)
+                    : item.output,
                 },
               ],
               timestamp: msg.timestamp,

--- a/web/packages/llm-mapper/mappers/openai/realtime.ts
+++ b/web/packages/llm-mapper/mappers/openai/realtime.ts
@@ -1,4 +1,5 @@
 import { LlmSchema, Message } from "../../types";
+import { isJSON } from "../../utils/contentHelpers";
 import { MapperFn } from "../types";
 
 export const mapRealtimeRequest: MapperFn<any, any> = ({
@@ -285,7 +286,9 @@ const mapRealtimeMessages = (messages: SocketMessage[]): Message[] => {
                 tool_calls: [
                   {
                     name: output.name,
-                    arguments: JSON.parse(output.arguments),
+                    arguments: isJSON(output.arguments)
+                      ? JSON.parse(output.arguments)
+                      : output.arguments,
                   },
                 ],
                 timestamp: msg.timestamp,
@@ -306,7 +309,9 @@ const mapRealtimeMessages = (messages: SocketMessage[]): Message[] => {
               tool_calls: [
                 {
                   name: undefined,
-                  arguments: JSON.parse(item.output),
+                  arguments: isJSON(item.output)
+                    ? JSON.parse(item.output)
+                    : item.output,
                 },
               ],
               timestamp: msg.timestamp,

--- a/worker/src/packages/llm-mapper/mappers/openai/realtime.ts
+++ b/worker/src/packages/llm-mapper/mappers/openai/realtime.ts
@@ -1,4 +1,5 @@
 import { LlmSchema, Message } from "../../types";
+import { isJSON } from "../../utils/contentHelpers";
 import { MapperFn } from "../types";
 
 export const mapRealtimeRequest: MapperFn<any, any> = ({
@@ -285,7 +286,9 @@ const mapRealtimeMessages = (messages: SocketMessage[]): Message[] => {
                 tool_calls: [
                   {
                     name: output.name,
-                    arguments: JSON.parse(output.arguments),
+                    arguments: isJSON(output.arguments)
+                      ? JSON.parse(output.arguments)
+                      : output.arguments,
                   },
                 ],
                 timestamp: msg.timestamp,
@@ -306,7 +309,9 @@ const mapRealtimeMessages = (messages: SocketMessage[]): Message[] => {
               tool_calls: [
                 {
                   name: undefined,
-                  arguments: JSON.parse(item.output),
+                  arguments: isJSON(item.output)
+                    ? JSON.parse(item.output)
+                    : item.output,
                 },
               ],
               timestamp: msg.timestamp,


### PR DESCRIPTION
Misc: Add simulated reproduction to examples
Fix: Only use parse in mapper if isJson
Fix: Now also using safeJsonStringify