### PR TITLE
misc: Add ECR repository for helicone

### DIFF
--- a/docker/terraform/main.tf
+++ b/docker/terraform/main.tf
@@ -58,6 +58,15 @@ resource "aws_ecr_repository" "aigateway" {
   }
 }
 
+resource "aws_ecr_repository" "helicone" {
+  name                 = "helicone/helicone"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
 # Output the repository URLs
 output "web_repository_url" {
   value = aws_ecr_repository.web.repository_url


### PR DESCRIPTION
This pull request adds a new AWS ECR repository resource for the `helicone` service in the Terraform configuration. The most important change is the creation of this repository with specific configurations.

### Infrastructure changes:

* Added a new `aws_ecr_repository` resource named `helicone` in `docker/terraform/main.tf`. This repository is configured with mutable image tags and enables image scanning on push.