### PR TITLE
Added "copy" function to blog headings

### DIFF
--- a/bifrost/components/blog/HeadingWithCopyLink.tsx
+++ b/bifrost/components/blog/HeadingWithCopyLink.tsx
@@ -55,7 +55,7 @@ export const HeadingWithCopyLink: React.FC<HeadingWithCopyLinkProps> = ({
                 <Button
                     variant="ghost"
                     size="icon"
-                    className="size-4 shrink-0"
+                    className="size-4 shrink-0 hidden sm:inline-flex"
                     onClick={(e) => {
                         e.stopPropagation();
                         copyAndJump();

--- a/bifrost/components/blog/HeadingWithCopyLink.tsx
+++ b/bifrost/components/blog/HeadingWithCopyLink.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Check, Link as LinkIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+
+interface HeadingWithCopyLinkProps {
+    level: 1 | 2 | 3 | 4 | 5 | 6;
+    id?: string;
+    children?: React.ReactNode;
+    className?: string;
+}
+
+export const HeadingWithCopyLink: React.FC<HeadingWithCopyLinkProps> = ({
+    level,
+    id,
+    children,
+    className,
+}) => {
+    const [isHovered, setIsHovered] = useState(false);
+    const [copied, setCopied] = useState(false);
+
+    const HeadingTag = `h${level}` as keyof JSX.IntrinsicElements;
+
+    const copyLink = async () => {
+        if (!id || copied) return;
+        const url = `${window.location.origin}${window.location.pathname}#${id}`;
+        try {
+            await navigator.clipboard.writeText(url);
+            setCopied(true);
+            setIsHovered(false);
+            setTimeout(() => setCopied(false), 1500);
+        } catch (err) {
+            console.error('Failed to copy link: ', err);
+        }
+    };
+
+    return (
+        <HeadingTag
+            id={id}
+            className={cn("relative flex items-center gap-2 cursor-pointer group", className)}
+            onClick={id ? copyLink : undefined}
+            onMouseEnter={() => id && setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+            title={id ? "Copy link to heading" : undefined}
+        >
+            {children}
+            {id && (
+                <TooltipProvider delayDuration={0}>
+                    <Tooltip open={copied}>
+                        <TooltipTrigger asChild>
+                            <div className="size-4 shrink-0">
+                                {copied ? (
+                                    <Check className="size-full text-brand" />
+                                ) : isHovered ? (
+                                    <LinkIcon className="size-full text-muted-foreground" />
+                                ) : null}
+                            </div>
+                        </TooltipTrigger>
+                        <TooltipContent side="right">Copied!</TooltipContent>
+                    </Tooltip>
+                </TooltipProvider>
+            )}
+        </HeadingTag>
+    );
+};

--- a/bifrost/components/blog/HeadingWithCopyLink.tsx
+++ b/bifrost/components/blog/HeadingWithCopyLink.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Check, Link as LinkIcon } from 'lucide-react';
+import { Check, Link } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Button } from '../ui/button';
 
 interface HeadingWithCopyLinkProps {
     level: 1 | 2 | 3 | 4 | 5 | 6;
@@ -20,19 +20,25 @@ export const HeadingWithCopyLink: React.FC<HeadingWithCopyLinkProps> = ({
 }) => {
     const [isHovered, setIsHovered] = useState(false);
     const [copied, setCopied] = useState(false);
-
     const HeadingTag = `h${level}` as keyof JSX.IntrinsicElements;
 
-    const copyLink = async () => {
-        if (!id || copied) return;
-        const url = `${window.location.origin}${window.location.pathname}#${id}`;
+    const copyAndJump = async () => {
+        if (!id) return;
+
+        const anchor = `#${id}`;
         try {
-            await navigator.clipboard.writeText(url);
+            await navigator.clipboard.writeText(anchor);
             setCopied(true);
-            setIsHovered(false);
             setTimeout(() => setCopied(false), 1500);
         } catch (err) {
             console.error('Failed to copy link: ', err);
+        }
+
+        // Jump to the element
+        const element = document.getElementById(id);
+        if (element) {
+            element.scrollIntoView({ behavior: 'smooth' });
+            window.history.replaceState(null, '', anchor);
         }
     };
 
@@ -40,27 +46,28 @@ export const HeadingWithCopyLink: React.FC<HeadingWithCopyLinkProps> = ({
         <HeadingTag
             id={id}
             className={cn("relative flex items-center gap-2 cursor-pointer group", className)}
-            onClick={id ? copyLink : undefined}
-            onMouseEnter={() => id && setIsHovered(true)}
+            onClick={copyAndJump}
+            onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
-            title={id ? "Copy link to heading" : undefined}
         >
             {children}
             {id && (
-                <TooltipProvider delayDuration={0}>
-                    <Tooltip open={copied}>
-                        <TooltipTrigger asChild>
-                            <div className="size-4 shrink-0">
-                                {copied ? (
-                                    <Check className="size-full text-brand" />
-                                ) : isHovered ? (
-                                    <LinkIcon className="size-full text-muted-foreground" />
-                                ) : null}
-                            </div>
-                        </TooltipTrigger>
-                        <TooltipContent side="right">Copied!</TooltipContent>
-                    </Tooltip>
-                </TooltipProvider>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-4 shrink-0"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        copyAndJump();
+                    }}
+                    aria-label="Copy link to section"
+                >
+                    {copied ? (
+                        <Check className="size-full text-muted-foreground" />
+                    ) : isHovered ? (
+                        <Link className="size-full text-muted-foreground" />
+                    ) : null}
+                </Button>
             )}
         </HeadingTag>
     );

--- a/bifrost/mdx-components.tsx
+++ b/bifrost/mdx-components.tsx
@@ -5,6 +5,7 @@ import { Questions } from "@/components/blog/Questions";
 import { FAQ } from "./components/blog/FAQ";
 import { ReactNode } from "react";
 import NextImage from "next/image";
+import { HeadingWithCopyLink } from "@/components/blog/HeadingWithCopyLink";
 
 const ResponsiveTable = ({ children }: { children: ReactNode }) => {
   return <div className="overflow-x-auto w-full">{children}</div>;
@@ -13,6 +14,12 @@ const ResponsiveTable = ({ children }: { children: ReactNode }) => {
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...components,
+    h1: (props) => <HeadingWithCopyLink level={1} {...props} />,
+    h2: (props) => <HeadingWithCopyLink level={2} {...props} />,
+    h3: (props) => <HeadingWithCopyLink level={3} {...props} />,
+    h4: (props) => <HeadingWithCopyLink level={4} {...props} />,
+    h5: (props) => <HeadingWithCopyLink level={5} {...props} />,
+    h6: (props) => <HeadingWithCopyLink level={6} {...props} />,
     CallToAction: CallToAction,
     BottomLine: BottomLine,
     Questions: Questions,


### PR DESCRIPTION
**A small UX improvement:** 
- hover to copy link to heading 
- click to copy + jump to heading 

**why?** 
- now you can reference a specific section of our blog, rather than linking the entire blog
- help us acquire more backlinks
- more precise linking internally

behaviour matches [this company](https://incident.io/building-with-ai/built-our-own-ai-tooling#introducing-workbench) and [Mintlify's](https://docs.helicone.ai/features/sessions). 

![CleanShot 2025-04-29 at 16 27 29](https://github.com/user-attachments/assets/ede0f94f-9f62-4d74-b4c1-0ce4e2fea740)
