### PR TITLE
fix: update docker-compose profile name from "include-helix" to "include-helicone"

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -132,7 +132,7 @@ services:
     restart: unless-stopped
     ports:
       - "5678:5678"
-    profiles: ["include-helix"]
+    profiles: ["include-helicone"]
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
Typo caused the compose script to not build and run the ai gateway.