### PR TITLE
Include cognitive services in Azure pattern mapping

### DIFF
--- a/bifrost/packages/cost/package.json
+++ b/bifrost/packages/cost/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@helicone-package/cost",
+  "types": "./",
+  "sideEffects": false,
+  "version": "1.0.0"
+}

--- a/bifrost/packages/cost/providers/mappings.ts
+++ b/bifrost/packages/cost/providers/mappings.ts
@@ -27,7 +27,7 @@ import { googleProvider } from "./google";
 const openAiPattern = /^https:\/\/api\.openai\.com/;
 const anthropicPattern = /^https:\/\/api\.anthropic\.com/;
 const azurePattern =
-  /^(https?:\/\/)?([^.]*\.)?(openai\.azure\.com|azure-api\.net)(\/.*)?$/;
+  /^https:\/\/.*\.(openai\.azure\.com|azure-api\.net|cognitiveservices\.azure\.com)\/?$/;
 const localProxyPattern = /^http:\/\/127\.0\.0\.1:\d+\/v\d+\/?$/;
 const heliconeProxyPattern = /^https:\/\/oai\.hconeai\.com/;
 const amdbartekPattern = /^https:\/\/.*\.amdbartek\.dev/;

--- a/docs/snippets/strings.mdx
+++ b/docs/snippets/strings.mdx
@@ -21,7 +21,7 @@ export const strings = {
   modifyBasePath: "Modify the base URL path and set up authentication",
   optional: "Optional",
   relatedGuides: "Related Guides",
-  replayLlmSessionsCookbookDescription: "Learn how to replay and modify LLM sessions using Helicone to optimize your AI agents and improve their performance.",
+  replayLlmSessionsCookbookDescription: "Learn how to trace, replay, and modify your LLM sessions using Helicone to optimize your AI agents and improve their performance.",
   sessionManagement: "Session Management",
   setApiKey: "Set up your Helicone API key in your .env file",
   setUpToolBaseUrl: (tool) => `Set up your ${tool} base URL`,

--- a/packages/cost/providers/mappings.ts
+++ b/packages/cost/providers/mappings.ts
@@ -27,7 +27,7 @@ import { googleProvider } from "./google";
 const openAiPattern = /^https:\/\/api\.openai\.com/;
 const anthropicPattern = /^https:\/\/api\.anthropic\.com/;
 const azurePattern =
-  /^(https?:\/\/)?([^.]*\.)?(openai\.azure\.com|azure-api\.net)(\/.*)?$/;
+  /^https:\/\/.*\.(openai\.azure\.com|azure-api\.net|cognitiveservices\.azure\.com)\/?$/;
 const localProxyPattern = /^http:\/\/127\.0\.0\.1:\d+\/v\d+\/?$/;
 const heliconeProxyPattern = /^https:\/\/oai\.hconeai\.com/;
 const amdbartekPattern = /^https:\/\/.*\.amdbartek\.dev/;

--- a/valhalla/jawn/src/packages/cost/package.json
+++ b/valhalla/jawn/src/packages/cost/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@helicone-package/cost",
+  "types": "./",
+  "sideEffects": false,
+  "version": "1.0.0"
+}

--- a/valhalla/jawn/src/packages/cost/providers/mappings.ts
+++ b/valhalla/jawn/src/packages/cost/providers/mappings.ts
@@ -27,7 +27,7 @@ import { googleProvider } from "./google";
 const openAiPattern = /^https:\/\/api\.openai\.com/;
 const anthropicPattern = /^https:\/\/api\.anthropic\.com/;
 const azurePattern =
-  /^(https?:\/\/)?([^.]*\.)?(openai\.azure\.com|azure-api\.net)(\/.*)?$/;
+  /^https:\/\/.*\.(openai\.azure\.com|azure-api\.net|cognitiveservices\.azure\.com)\/?$/;
 const localProxyPattern = /^http:\/\/127\.0\.0\.1:\d+\/v\d+\/?$/;
 const heliconeProxyPattern = /^https:\/\/oai\.hconeai\.com/;
 const amdbartekPattern = /^https:\/\/.*\.amdbartek\.dev/;

--- a/web/packages/cost/package.json
+++ b/web/packages/cost/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@helicone-package/cost",
+  "types": "./",
+  "sideEffects": false,
+  "version": "1.0.0"
+}

--- a/web/packages/cost/providers/mappings.ts
+++ b/web/packages/cost/providers/mappings.ts
@@ -27,7 +27,7 @@ import { googleProvider } from "./google";
 const openAiPattern = /^https:\/\/api\.openai\.com/;
 const anthropicPattern = /^https:\/\/api\.anthropic\.com/;
 const azurePattern =
-  /^(https?:\/\/)?([^.]*\.)?(openai\.azure\.com|azure-api\.net)(\/.*)?$/;
+  /^https:\/\/.*\.(openai\.azure\.com|azure-api\.net|cognitiveservices\.azure\.com)\/?$/;
 const localProxyPattern = /^http:\/\/127\.0\.0\.1:\d+\/v\d+\/?$/;
 const heliconeProxyPattern = /^https:\/\/oai\.hconeai\.com/;
 const amdbartekPattern = /^https:\/\/.*\.amdbartek\.dev/;

--- a/worker/src/packages/cost/package.json
+++ b/worker/src/packages/cost/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@helicone-package/cost",
+  "types": "./",
+  "sideEffects": false,
+  "version": "1.0.0"
+}

--- a/worker/src/packages/cost/providers/mappings.ts
+++ b/worker/src/packages/cost/providers/mappings.ts
@@ -27,7 +27,7 @@ import { googleProvider } from "./google";
 const openAiPattern = /^https:\/\/api\.openai\.com/;
 const anthropicPattern = /^https:\/\/api\.anthropic\.com/;
 const azurePattern =
-  /^https:\/\/.*\.(openai\.azure\.com|azure-api\.net|cognitiveservices\.azure\.com)\/?$/;
+  /^(https?:\/\/)?([^.]*\.)?(openai\.azure\.com|azure-api\.net|cognitiveservices\.azure\.com)(\/.*)?$/;
 const localProxyPattern = /^http:\/\/127\.0\.0\.1:\d+\/v\d+\/?$/;
 const heliconeProxyPattern = /^https:\/\/oai\.hconeai\.com/;
 const amdbartekPattern = /^https:\/\/.*\.amdbartek\.dev/;

--- a/worker/src/packages/cost/providers/mappings.ts
+++ b/worker/src/packages/cost/providers/mappings.ts
@@ -27,7 +27,7 @@ import { googleProvider } from "./google";
 const openAiPattern = /^https:\/\/api\.openai\.com/;
 const anthropicPattern = /^https:\/\/api\.anthropic\.com/;
 const azurePattern =
-  /^(https?:\/\/)?([^.]*\.)?(openai\.azure\.com|azure-api\.net)(\/.*)?$/;
+  /^https:\/\/.*\.(openai\.azure\.com|azure-api\.net|cognitiveservices\.azure\.com)\/?$/;
 const localProxyPattern = /^http:\/\/127\.0\.0\.1:\d+\/v\d+\/?$/;
 const heliconeProxyPattern = /^https:\/\/oai\.hconeai\.com/;
 const amdbartekPattern = /^https:\/\/.*\.amdbartek\.dev/;


### PR DESCRIPTION
- Updated Azure regex mapping to include the new Azure `cognitiveservices` urls: https://azure.microsoft.com/en-us/products/ai-services/openai-service 
- Fixed the description text for the Trace & Replay article card.

