### PR TITLE
remove providers in onboarding doc as no longer supported by HeliconeAsyncLogger

### DIFF
--- a/web/pages/onboarding/integrate/async/index.tsx
+++ b/web/pages/onboarding/integrate/async/index.tsx
@@ -14,10 +14,7 @@ const CODE_SNIPPETS: CodeSnippet = {
 import OpenAI from "openai";
 
 const logger = new HeliconeAsyncLogger({
-  apiKey: "${key}",
-  providers: {
-    openAI: OpenAI
-  }
+  apiKey: "${key}"
 });
 logger.init();
 


### PR DESCRIPTION
# Why
- HeliconeAsyncLogger throws an error when providing `providers`
# What
- Remove `providers` from doc