### PR TITLE
feat: [ENG-1671] Azure provider change for requests coming from azure

### DIFF
--- a/valhalla/jawn/src/controllers/public/requestController.ts
+++ b/valhalla/jawn/src/controllers/public/requestController.ts
@@ -136,6 +136,26 @@ export class RequestController extends Controller {
     } else {
       this.setStatus(201);
     }
+
+    // TODO This is a hack for backwards compatibility on previous requests tagged as OPENAI coming from Azure OpenAI. 
+    // TODO Move this to a separate function, since it is not specific to clickhouse
+    function patchAzureProvider(requests: Result<HeliconeRequest[], string>) {
+      const azurePattern =
+        /^(https?:\/\/)?([^.]*\.)?(openai\.azure\.com|azure-api\.net|cognitiveservices\.azure\.com)(\/.*)?$/;
+
+      if (requests.data && Array.isArray(requests.data)) {
+        for (const request of requests.data) {
+          const targetUrl = request?.['target_url'];
+          if (typeof targetUrl === 'string' && azurePattern.test(targetUrl)) {
+            request['provider'] = 'AZURE';
+          }
+        }
+      }
+    }
+
+    patchAzureProvider(requests);
+
+
     return requests;
   }
 


### PR DESCRIPTION
This pull request introduces a backward compatibility fix for handling Azure OpenAI requests in the `RequestController` class. The change ensures that requests originating from specific Azure-related domains are appropriately tagged with the provider as `AZURE`.

### Backward compatibility fix:
* Added a helper function `patchAzureProvider` within the `RequestController` class to detect and tag requests with URLs matching Azure-related domains (e.g., `openai.azure.com`, `azure-api.net`) as `AZURE`. This function is applied to the `requests` object before returning it.