### PR TITLE
[ENG-1561] Add Intercom Support in Replace of Pylon and Messages with Slack

### DIFF
--- a/web/components/layout/orgDropdown.tsx
+++ b/web/components/layout/orgDropdown.tsx
@@ -28,6 +28,8 @@ import {
 import { UpgradeProDialog } from "../templates/organization/plan/upgradeProDialog";
 import { useOrg } from "./org/organizationContext";
 import OrgMoreDropdown from "./orgMoreDropdown";
+import Intercom from "@intercom/messenger-js-sdk";
+import { INTERCOM_APP_ID } from "./SidebarHelpDropdown";
 
 interface OrgDropdownProps {}
 
@@ -87,7 +89,10 @@ export default function OrgDropdown({}: OrgDropdownProps) {
   }, [theme, setTheme]);
 
   const handleSignOut = useCallback(() => {
-    heliconeAuthClient.signOut().then(() => router.push("/"));
+    heliconeAuthClient.signOut().then(() => {
+      Intercom({ app_id: INTERCOM_APP_ID, hide_default_launcher: true });
+      router.push("/");
+    });
   }, [heliconeAuthClient, router]);
 
   // Get tier display info from the centralized config

--- a/web/package.json
+++ b/web/package.json
@@ -33,6 +33,7 @@
     "@headlessui/react": "^1.7.18",
     "@helicone/prompts": "^1.0.11",
     "@heroicons/react": "^2.0.13",
+    "@intercom/messenger-js-sdk": "^0.0.14",
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1797,6 +1797,11 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
+"@intercom/messenger-js-sdk@^0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@intercom/messenger-js-sdk/-/messenger-js-sdk-0.0.14.tgz#a27999370cc0a82a2a57a779426df25a57891863"
+  integrity sha512-2dH4BDAh9EI90K7hUkAdZ76W79LM45Sd1OBX7t6Vzy8twpNiQ5X+7sH9G5hlJlkSGnf+vFWlFcy9TOYAyEs1hA==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz"


### PR DESCRIPTION
- intercom workflow https://app.intercom.com/a/apps/mna0ba2h/automation/workflows/47987208?mode=edit&visual=enabled

- 
![Screenshot 2025-05-08 at 2 04 51 PM](https://github.com/user-attachments/assets/fd161eca-5e9e-4309-b680-8b57249a27a6)

- only show intercom on dashboard (will not show on other pages)
- notifies slack but doesn't support slack integration. Can just use one account

## Note

Free trails ends in 14 days

notion - https://www.notion.so/helicone/Intercom-1edc78c0f25e809f8881f1630b17f71f?pvs=4