### PR TITLE
Include videos in OpenAI docs

### DIFF
--- a/docs/integrations/openai/javascript.mdx
+++ b/docs/integrations/openai/javascript.mdx
@@ -12,6 +12,14 @@ import { strings } from "/snippets/strings.mdx";
 
 ## {strings.howToIntegrate}
 
+<video width="100%" controls autoplay loop>
+  <source
+    src="https://marketing-assets-helicone.s3.us-west-2.amazonaws.com/Helicone+Tutorial+Video.mp4"
+    type="video/mp4"
+  />
+  Your browser does not support the video tag.
+</video>
+
 <Steps>
   <Step title={strings.generateKey}>
     <div dangerouslySetInnerHTML={{ __html: strings.generateKeyInstructions }} />

--- a/docs/integrations/openai/python.mdx
+++ b/docs/integrations/openai/python.mdx
@@ -11,6 +11,14 @@ import { strings } from "/snippets/strings.mdx";
 
 ## {strings.howToIntegrate}
 
+<video width="100%" controls autoplay loop>
+  <source
+    src="https://marketing-assets-helicone.s3.us-west-2.amazonaws.com/Helicone+OpenAI+Python+Tutorial.mp4"
+    type="video/mp4"
+  />
+  Your browser does not support the video tag.
+</video>
+
 <Steps>
   <Step title={strings.generateKey}>
     <div dangerouslySetInnerHTML={{ __html: strings.generateKeyInstructions }} />


### PR DESCRIPTION
Included tutorial videos for OpenAI docs for JS & Python.

![CleanShot 2025-05-20 at 18 32 09@2x](https://github.com/user-attachments/assets/8a3f1424-932b-4691-bfce-291fc31463fc)
![CleanShot 2025-05-20 at 18 32 05@2x](https://github.com/user-attachments/assets/5ee16b2a-927a-45bf-9dd8-d2153900aef4)
