### PR TITLE
Embed tutorial video and fixed small typo

### DIFF
--- a/docs/other-integrations/open-webui.mdx
+++ b/docs/other-integrations/open-webui.mdx
@@ -18,6 +18,8 @@ Integrating Helicone with Open WebUI enables comprehensive observability across 
 
 ## Integration Steps
 
+https://youtu.be/8iVHOkUrpSA
+
 <Steps>
   <Step title="Create a Helicone account + Generate an API Key">
     Create a [Helicone account](https://www.helicone.ai/) and log in to generate an [API key here](https://us.helicone.ai/settings/api-keys).
@@ -33,7 +35,7 @@ Integrating Helicone with Open WebUI enables comprehensive observability across 
   Portal](https://platform.openai.com/account/api-keys) to generate an API key.
 </Step>
 
-  <Step title="Run your Open WebUI application using Helicone\'s base URL">
+  <Step title="Run your Open WebUI application using Helicone's base URL">
     Update the OpenAI API base URL of your Docker command when launching your Web OpenUI Docker container. By using this base URL, you will be able to both perform queries and monitor them automatically.
 
 ```bash


### PR DESCRIPTION
Embed tutorial video for the integration, as well as fixed a small `\` markdown typo.

https://youtu.be/8iVHOkUrpSA