### PR TITLE
Fix backend URL default

### DIFF
--- a/bifrost/lib/clients/jawn.ts
+++ b/bifrost/lib/clients/jawn.ts
@@ -16,9 +16,15 @@ export function getJawnClient(apiKey?: string) {
   //       }
   //     : {};
 
+  const region = process.env.REGION || "us";
   return createClient<publicPaths>({
     baseUrl:
-      process.env.NEXT_PUBLIC_HELICONE_JAWN_SERVICE ?? "http://localhost:8585",
+      process.env.NEXT_PUBLIC_HELICONE_JAWN_SERVICE ||
+      (process.env.NODE_ENV === "development"
+        ? "http://localhost:8585"
+        : region === "eu"
+        ? "https://eu.api.helicone.ai"
+        : "https://api.helicone.ai"),
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },

--- a/web/lib/clients/jawn.ts
+++ b/web/lib/clients/jawn.ts
@@ -10,8 +10,15 @@ import type { paths as publicPaths } from "./jawnTypes/public";
 type allPaths = publicPaths & privatePaths;
 
 export function getJawnClient(orgId?: string | "none") {
+  const region = env("REGION") || process.env.REGION || "us";
   return createFetchClient<allPaths>({
-    baseUrl: env("NEXT_PUBLIC_HELICONE_JAWN_SERVICE"),
+    baseUrl:
+      env("NEXT_PUBLIC_HELICONE_JAWN_SERVICE") ||
+      (process.env.NODE_ENV === "development"
+        ? "http://localhost:8585"
+        : region === "eu"
+        ? "https://eu.api.helicone.ai"
+        : "https://api.helicone.ai"),
     fetch: (request: Request) => {
       // Read cookies on each request to get latest values
       const currentOrgId = orgId || Cookies.get(ORG_ID_COOKIE_KEY);

--- a/web/pages/api/stripe/event_webhook/index.ts
+++ b/web/pages/api/stripe/event_webhook/index.ts
@@ -399,8 +399,14 @@ async function generateTempAPIKey(
 // Helper function to get the Jawn service URL, replacing localhost with 127.0.0.1 in serverless environments
 function getJawnServiceUrl(): string {
   // Get the URL from environment variable
+  const region = process.env.REGION || "us";
   const jawnServiceUrl =
-    process.env.NEXT_PUBLIC_HELICONE_JAWN_SERVICE || "http://localhost:8585";
+    process.env.NEXT_PUBLIC_HELICONE_JAWN_SERVICE ||
+    (process.env.NODE_ENV === "development"
+      ? "http://localhost:8585"
+      : region === "eu"
+      ? "https://eu.api.helicone.ai"
+      : "https://api.helicone.ai");
 
   // In serverless environments (Next.js API routes), replace localhost with 127.0.0.1
   // This is needed because localhost doesn't resolve correctly in serverless environments


### PR DESCRIPTION
## Summary
- ensure both frontends default to the production Helicone backend when no env var is set
- update serverless webhook handler to use the same fallback logic

## Testing
- `yarn workspace helicone lint` *(fails: helicone-monorepo@workspace:.: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6847afa7a588832abf59d510b4b444b1