### PR TITLE
log when connection drops by wrapping in try catch

### DIFF
--- a/worker/src/lib/HeliconeProxyRequest/ProxyRequestHandler.ts
+++ b/worker/src/lib/HeliconeProxyRequest/ProxyRequestHandler.ts
@@ -17,7 +17,6 @@ import {
   HeliconeProxyRequest,
   RetryOptions,
 } from "../models/HeliconeProxyRequest";
-import { error } from "console";
 
 export type ProxyResult = {
   loggable: DBLoggable;


### PR DESCRIPTION
There is an issue when providers drop connections we are not catching them and logging it into Helicone properly. 

This ensures we will.