### PR TITLE
Add gemini-2.5-flash pricing

### DIFF
--- a/packages/cost/providers/google/index.ts
+++ b/packages/cost/providers/google/index.ts
@@ -79,6 +79,17 @@ export const costs: ModelRow[] = [
   {
     model: {
       operator: "equals",
+      value: "gemini-2.5-flash",
+    },
+    cost: {
+      prompt_token: 0.00000030,
+      completion_token: 0.0000025,
+      prompt_cache_read_token: 0.000000075,
+    }
+  },
+  {
+    model: {
+      operator: "equals",
       value: "gemini-2.5-pro",
     },
     cost: {


### PR DESCRIPTION
https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-flash

<img width="1063" alt="Screenshot 2025-07-07 at 13 12 19" src="https://github.com/user-attachments/assets/1dd3adf4-c7c3-4373-afc1-312984083521" />

Release: https://blog.google/products/gemini/gemini-2-5-model-family-expands/

This is different from gemini-2.5-flash-preview