### PR TITLE
Add local 24h time tooltip for requests

### DIFF
--- a/web/components/shared/utils/utils.tsx
+++ b/web/components/shared/utils/utils.tsx
@@ -44,6 +44,18 @@ const getUSDateFromString = (value: string) => {
   return getUSDate(date);
 };
 
+const get24HourFromString = (value: string) => {
+  const date = new Date(value);
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
+};
+
 const getUSDateMin = (value: string) => {
   const date = new Date(value);
   const day = date.getDate();
@@ -80,6 +92,7 @@ export {
   capitalizeWords,
   getUSDate,
   getUSDateFromString,
+  get24HourFromString,
   getUSDateMin,
   getUSDateShort,
   removeLeadingWhitespace,

--- a/web/components/templates/requests/initialColumns.tsx
+++ b/web/components/templates/requests/initialColumns.tsx
@@ -2,7 +2,16 @@ import { MappedLLMRequest } from "@helicone-package/llm-mapper/types";
 import { HandThumbDownIcon, HandThumbUpIcon } from "@heroicons/react/24/solid";
 import { ColumnDef } from "@tanstack/react-table";
 import { clsx } from "../../shared/clsx";
-import { getUSDateFromString } from "../../shared/utils/utils";
+import {
+  getUSDateFromString,
+  get24HourFromString,
+} from "../../shared/utils/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import CostPill from "./costPill";
 import { COUTNRY_CODE_DIRECTORY } from "./countryCodeDirectory";
 import ModelPill from "./modelPill";
@@ -31,11 +40,23 @@ export const getInitialColumns = (): ColumnDef<MappedLLMRequest>[] => [
     id: "createdAt",
     accessorKey: "createdAt",
     header: "Created At",
-    cell: (info) => (
-      <span className="text-gray-900 dark:text-gray-100 font-medium">
-        {getUSDateFromString(info.row.original.heliconeMetadata.createdAt)}
-      </span>
-    ),
+    cell: (info) => {
+      const value = info.row.original.heliconeMetadata.createdAt;
+      return (
+        <TooltipProvider>
+          <Tooltip delayDuration={100}>
+            <TooltipTrigger asChild>
+              <span className="text-gray-900 dark:text-gray-100 font-medium cursor-default">
+                {getUSDateFromString(value)}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              <p>{get24HourFromString(value)}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      );
+    },
     meta: {
       sortKey: "created_at",
     },


### PR DESCRIPTION
## Summary
- show request created time with tooltip that displays local 24‑hour format
- expose helper to format 24‑hour times

## Testing
- `yarn lint` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_e_684761836938832ab6adef5d24f43872