### PR TITLE
[ENG-1631] Show full conversation in rendered mode

### DIFF
--- a/web/components/templates/requests/RenderHeliconeRequest.tsx
+++ b/web/components/templates/requests/RenderHeliconeRequest.tsx
@@ -62,6 +62,7 @@ export function RenderMappedRequest({
   mappedRequest,
   className,
   messageIndexFilter,
+  onRequestSelect,
 }: {
   mappedRequest: MappedLLMRequest;
   className?: string;
@@ -69,6 +70,7 @@ export function RenderMappedRequest({
     startIndex: number;
     endIndex: number;
   };
+  onRequestSelect?: (request_id: string) => void;
 }) {
   const { mode, toggleMode, setMode } = useRequestRenderModeStore();
   const isShiftPressed = useShiftKeyPress();
@@ -146,6 +148,7 @@ export function RenderMappedRequest({
                 <Realtime
                   mappedRequest={mappedRequest}
                   messageIndexFilter={messageIndexFilter}
+                  onRequestSelect={onRequestSelect}
                 />
               );
 

--- a/web/components/templates/requests/RequestDrawer.tsx
+++ b/web/components/templates/requests/RequestDrawer.tsx
@@ -47,7 +47,13 @@ interface RequestDivProps {
   onRequestSelect?: (request_id: string) => void;
 }
 export default function RequestDrawer(props: RequestDivProps) {
-  const { onCollapse, onNavigate, request, showCollapse = true, onRequestSelect } = props;
+  const {
+    onCollapse,
+    onNavigate,
+    request,
+    showCollapse = true,
+    onRequestSelect,
+  } = props;
 
   const { setNotification } = useNotification();
   const router = useRouter();
@@ -611,8 +617,8 @@ export default function RequestDrawer(props: RequestDivProps) {
 
         <div className="p-4 h-full w-full overflow-auto bg-card">
           {/* Mapped Request */}
-          <RenderMappedRequest 
-            mappedRequest={request} 
+          <RenderMappedRequest
+            mappedRequest={request}
             onRequestSelect={onRequestSelect}
           />
         </div>

--- a/web/components/templates/requests/RequestDrawer.tsx
+++ b/web/components/templates/requests/RequestDrawer.tsx
@@ -44,9 +44,10 @@ interface RequestDivProps {
   onNavigate?: (direction: "prev" | "next") => void;
   request?: MappedLLMRequest;
   showCollapse?: boolean;
+  onRequestSelect?: (request_id: string) => void;
 }
 export default function RequestDrawer(props: RequestDivProps) {
-  const { onCollapse, onNavigate, request, showCollapse = true } = props;
+  const { onCollapse, onNavigate, request, showCollapse = true, onRequestSelect } = props;
 
   const { setNotification } = useNotification();
   const router = useRouter();
@@ -610,7 +611,10 @@ export default function RequestDrawer(props: RequestDivProps) {
 
         <div className="p-4 h-full w-full overflow-auto bg-card">
           {/* Mapped Request */}
-          <RenderMappedRequest mappedRequest={request} />
+          <RenderMappedRequest 
+            mappedRequest={request} 
+            onRequestSelect={onRequestSelect}
+          />
         </div>
 
         {/* Footer */}

--- a/web/components/templates/requests/components/Realtime.tsx
+++ b/web/components/templates/requests/components/Realtime.tsx
@@ -106,7 +106,10 @@ export const Realtime: React.FC<RealtimeProps> = ({
       const timeB = b.timestamp ? new Date(b.timestamp).getTime() : 0;
       return timeA - timeB;
     });
-  }, [mappedRequest.schema.request?.messages, mappedRequest.schema.response?.messages]);
+  }, [
+    mappedRequest.schema.request?.messages,
+    mappedRequest.schema.response?.messages,
+  ]);
 
   // Define getMessageType function before using it
   const getMessageType = (message: any): MessageType => {
@@ -224,8 +227,15 @@ export const Realtime: React.FC<RealtimeProps> = ({
   };
 
   useEffect(() => {
-    if (messageToScrollToRef.current && filterInfo?.isFiltered && shouldScroll) {
-      messageToScrollToRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    if (
+      messageToScrollToRef.current &&
+      filterInfo?.isFiltered &&
+      shouldScroll
+    ) {
+      messageToScrollToRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
     }
   }, [filterInfo?.isFiltered, filteredMessages, shouldScroll]);
 
@@ -259,11 +269,13 @@ export const Realtime: React.FC<RealtimeProps> = ({
           const messageKey = `${idx}-${message.timestamp}`; // Use index within the current filtered list + timestamp
           const isDeletedExpanded = deletedMessageStates[messageKey] ?? false; // Use state, default to false if not set
 
-          const shouldScrollToThisMessage = filterInfo?.isFiltered && 
-            idx >= (filterInfo.startIndex || 0) && 
+          const shouldScrollToThisMessage =
+            filterInfo?.isFiltered &&
+            idx >= (filterInfo.startIndex || 0) &&
             idx <= (filterInfo.endIndex || filterInfo.startIndex || 0);
 
-          const isFilteredMessage = !filterInfo?.isFiltered || shouldScrollToThisMessage;
+          const isFilteredMessage =
+            !filterInfo?.isFiltered || shouldScrollToThisMessage;
 
           return (
             <div

--- a/web/components/templates/requests/components/Realtime.tsx
+++ b/web/components/templates/requests/components/Realtime.tsx
@@ -78,12 +78,11 @@ export const Realtime: React.FC<RealtimeProps> = ({
     if (propMessageIndexFilter) {
       return propMessageIndexFilter; // Use prop if available
     }
-;
     const stepIndexStr =
       mappedRequest.heliconeMetadata?.customProperties
         ?._helicone_realtime_step_index;
-    console.log(stepIndexStr)
-    console.log(mappedRequest)
+    console.log(stepIndexStr);
+    console.log(mappedRequest);
     if (stepIndexStr) {
       const stepIndex = parseInt(stepIndexStr, 10);
       if (!isNaN(stepIndex)) {
@@ -283,10 +282,22 @@ export const Realtime: React.FC<RealtimeProps> = ({
               className={`flex flex-col px-4 pb-4 mb-4 w-full 
                 ${isUser ? "items-end" : "items-start"}
                 ${isFilteredMessage ? "" : "opacity-25"}
-                ${onRequestSelect ? "hover:cursor-pointer hover:bg-accent/50" : ""}`}
+                ${
+                  onRequestSelect
+                    ? "hover:cursor-pointer hover:bg-accent/50"
+                    : ""
+                }`}
               onClick={() => {
-                if (filterInfo?.isFiltered && filterInfo?.startIndex === filterInfo?.endIndex) {
-                  onRequestSelect?.(mappedRequest.id.replace(`-step-${filterInfo?.startIndex}`, `-step-${idx}`)) 
+                if (
+                  filterInfo?.isFiltered &&
+                  filterInfo?.startIndex === filterInfo?.endIndex
+                ) {
+                  onRequestSelect?.(
+                    mappedRequest.id.replace(
+                      `-step-${filterInfo?.startIndex}`,
+                      `-step-${idx}`
+                    )
+                  );
                 }
               }}
             >

--- a/web/components/templates/requests/components/Realtime.tsx
+++ b/web/components/templates/requests/components/Realtime.tsx
@@ -37,6 +37,7 @@ interface RealtimeProps {
     startIndex: number;
     endIndex: number;
   };
+  onRequestSelect?: (request_id: string) => void;
 }
 
 // Helper function to determine the default expansion state for deleted messages
@@ -67,6 +68,7 @@ const calculateDefaultExpandedStates = (
 export const Realtime: React.FC<RealtimeProps> = ({
   mappedRequest,
   messageIndexFilter: propMessageIndexFilter,
+  onRequestSelect,
 }) => {
   const messageToScrollToRef = useRef<HTMLDivElement>(null);
   const [shouldScroll, setShouldScroll] = useState(true);
@@ -76,10 +78,12 @@ export const Realtime: React.FC<RealtimeProps> = ({
     if (propMessageIndexFilter) {
       return propMessageIndexFilter; // Use prop if available
     }
-
+;
     const stepIndexStr =
       mappedRequest.heliconeMetadata?.customProperties
         ?._helicone_realtime_step_index;
+    console.log(stepIndexStr)
+    console.log(mappedRequest)
     if (stepIndexStr) {
       const stepIndex = parseInt(stepIndexStr, 10);
       if (!isNaN(stepIndex)) {
@@ -278,7 +282,13 @@ export const Realtime: React.FC<RealtimeProps> = ({
               ref={shouldScrollToThisMessage ? messageToScrollToRef : null}
               className={`flex flex-col px-4 pb-4 mb-4 w-full 
                 ${isUser ? "items-end" : "items-start"}
-                ${isFilteredMessage ? "" : "opacity-25"}`}
+                ${isFilteredMessage ? "" : "opacity-25"}
+                ${onRequestSelect ? "hover:cursor-pointer hover:bg-accent/50" : ""}`}
+              onClick={() => {
+                if (filterInfo?.isFiltered && filterInfo?.startIndex === filterInfo?.endIndex) {
+                  onRequestSelect?.(mappedRequest.id.replace(`-step-${filterInfo?.startIndex}`, `-step-${idx}`)) 
+                }
+              }}
             >
               {isDeleted ? (
                 // Collapsible structure for deleted messages

--- a/web/components/templates/sessions/sessionId/Tree/TreeView.tsx
+++ b/web/components/templates/sessions/sessionId/Tree/TreeView.tsx
@@ -104,7 +104,7 @@ export const TreeView: React.FC<TreeViewProps> = ({
     } else {
       drawerRef.current?.resize(drawerSize);
     }
-  }
+  };
 
   const onRowSelectHandler = (row: TableTreeNode) => {
     if (row.trace) {

--- a/web/components/templates/sessions/sessionId/Tree/TreeView.tsx
+++ b/web/components/templates/sessions/sessionId/Tree/TreeView.tsx
@@ -13,7 +13,7 @@ import {
 import { Muted } from "@/components/ui/typography";
 import { CellContext, ColumnDef } from "@tanstack/react-table";
 import { formatDistanceToNow } from "date-fns";
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { tracesToTreeNodeData } from "../../../../../lib/sessions/helpers";
 import {
   HeliconeRequestType,
@@ -97,15 +97,19 @@ export const TreeView: React.FC<TreeViewProps> = ({
     return trace?.request; // Return the request directly
   }, [selectedRequestId, session.traces]);
 
+  const resizeDrawer = () => {
+    drawerRef.current?.expand();
+    if (drawerSize === 0) {
+      drawerRef.current?.resize(33);
+    } else {
+      drawerRef.current?.resize(drawerSize);
+    }
+  }
+
   const onRowSelectHandler = (row: TableTreeNode) => {
     if (row.trace) {
       setSelectedRequestId(row.trace.request_id);
-      drawerRef.current?.expand();
-      if (drawerSize === 0) {
-        drawerRef.current?.resize(33);
-      } else {
-        drawerRef.current?.resize(drawerSize);
-      }
+      resizeDrawer();
     } else {
       // Optional: handle click on group row if needed (e.g., toggle expansion)
       // React-table's expander button already handles toggling.
@@ -120,6 +124,12 @@ export const TreeView: React.FC<TreeViewProps> = ({
   const handleToggleAllRows = (table: any) => {
     table.toggleAllRowsExpanded();
   };
+
+  // Handle message selection
+  const handleRequestSelect = useCallback((request_id: string) => {
+    setSelectedRequestId(request_id);
+    resizeDrawer();
+  }, []);
 
   return (
     <Col className="h-full">
@@ -199,6 +209,7 @@ export const TreeView: React.FC<TreeViewProps> = ({
             <RequestDrawer
               request={selectedRequestData}
               onCollapse={handleCollapseDrawer}
+              onRequestSelect={handleRequestSelect}
             />
           )}
         </ResizablePanel>


### PR DESCRIPTION
before:
1. split realtime request into a bunch of requests for each turn/action in the session
2. rendered mode shows the current turn
instead:
2. rendered mode shows full conversation, but scrolls to the current message and makes others grayed out
<img width="501" alt="Screenshot 2025-05-09 at 1 01 44 PM" src="https://github.com/user-attachments/assets/0bcb4d5e-8da1-475d-b86e-4e5ffccaed6b" />
