### PR TITLE
[ENG-1575] Account for newlines in tool output renderer for strings

### DIFF
--- a/web/components/templates/requests/components/chatComponent/single/JsonRenderer.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/JsonRenderer.tsx
@@ -40,12 +40,18 @@ const StringRenderer: React.FC<StringRendererProps> = ({
   const isTruncated = data.length > maxLength;
 
   return (
-    <span className={`text-violet-600 dark:text-violet-400 ${!showRawString ? 'whitespace-pre-wrap' : ''}`}>
-      {expanded || !isTruncated ? (
-        showRawString ? `"${data.replace(/\n/g, "\\n")}"` : data
-      ) : (
-        showRawString ? `"${data.slice(0, maxLength).replace(/\n/g, "\\n")}"` : data.slice(0, maxLength)
-      )}
+    <span
+      className={`text-violet-600 dark:text-violet-400 ${
+        !showRawString ? "whitespace-pre-wrap" : ""
+      }`}
+    >
+      {expanded || !isTruncated
+        ? showRawString
+          ? `"${data.replace(/\n/g, "\\n")}"`
+          : data
+        : showRawString
+        ? `"${data.slice(0, maxLength).replace(/\n/g, "\\n")}"`
+        : data.slice(0, maxLength)}
       {isTruncated && !expanded && (
         <span className="text-slate-400 dark:text-slate-500">...</span>
       )}

--- a/web/components/templates/requests/components/chatComponent/single/JsonRenderer.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/JsonRenderer.tsx
@@ -45,13 +45,15 @@ const StringRenderer: React.FC<StringRendererProps> = ({
         !showRawString ? "whitespace-pre-wrap" : ""
       }`}
     >
-      {expanded || !isTruncated
-        ? showRawString
-          ? `"${data.replace(/\n/g, "\\n")}"`
-          : data
-        : showRawString
-        ? `"${data.slice(0, maxLength).replace(/\n/g, "\\n")}"`
-        : data.slice(0, maxLength)}
+        {(() => {
+        if (expanded || !isTruncated) {
+          return showRawString ? `"${data.replace(/\n/g, "\\n")}"` : data;
+        } else {
+          return showRawString 
+            ? `"${data.slice(0, maxLength).replace(/\n/g, "\\n")}"` 
+            : data.slice(0, maxLength);
+        }
+      })()}
       {isTruncated && !expanded && (
         <span className="text-slate-400 dark:text-slate-500">...</span>
       )}

--- a/web/components/templates/requests/components/chatComponent/single/JsonRenderer.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/JsonRenderer.tsx
@@ -28,22 +28,27 @@ interface JsonRendererProps {
 interface StringRendererProps {
   data: string;
   maxLength?: number;
+  showRawString?: boolean;
 }
 
 const StringRenderer: React.FC<StringRendererProps> = ({
   data,
   maxLength = 10_000,
+  showRawString = false,
 }) => {
   const [expanded, setExpanded] = useState(false);
   const isTruncated = data.length > maxLength;
 
   return (
-    <span className="text-violet-600 dark:text-violet-400">
-      &quot;{expanded || !isTruncated ? data : data.slice(0, maxLength)}
+    <span className={`text-violet-600 dark:text-violet-400 ${!showRawString ? 'whitespace-pre-wrap' : ''}`}>
+      {expanded || !isTruncated ? (
+        showRawString ? `"${data.replace(/\n/g, "\\n")}"` : data
+      ) : (
+        showRawString ? `"${data.slice(0, maxLength).replace(/\n/g, "\\n")}"` : data.slice(0, maxLength)
+      )}
       {isTruncated && !expanded && (
         <span className="text-slate-400 dark:text-slate-500">...</span>
       )}
-      &quot;
       {isTruncated && (
         <button
           onClick={() => setExpanded(!expanded)}
@@ -108,7 +113,7 @@ export const JsonRenderer: React.FC<JsonRendererProps> = ({
   }
 
   if (typeof data === "string") {
-    return <StringRenderer data={data} />;
+    return <StringRenderer data={data} showRawString={level !== 0} />;
   }
 
   if (Array.isArray(data)) {

--- a/web/components/templates/requests/components/chatComponent/single/JsonRenderer.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/JsonRenderer.tsx
@@ -45,12 +45,12 @@ const StringRenderer: React.FC<StringRendererProps> = ({
         !showRawString ? "whitespace-pre-wrap" : ""
       }`}
     >
-        {(() => {
+      {(() => {
         if (expanded || !isTruncated) {
           return showRawString ? `"${data.replace(/\n/g, "\\n")}"` : data;
         } else {
-          return showRawString 
-            ? `"${data.slice(0, maxLength).replace(/\n/g, "\\n")}"` 
+          return showRawString
+            ? `"${data.slice(0, maxLength).replace(/\n/g, "\\n")}"`
             : data.slice(0, maxLength);
         }
       })()}


### PR DESCRIPTION
Modifies JsonRenderer:
- if is a string (level 0), then show without quotes and account for newlines
- if json and rendering strings past lvl0, show with quotes and show literal newlines