### PR TITLE
fix: retry 5xx errors in worker

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(grep:*)"
+    ],
+    "deny": []
+  }
+}

--- a/worker/src/lib/clients/ProviderClient.ts
+++ b/worker/src/lib/clients/ProviderClient.ts
@@ -147,8 +147,8 @@ export async function callProviderWithRetry(
           const res = await callProvider(callProps);
 
           lastResponse = res;
-          // Throw an error if the status code is 429
-          if (res.status === 429 || res.status === 500 || res.status === 522) {
+          // Throw an error if the status code is 429 or 5xx
+          if (res.status === 429 || (res.status < 600 && res.status >= 500)) {
             throw new Error(`Status code ${res.status}`);
           }
           return res;


### PR DESCRIPTION
Previously, we only retried a limited subset of 5xx errors: `500` and `522`. However, all 5xx errors can be safely retried, so this commit updates the condition to check for a range of 5xx errors.

This resolves issues where eg `502 bad gateway` errors would not be retried

