### PR TITLE
[ENG-1619] Fix improperly parsed filters

### DIFF
--- a/web/services/hooks/requests.tsx
+++ b/web/services/hooks/requests.tsx
@@ -12,18 +12,26 @@ function formatDateForClickHouse(date: Date): string {
   return date.toISOString().slice(0, 19).replace("T", " ");
 }
 
+function isISODateString(value: any): boolean {
+  if (typeof value !== "string") return false;
+  // match: 2025-04-08T00:32:56.000Z
+  const isoDateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/;
+  return isoDateRegex.test(value) && !isNaN(Date.parse(value));
+}
+
 function processFilter(filter: any): any {
   if (typeof filter !== "object" || filter === null) {
     return filter;
   }
 
   const result: any = Array.isArray(filter) ? [] : {};
-
   for (const key in filter) {
-    if (key === "gte" || key === "lte" || key === "gt" || key === "lt") {
-      result[key] = formatDateForClickHouse(new Date(filter[key]));
-    } else if (typeof filter[key] === "object") {
+    const isDate = isISODateString(filter[key]);
+    console.log("DATE", isDate, filter[key])
+    if (typeof filter[key] === "object") {
       result[key] = processFilter(filter[key]);
+    } else if (isDate) {
+      result[key] = formatDateForClickHouse(new Date(filter[key]));
     } else {
       result[key] = filter[key];
     }

--- a/web/services/hooks/requests.tsx
+++ b/web/services/hooks/requests.tsx
@@ -27,7 +27,6 @@ function processFilter(filter: any): any {
   const result: any = Array.isArray(filter) ? [] : {};
   for (const key in filter) {
     const isDate = isISODateString(filter[key]);
-    console.log("DATE", isDate, filter[key])
     if (typeof filter[key] === "object") {
       result[key] = processFilter(filter[key]);
     } else if (isDate) {


### PR DESCRIPTION
`processFilter` used on the `request/count` call in the requests page improperly handles numbers and non-dates on comparisons that are not eq or neq.