### PR TITLE
misc: Removed kubernetes section from cloud docs

### DIFF
--- a/docs/getting-started/self-host/cloud.mdx
+++ b/docs/getting-started/self-host/cloud.mdx
@@ -108,9 +108,3 @@ The next steps before becoming production ready are:
    - Change public variables for our backend routes. (NEXT_PUBLIC_BASE_PATH, SUPABASE_PUBLIC_URL, API_EXTERNAL_URL)
 
 3. Add a database backup strategy and change the volume to a persistent volume
-
-# Running in Kubertes (Beta)
-
-We have a Helm chart that is not well maintained that you all can try. It's not production ready yet.
-
-https://github.com/Helicone/helicone-helm-chart


### PR DESCRIPTION
This PR removes the kubernetes section from the cloud docs, since it is already described in the kubernetes section.