### PR TITLE
refactor: nullable provider keys

### DIFF
--- a/supabase/migrations/20250721011118_nullable_provider_key.sql
+++ b/supabase/migrations/20250721011118_nullable_provider_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."provider_keys" ALTER COLUMN "provider_key" DROP NOT NULL;

--- a/valhalla/jawn/src/managers/apiKeys/KeyManager.ts
+++ b/valhalla/jawn/src/managers/apiKeys/KeyManager.ts
@@ -281,9 +281,11 @@ export class KeyManager extends BaseManager {
       const values = [];
       let paramIndex = 1;
 
-      if (providerKey !== undefined) {
-        updateParts.push(`provider_key = $${paramIndex++}`);
+      updateParts.push(`provider_key = $${paramIndex++}`);
+      if (providerKey !== "" && providerKey !== undefined) {
         values.push(providerKey);
+      } else {
+        values.push(null);
       }
 
       if (config !== undefined) {

--- a/web/components/providers/ProviderCard.tsx
+++ b/web/components/providers/ProviderCard.tsx
@@ -252,14 +252,8 @@ export const ProviderCard: React.FC<ProviderCardProps> = ({ provider }) => {
       dispatch({ type: "SET_KEY_LOADING" });
 
       try {
-        const key = await viewDecryptedProviderKey(existingKey.id);
-
-        if (key) {
-          dispatch({ type: "SET_DECRYPTED_KEY", payload: key });
-        } else {
-          setNotification("Failed to retrieve key", "error");
-          dispatch({ type: "HIDE_KEY" });
-        }
+        const key = await viewDecryptedProviderKey(existingKey.id) ?? "";
+        dispatch({ type: "SET_DECRYPTED_KEY", payload: key });
       } catch (error) {
         console.error("Error viewing key:", error);
         setNotification("Failed to retrieve key", "error");

--- a/web/components/providers/ProvidersPage.tsx
+++ b/web/components/providers/ProvidersPage.tsx
@@ -34,25 +34,6 @@ export const ProvidersPage: React.FC = () => {
       <div className="flex flex-col gap-4 max-w-5xl mx-auto">
         <H1>Provider API Keys</H1>
 
-        <Alert
-          variant="warning"
-          className="bg-amber-50 dark:bg-amber-950 border-amber-200 dark:border-amber-800 py-2"
-        >
-          <AlertDescription>
-            <strong>Important:</strong> These keys are not for proxying
-            requests. See{" "}
-            <Link
-              href="https://docs.helicone.ai/getting-started/integration-methods"
-              className="text-primary font-medium"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              integration docs
-            </Link>
-            .
-          </AlertDescription>
-        </Alert>
-
         <div className="flex flex-col sm:flex-row gap-3">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />


### PR DESCRIPTION
The `pgsodium` library can't handle empty strings, so instead of allowing users to set their provider key to an empty string, we need to represent it as nullable in the database so that when we need to decrypt it, we can gracefully handle it.