### PR TITLE
fix: betterAuth client id issue

### DIFF
--- a/web/packages/common/toImplement/client/betterAuthHelper.ts
+++ b/web/packages/common/toImplement/client/betterAuthHelper.ts
@@ -41,7 +41,8 @@ async function ensureUserInBetterAuth(email: string, password: string): Promise<
 export const heliconeAuthClientFromSession = (
   session: ReturnType<typeof authClient.useSession>["data"],
   refetch: () => void,
-  org?: { org: HeliconeOrg; role: string }
+  org?: { org: HeliconeOrg; role: string },
+  dbUser?: HeliconeUser,
 ): HeliconeAuthClient => {
   const sessionData = session ?? null;
   const betterAuthUser = sessionData?.user ?? null;
@@ -65,6 +66,9 @@ export const heliconeAuthClientFromSession = (
     },
 
     async getUser(): Promise<Result<HeliconeUser, string>> {
+      if (dbUser) {
+        return ok(dbUser);
+      }
       if (!user) {
         return err("User not found");
       }

--- a/web/packages/common/toImplement/server/useBetterAuthClient.ts
+++ b/web/packages/common/toImplement/server/useBetterAuthClient.ts
@@ -84,6 +84,7 @@ export async function betterAuthClientFromSSRContext(
           org: org.data[0]! as HeliconeOrg,
           role: org.data[0].role ?? "member",
         }
-      : undefined
+      : undefined,
+    user.data ?? undefined
   );
 }


### PR DESCRIPTION
this commit fixes an issue with the better auth client that accidentally uses the session id for the user instead of the uuid

