### PR TITLE
chore: remove deprecated request gateway router ID migration files

### DIFF
--- a/supabase/migrations/20250716011118_request_gateway_router_id.sql
+++ b/supabase/migrations/20250716011118_request_gateway_router_id.sql
@@ -1,5 +1,0 @@
-ALTER TABLE "public"."request" ADD COLUMN gateway_router_id UUID;
-ALTER TABLE "public"."request" ADD COLUMN gateway_deployment_target VARCHAR(255);
-
-ALTER TABLE "public"."request" ADD CONSTRAINT "request_gateway_router_id_fkey" FOREIGN KEY (gateway_router_id) REFERENCES "public"."routers"("id") ON UPDATE CASCADE ON DELETE CASCADE;
-

--- a/supabase/migrations/20250718011118_request_gateway_drop_router_id.sql
+++ b/supabase/migrations/20250718011118_request_gateway_drop_router_id.sql
@@ -1,4 +1,0 @@
-ALTER TABLE "public"."request" DROP COLUMN IF EXISTS gateway_router_id;
-ALTER TABLE "public"."request" DROP COLUMN IF EXISTS gateway_deployment_target;
-
-ALTER TABLE "public"."request" DROP CONSTRAINT IF EXISTS "request_gateway_router_id_fkey";


### PR DESCRIPTION
This commit deletes the SQL migration files related to the `gateway_router_id` and `gateway_deployment_target` columns in the `request` table, as they are no longer needed.

