### PR TITLE
Include OpenAI Responses API to docs

### DIFF
--- a/docs/integrations/openai/responses.mdx
+++ b/docs/integrations/openai/responses.mdx
@@ -1,0 +1,197 @@
+---
+title: "OpenAI Responses Integration"
+sidebarTitle: "Responses"
+description: "Integrate OpenAI Responses with Helicone to monitor and analyze your model's responses."
+"twitter:title": "OpenAI Responses Integration - Helicone OSS LLM Observability"
+icon: "plug"
+iconType: "solid"
+---
+
+## Introduction
+
+OpenAI Responses enable you to provide text or image inputs to generate text or JSON outputs by calling your own custom code or use built-in tools like web search or file search. By integrating them with Helicone, you can monitor performance, analyze interactions, and gain valuable insights into your responses.
+
+## Integration Steps
+
+<Steps>
+  <Step title="Create an Account and Generate an API Key">
+    Log into [Helicone](https://www.helicone.ai) or create a new account. Once logged in, generate a [Helicone API key](https://helicone.ai/developer).
+
+    <Note>
+      Keep your API keys secure and do not expose them publicly.
+    </Note>
+
+  </Step>
+
+  <Step title="Set Environment Variables">
+    Set your OpenAI and Helicone API keys as environment variables:
+
+    ```bash
+    export OPENAI_API_KEY=<your-openai-api-key>
+    export HELICONE_API_KEY=<your-helicone-api-key>
+    ```
+
+  </Step>
+
+  <Step title="Install the OpenAI SDK">
+    If you haven't already, install the OpenAI SDK:
+
+    ```bash
+    npm install openai
+    ```
+
+  </Step>
+
+  <Step title="Configure the OpenAI Client to Use Helicone Proxy">
+    Modify your OpenAI client configuration to route requests through the Helicone proxy and include the `Helicone-Auth` header:
+
+    ```typescript
+    import OpenAI from "openai";
+
+    const openai = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+      baseURL: "https://oai.helicone.ai/v1",
+      defaultHeaders: {
+        "Helicone-Auth": `Bearer ${process.env.HELICONE_API_KEY}`,
+      },
+    });
+    ```
+
+  </Step>
+
+  <Step title="Start Using OpenAI Responses API with Helicone">
+    With the above setup, any calls to OpenAI Responses API will automatically be logged and monitored by Helicone. You can now implement your responses without any additional configuration.
+
+    Here's a basic example of creating and using a response for different types of inputs and tools:
+
+    <Note>
+      Replace the response's model, input, and output with content relevant to your application.
+    </Note>
+
+    ```typescript
+    // Text input response
+    const textInputResponse = await openai.responses.create({
+        model: "gpt-4.1",
+        input: "Tell me a three sentence bedtime story about a unicorn."
+    });
+
+    console.log(textInputResponse);
+
+    // Image input response
+    const imageInputResponse = await openai.responses.create({
+        model: "gpt-4.1",
+        input: [
+            {
+                role: "user",
+                content: [
+                    { type: "input_text", text: "what is in this image?" },
+                    {
+                        type: "input_image",
+                        image_url:
+                            "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+                    },
+                ],
+            },
+        ],
+    });
+
+    console.log(imageInputResponse);
+
+    // Web search tool usage
+    const webSearchResponse = await openai.responses.create({
+      model: "gpt-4.1",
+      tools: [{ type: "web_search_preview" }],
+      input: "What was a positive news story from today?",
+    });
+
+    console.log(webSearchResponse);
+
+    // File search tool usage
+    const fileSearchResponse = await openai.responses.create({
+      model: "gpt-4.1",
+      tools: [{
+        type: "file_search",
+        vector_store_ids: ["vs_1234567890"],
+        max_num_results: 20
+      }],
+      input: "What are the attributes of an ancient brown dragon?",
+    });
+
+    console.log(fileSearchResponse);
+
+    // Streaming response
+    const streamingResponse = await openai.responses.create({
+      model: "gpt-4.1",
+      instructions: "You are a helpful assistant.",
+      input: "Hello!",
+      stream: true,
+    });
+
+    for await (const event of streamingResponse) {
+        console.log(event);
+    }
+
+    // Function calling response
+    const tools = [
+      {
+        type: "function" as const,
+        name: "get_current_weather",
+        description: "Get the current weather in a given location",
+        parameters: {
+          type: "object",
+          properties: {
+            location: {
+              type: "string",
+              description: "The city and state, e.g. San Francisco, CA"
+            },
+            unit: { type: "string", enum: ["celsius", "fahrenheit"] }
+          },
+          required: ["location", "unit"]
+        },
+        strict: true
+      },
+    ];
+
+    const functionCallingResponse = await openai.responses.create({
+        model: "gpt-4.1",
+        tools: tools,
+        input: "What is the weather like in Boston today?",
+        tool_choice: "auto",
+    });
+
+    console.log(functionCallingResponse);
+
+    // Reasoning response
+    const reasoningResponse = await openai.responses.create({
+      model: "o3-mini",
+      input: "How much wood would a woodchuck chuck?",
+      reasoning: {
+        effort: "high"
+      }
+    });
+
+    console.log(reasoningResponse);
+    ```
+  </Step>
+</Steps>
+
+<Note>
+  You can also include session headers in each request to have more granular
+  control over session tracking. This approach is especially useful if you want
+  to handle sessions dynamically or manage multiple sessions concurrently.
+</Note>
+
+### Related Guides
+
+<CardGroup cols={1}>
+  <Card
+    title="Building a chatbot with OpenAI structured outputs"
+    icon="lightbulb"
+    href="/guides/cookbooks/openai-structured-outputs"
+    iconType="light"
+    vertical
+  >
+    This step-by-step guide covers function calling, response formatting and
+    monitoring with Helicone.
+  </Card>
+</CardGroup>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -103,7 +103,8 @@
             "integrations/openai/llamaindex",
             "integrations/openai/curl",
             "integrations/openai/assistants",
-            "integrations/openai/realtime"
+            "integrations/openai/realtime",
+            "integrations/openai/responses"
           ]
         },
         {


### PR DESCRIPTION
Generate documentation for the OpenAI Responses API.
- Include the Responses API inside OpenAI's the sidebar
- Generate documentation leveraging OpenAI examples

![CleanShot 2025-04-24 at 12 33 16@2x](https://github.com/user-attachments/assets/9614c9c4-226a-4a2f-a871-3a50d2006ad0)
