### PR TITLE
misc: enable react query devtools in development mode

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -73,7 +73,6 @@
     "@supabase/auth-helpers-react": "^0.3.1",
     "@supabase/supabase-js": "^2.1.1",
     "@tanstack/react-query": "^5.71.10",
-    "@tanstack/react-query-devtools": "5.71.10",
     "@tanstack/react-table": "^8.15.0",
     "@tremor/react": "^3.18.3",
     "@types/nodemailer": "^6.4.17",
@@ -174,6 +173,7 @@
     "tailwind-scrollbar": "^4.0.0",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "5.1.6"
+    "typescript": "5.1.6",
+    "@tanstack/react-query-devtools": "5.71.10"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -73,6 +73,7 @@
     "@supabase/auth-helpers-react": "^0.3.1",
     "@supabase/supabase-js": "^2.1.1",
     "@tanstack/react-query": "^5.71.10",
+    "@tanstack/react-query-devtools": "5.71.10",
     "@tanstack/react-table": "^8.15.0",
     "@tremor/react": "^3.18.3",
     "@types/nodemailer": "^6.4.17",

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -22,6 +22,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { Inter } from "next/font/google";
 import { env } from "next-runtime-env";
 import { FilterProvider } from "@/filterAST/context/filterContext";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -116,6 +117,9 @@ export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
                 </OrgContextProvider>
               </DndProvider>
             </NotificationProvider>
+            {process.env.NODE_ENV === "development" && (
+              <ReactQueryDevtools initialIsOpen={false} />
+            )}
           </QueryClientProvider>
         </SupabaseProvider>
       </PHProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5705,6 +5705,18 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.76.2.tgz#67439edc48ff5a654c8e25979be4660e6402130b"
   integrity sha512-PFGwWh5ss9cJQ67l6bZ7hqXbisX2gy13G2jP+VGY1bgdbCfOMWh6UBVnN62QbFXro6CCoX9hYzTnZHr6Rz00YQ==
 
+"@tanstack/query-devtools@5.71.5":
+  version "5.71.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.71.5.tgz#65ba36c1589a88707a4985b8b0e7742171ba72e3"
+  integrity sha512-Fq1JeAp+I52Md/KnyeFxzG7G0RpdHgeOfDNhSPkZQs/JqqXuAfpUf+wFHDz+vP0GZbSnla2JmcLSQebOkIb1yA==
+
+"@tanstack/react-query-devtools@5.71.10":
+  version "5.71.10"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.71.10.tgz#517bcc88992c9f1a0c0b01621b019c7642296166"
+  integrity sha512-n0xsIzwNvkIoZCmfHww28jFmnVTVzOt5dHj/py3LNFMJHGnJq9o9ttQESzVt2Hr7as00Aqf8ElVwH6na1o6dnw==
+  dependencies:
+    "@tanstack/query-devtools" "5.71.5"
+
 "@tanstack/react-query@^5.62.0", "@tanstack/react-query@^5.71.10":
   version "5.76.2"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.76.2.tgz#3fd2247648f5332f1c203554b639b83c0c00039d"


### PR DESCRIPTION
It is useful when debugging issues related to React Query to have a devtool view like so:
![image](https://github.com/user-attachments/assets/e77decb3-06fd-4ad2-bb42-a8766ea707fc)
