### PR TITLE
feat: add pg trigger for provider keys changes

### DIFF
--- a/supabase/migrations/20230803235603_key_management.sql
+++ b/supabase/migrations/20230803235603_key_management.sql
@@ -60,6 +60,29 @@ REVOKE EXECUTE ON FUNCTION public.soft_delete_helicone_proxy_keys() FROM anon;
 ALTER TABLE public.request 
 ADD COLUMN helicone_proxy_key_id uuid NULL REFERENCES public.helicone_proxy_keys(id);
 
+-- A MOCK DECRYPTER PROVIDER KEYS TABLE TO REPLICATE THE PROD VIEW
+ALTER TABLE provider_keys ADD COLUMN IF NOT EXISTS key_id UUID DEFAULT NULL; /* just to have a column to replicate it as it is in prod */
+ALTER TABLE provider_keys ADD COLUMN IF NOT EXISTS nonce BYTEA DEFAULT NULL; /* just to have a column to replicate it as it is in prod */
+
+CREATE VIEW decrypted_provider_keys AS
+(
+  SELECT
+    provider_keys.id,
+    provider_keys.org_id,
+    provider_keys.provider_name,
+    provider_keys.provider_key_name,
+    provider_keys.vault_key_id,
+    provider_keys.soft_delete,
+    provider_keys.created_at,
+    provider_keys.provider_key,
+    provider_keys.provider_key as decrypted_provider_key,
+    provider_keys.key_id,
+    provider_keys.nonce,
+    provider_keys.config
+  FROM provider_keys
+)
+
+
 -- CREATE EXTENSION IF NOT EXISTS pgsodium;
 
 -- CREATE OR REPLACE FUNCTION verify_helicone_proxy_key(api_key text, stored_hashed_key text)

--- a/supabase/migrations/20250628011119_broadcast_provider_keys_changes.sql
+++ b/supabase/migrations/20250628011119_broadcast_provider_keys_changes.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION broadcast_provider_keys_change() RETURNS trigger AS $$
+BEGIN
+  PERFORM pg_notify(
+    'connected_cloud_gateways',           -- channel
+    json_build_object(
+      'event', 'provider_keys_updated',
+      'organization_id', COALESCE(NEW.org_id, OLD.org_id),
+      'provider_key', COALESCE(NEW.decrypted_provider_key, OLD.decrypted_provider_key),
+      'provider_name', COALESCE(NEW.provider_name, OLD.provider_name),
+      'op', TG_OP
+    )::text
+  );
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER t_connected_gateways_broadcast
+AFTER INSERT OR UPDATE OR DELETE ON decrypted_provider_keys
+FOR EACH ROW EXECUTE FUNCTION broadcast_provider_keys_change();

--- a/supabase/migrations/20250628011119_broadcast_provider_keys_changes.sql
+++ b/supabase/migrations/20250628011119_broadcast_provider_keys_changes.sql
@@ -1,11 +1,19 @@
 CREATE OR REPLACE FUNCTION broadcast_provider_keys_change() RETURNS trigger AS $$
+DECLARE
+  decrypted_key TEXT;
 BEGIN
+  -- Query the decrypted_provider_keys view to get the decrypted value
+  SELECT decrypted_provider_key INTO decrypted_key
+  FROM decrypted_provider_keys 
+  WHERE id = COALESCE(NEW.id, OLD.id)
+  LIMIT 1;
+
   PERFORM pg_notify(
     'connected_cloud_gateways',           -- channel
     json_build_object(
       'event', 'provider_keys_updated',
       'organization_id', COALESCE(NEW.org_id, OLD.org_id),
-      'provider_key', COALESCE(NEW.decrypted_provider_key, OLD.decrypted_provider_key),
+      'provider_key', decrypted_key,  -- Use the decrypted value from the view
       'provider_name', COALESCE(NEW.provider_name, OLD.provider_name),
       'op', TG_OP
     )::text
@@ -15,5 +23,5 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER t_connected_gateways_broadcast
-AFTER INSERT OR UPDATE OR DELETE ON decrypted_provider_keys
+AFTER INSERT OR UPDATE OR DELETE ON provider_keys
 FOR EACH ROW EXECUTE FUNCTION broadcast_provider_keys_change();


### PR DESCRIPTION
The change in `supabase/migrations/20230803235603_key_management.sql` won't run in prod since it's updating a previously run migration