### PR TITLE
latency as extra arg and moving headers to options

### DIFF
--- a/docs/getting-started/integration-method/manual-logger-typescript.mdx
+++ b/docs/getting-started/integration-method/manual-logger-typescript.mdx
@@ -108,11 +108,9 @@ const requestBody = {
 const response = await openai.chat.completions.create(requestBody);
 
 // Log the request and response to Helicone
-await helicone.logSingleRequest(
-  requestBody,
-  JSON.stringify(response),
-  { "Helicone-User-Id": "user-123" } // Optional additional headers
-);
+await helicone.logSingleRequest(requestBody, JSON.stringify(response), {
+  additionalHeaders: { "Helicone-User-Id": "user-123" }, // Optional additional headers
+});
 
 console.log(response.choices[0].message.content);
 ```
@@ -176,7 +174,7 @@ const { question } = await request.json();
 
     after(
       helicone.logSingleRequest(nonStreamingBody, JSON.stringify(completion), {
-        "Helicone-User-Id": "123",
+        additionalHeaders: { "Helicone-User-Id": "123" },
       }),
     );
 
@@ -421,7 +419,10 @@ Used for logging a single request with a response body without needing to manage
 logSingleRequest(
   request: HeliconeLogRequest,
   body: string,
-  additionalHeaders?: Record<string, string>
+  options: {
+    additionalHeaders?: Record<string, string>;
+    latencyMs?: number;
+  }
 ): Promise<void>
 ```
 
@@ -436,7 +437,7 @@ logSingleRequest(
 ```typescript
 const response = await llmProvider.createCompletion(requestBody);
 await helicone.logSingleRequest(requestBody, JSON.stringify(response), {
-  "Helicone-User-Id": userId,
+  additionalHeaders: { "Helicone-User-Id": userId },
 });
 ```
 

--- a/docs/guides/cookbooks/manual-logger-streaming.mdx
+++ b/docs/guides/cookbooks/manual-logger-streaming.mdx
@@ -362,7 +362,7 @@ await helicone.logSingleRequest(
     input: { expression: "2 + 2" },
   },
   JSON.stringify({ result: 4 }),
-  { "Helicone-User-Id": "user-123" }
+  { additionalHeaders: { "Helicone-User-Id": "user-123" } }
 );
 
 // Log a vector database operation
@@ -379,7 +379,7 @@ await helicone.logSingleRequest(
     { id: "2", content: "Pasta recipe 2", score: 0.87 },
     { id: "3", content: "Pasta recipe 3", score: 0.82 },
   ]),
-  { "Helicone-User-Id": "user-123" }
+  { additionalHeaders: { "Helicone-User-Id": "user-123" } }
 );
 ```
 

--- a/sdk/typescript/helpers/manual_logger/HeliconeManualLogger.ts
+++ b/sdk/typescript/helpers/manual_logger/HeliconeManualLogger.ts
@@ -114,7 +114,7 @@ export class HeliconeManualLogger {
    *
    * @example
    * ```typescript
-   * helicone.logSingleRequest(request, body, { "Helicone-User-Id": userId }, 1000);
+   * helicone.logSingleRequest(request, body, { additionalHeaders: { "Helicone-User-Id": userId }, latencyMs: 1000 });
    * ```
    */
   public async logSingleRequest(

--- a/sdk/typescript/helpers/manual_logger/HeliconeManualLogger.ts
+++ b/sdk/typescript/helpers/manual_logger/HeliconeManualLogger.ts
@@ -109,19 +109,31 @@ export class HeliconeManualLogger {
    * @param request - The request object to log
    * @param body - The response body as a string
    * @param additionalHeaders - Additional headers to send with the request
+   * @param latencyMs - The latency of the request in milliseconds
    * @returns A Promise that resolves when logging is complete
+   *
+   * @example
+   * ```typescript
+   * helicone.logSingleRequest(request, body, { "Helicone-User-Id": userId }, 1000);
+   * ```
    */
   public async logSingleRequest(
     request: HeliconeLogRequest,
     body: string,
-    additionalHeaders?: Record<string, string>
+    options: {
+      additionalHeaders?: Record<string, string>;
+      latencyMs?: number;
+    }
   ): Promise<void> {
     const startTime = Date.now();
+    const endTime = options.latencyMs
+      ? startTime + options.latencyMs
+      : Date.now();
 
     await this.sendLog(request, body, {
       startTime,
-      endTime: Date.now(),
-      additionalHeaders,
+      endTime,
+      additionalHeaders: options.additionalHeaders,
       status: 200,
     });
   }

--- a/sdk/typescript/helpers/package.json
+++ b/sdk/typescript/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helicone/helpers",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "description": "A Node.js wrapper for some of Helicone's common functionalities",


### PR DESCRIPTION
Enhance logSingleRequest with latency tracking

Before:
```ts
await helicone.logSingleRequest(requestBody, JSON.stringify(response), { "Helicone-User-Id": userId });
```

After:
```ts
await helicone.logSingleRequest(requestBody, JSON.stringify(response), {
  additionalHeaders: { "Helicone-User-Id": userId },
  latencyMs: 1000 // Optional custom latency tracking
});
```