### PR TITLE
feat: Control Plane support for presigned urls

### DIFF
--- a/bifrost/lib/clients/jawnTypes/private.ts
+++ b/bifrost/lib/clients/jawnTypes/private.ts
@@ -410,6 +410,9 @@ export interface paths {
   "/v1/router/control-plane/whoami": {
     get: operations["Whoami"];
   };
+  "/v1/router/control-plane/sign-s3-url": {
+    post: operations["SignS3Url"];
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -15198,6 +15201,14 @@ Json: JsonObject;
     ConvertToWavRequestBody: {
       audioData: string;
     };
+    "ResultSuccess__url-string__": {
+      data: {
+        url: string;
+      };
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result__url-string_.string_": components["schemas"]["ResultSuccess__url-string__"] | components["schemas"]["ResultError_string_"];
   };
   responses: {
   };
@@ -17719,6 +17730,25 @@ export interface operations {
             organizationId: string;
             userId: string;
           };
+        };
+      };
+    };
+  };
+  SignS3Url: {
+    requestBody: {
+      content: {
+        "application/json": {
+          /** Format: double */
+          payloadSize: number;
+          requestId: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result__url-string_.string_"];
         };
       };
     };

--- a/valhalla/jawn/src/lib/shared/db/s3Client.ts
+++ b/valhalla/jawn/src/lib/shared/db/s3Client.ts
@@ -221,6 +221,25 @@ export class S3Client {
     }
   }
 
+  async putObjectSignedUrlWithExpiration(key: string, bodySize: number, expiresIn: number): Promise<Result<string, string>> {
+    try {
+      this.awsClient;
+      const command = new PutObjectCommand({
+        Bucket: this.bucketName,
+        Key: key,
+        ContentLength: bodySize,
+      });
+
+      const signedUrl = await getSignedUrl(this.awsClient, command, {
+        expiresIn,
+      });
+
+      return { data: signedUrl, error: null };
+    } catch (error: any) {
+      return { data: null, error: error.message };
+    }
+  }
+
   async uploadToS3(
     key: string,
     body: ArrayBuffer | Buffer,

--- a/valhalla/jawn/src/managers/router/ControlPlaneManager.ts
+++ b/valhalla/jawn/src/managers/router/ControlPlaneManager.ts
@@ -1,0 +1,37 @@
+import { S3Client } from "../../lib/shared/db/s3Client";
+import { Result } from "../../packages/common/result";
+import { BaseManager } from "../BaseManager";
+import { AuthParams } from "../../packages/common/auth/types";
+
+export class ControlPlaneManager extends BaseManager {
+  private s3Client: S3Client;
+  constructor(authParams: AuthParams) {
+    super(authParams);
+
+    this.s3Client = new S3Client(
+      process.env.S3_ACCESS_KEY ?? "",
+      process.env.S3_SECRET_KEY ?? "",
+      process.env.S3_ENDPOINT ?? "",
+      process.env.S3_BUCKET_NAME ?? "",
+      (process.env.S3_REGION as "us-west-2" | "eu-west-1") ?? "us-west-2"
+    );
+  }
+
+  async signS3Url(
+    requestId: string,
+    payloadSize: number,
+    authParams: AuthParams
+  ): Promise<Result<string, string>> {
+    const key = this.s3Client.getRawRequestResponseKey(
+      requestId,
+      authParams.organizationId
+    );
+    // 10 minutes
+    const expiresIn = 60 * 10;
+    return await this.s3Client.putObjectSignedUrlWithExpiration(
+      key,
+      payloadSize,
+      expiresIn
+    );
+  }
+}

--- a/valhalla/jawn/src/middleware/ratelimitter.ts
+++ b/valhalla/jawn/src/middleware/ratelimitter.ts
@@ -24,7 +24,10 @@ if (IS_RATE_LIMIT_ENABLED) {
       if (req.path.startsWith("/v1/log")) {
         return 1_000_000;
       }
-      if (req.path.startsWith("/v1/trace")) {
+      if (
+        req.path.startsWith("/v1/trace") ||
+        req.path.startsWith("/v1/router/control-plane/sign-s3-url")
+      ) {
         return 10_000;
       }
       return 200;

--- a/valhalla/jawn/src/tsoa-build/private/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/private/routes.ts
@@ -13812,6 +13812,20 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ResultSuccess__url-string__": {
+        "dataType": "refObject",
+        "properties": {
+            "data": {"dataType":"nestedObjectLiteral","nestedProperties":{"url":{"dataType":"string","required":true}},"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Result__url-string_.string_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess__url-string__"},{"ref":"ResultError_string_"}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 };
 const templateService = new ExpressTemplateService(models, {"noImplicitAdditionalProperties":"throw-on-extras","bodyCoercion":true});
 
@@ -18410,6 +18424,38 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'whoami',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsRouterControlPlaneController_signS3Url: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                body: {"in":"body","name":"body","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"payloadSize":{"dataType":"double","required":true},"requestId":{"dataType":"string","required":true}}},
+        };
+        app.post('/v1/router/control-plane/sign-s3-url',
+            authenticateMiddleware([{"api_key":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(RouterControlPlaneController)),
+            ...(fetchMiddlewares<RequestHandler>(RouterControlPlaneController.prototype.signS3Url)),
+
+            async function RouterControlPlaneController_signS3Url(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsRouterControlPlaneController_signS3Url, request, response });
+
+                const controller = new RouterControlPlaneController();
+
+              await templateService.apiHandler({
+                methodName: 'signS3Url',
                 controller,
                 response,
                 next,

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -45358,6 +45358,44 @@
 				],
 				"type": "object",
 				"additionalProperties": false
+			},
+			"ResultSuccess__url-string__": {
+				"properties": {
+					"data": {
+						"properties": {
+							"url": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"url"
+						],
+						"type": "object"
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result__url-string_.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess__url-string__"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
 			}
 		},
 		"securitySchemes": {
@@ -52041,6 +52079,55 @@
 					}
 				],
 				"parameters": []
+			}
+		},
+		"/v1/router/control-plane/sign-s3-url": {
+			"post": {
+				"operationId": "SignS3Url",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result__url-string_.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Router Control Plane"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"properties": {
+									"payloadSize": {
+										"type": "number",
+										"format": "double"
+									},
+									"requestId": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"payloadSize",
+									"requestId"
+								],
+								"type": "object"
+							}
+						}
+					}
+				}
 			}
 		}
 	},

