### PR TITLE
Fix free tier limits

### DIFF
--- a/bifrost/app/blog/blogs/weights-and-biases/src.mdx
+++ b/bifrost/app/blog/blogs/weights-and-biases/src.mdx
@@ -46,7 +46,7 @@ Weights and Biases provides detailed logging and tracing, which can be resource-
 
 ### Cost-effectiveness
 
-Helicone operates on a volumetric pricing model, making it a more cost-effective option if you have high-volume usage. In addition, the first 100,000 requests per month are free.
+Helicone operates on a volumetric pricing model, making it a more cost-effective option if you have high-volume usage. In addition, the first 10,000 requests per month are free.
 
 ### Reliability and Scalability
 

--- a/bifrost/components/templates/pricing/featureTable.tsx
+++ b/bifrost/components/templates/pricing/featureTable.tsx
@@ -77,7 +77,7 @@ const sections: {
       {
         name: "Request Logs",
         tiers: {
-          Free: "Up to 100k Free",
+          Free: "Up to 10k Free",
           Growth: "Pay as you go",
           Enterprise: "Unlimited",
         },

--- a/web/components/templates/pricing/featureTable.tsx
+++ b/web/components/templates/pricing/featureTable.tsx
@@ -77,7 +77,7 @@ const sections: {
       {
         name: "Request Logs",
         tiers: {
-          Free: "Up to 100k Free",
+          Free: "Up to 10k Free",
           Growth: "Pay as you go",
           Enterprise: "Unlimited",
         },


### PR DESCRIPTION
## Summary
- update free tier limits in pricing components to 10k
- correct weights-and-biases blog post

## Testing
- `yarn workspaces foreach -A run test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6840f8e752288320a8942b3ce6085d16