--- a/web/lib/clients/jawnTypes/private.ts
+++ b/web/lib/clients/jawnTypes/private.ts
@@ -410,6 +410,9 @@ export interface paths {
   "/v1/router/control-plane/whoami": {
     get: operations["Whoami"];
   };
+  "/v1/router/control-plane/sign-s3-url": {
+    post: operations["SignS3Url"];
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -15198,6 +15201,14 @@ Json: JsonObject;
     ConvertToWavRequestBody: {
       audioData: string;
     };
+    "ResultSuccess__url-string__": {
+      data: {
+        url: string;
+      };
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result__url-string_.string_": components["schemas"]["ResultSuccess__url-string__"] | components["schemas"]["ResultError_string_"];
   };
   responses: {
   };
@@ -17719,6 +17730,25 @@ export interface operations {
             organizationId: string;
             userId: string;
           };
+        };
+      };
+    };
+  };
+  SignS3Url: {
+    requestBody: {
+      content: {
+        "application/json": {
+          /** Format: double */
+          payloadSize: number;
+          requestId: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result__url-string_.string_"];
         };
       };
     };


### PR DESCRIPTION
  - This commit adds LLM observability support to sidecar mode by leveraging a new JAWN endpoint to pre-sign PUT object URLs for the raw request+response body. This enables the sidecar to upload objects to S3 securely without distributing AWS credentials to each sidecar deployment.
- The way this works is that the sidecar sends the `requestId` and `payloadSize` to JAWN along with an `authorization` header with the Helicone API key associated with the request. If JAWN authenticates the user, then it will construct the object key path based on the authenticated org and the passed request id. Additionally, it will include the `content-length` header in the signed request params which will prevent users from sending large payloads into the S3 bucket with the authorized URL. Max size limits for this payload size parameter are enforced in the JAWN backend.

