### PR TITLE
feat:add dark theme support for homepage

### DIFF
--- a/bifrost/app/email-signup/page.tsx
+++ b/bifrost/app/email-signup/page.tsx
@@ -34,7 +34,7 @@ const bullets: string[] = [
 
 const EmailSignup = () => {
   return (
-    <div className="w-full h-full antialiased text-black">
+    <div className="w-full h-full antialiased text-foreground">
       <div className="h-full">
         <div className="flex flex-col mx-auto w-full gap-8 max-w-5xl p-4 md:px-8 pb-24 pt-10 sm:pb-32 lg:flex lg:py-24 antialiased">
           <div className="flex flex-col w-2/3">
@@ -42,7 +42,7 @@ const EmailSignup = () => {
               Subscribe to Helicone 💌
             </h1>
             <br />
-            <p className="text-gray-700 text-sm">
+            <p className="text-muted-foreground text-sm">
               The difference between good and great AI engineers? Visibility
               into what&apos;s actually happening.
             </p>
@@ -50,7 +50,7 @@ const EmailSignup = () => {
             <ul className="py-8 flex flex-col space-y-4">
               {bullets.map((bullet, idx) => (
                 <li
-                  className="flex items-center text-gray-700 gap-2 text-sm sm:text-md"
+                  className="flex items-center text-muted-foreground gap-2 text-sm sm:text-md"
                   key={idx}
                 >
                   <CheckCircleIcon className="h-4 w-4 sm:h-5 sm:w-5 text-sky-500" />
@@ -59,7 +59,7 @@ const EmailSignup = () => {
               ))}
             </ul>
 
-            <p className="text-black text-sm mt-4">
+            <p className="text-foreground text-sm mt-4">
               Building better AI systems starts with better insights.
             </p>
             <br />

--- a/bifrost/app/globals.css
+++ b/bifrost/app/globals.css
@@ -46,24 +46,24 @@ h6[id] {
     --radius: 0.5rem;
   }
   .dark {
-    --background: 240 10% 3.9%;
+    --background: 240 10% 4%;
     --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
+    --card: 240 8% 6%;
     --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
+    --popover: 240 8% 6%;
     --popover-foreground: 0 0% 98%;
     --primary: 0 0% 98%;
     --primary-foreground: 240 5.9% 10%;
-    --secondary: 240 3.7% 15.9%;
+    --secondary: 240 4% 12%;
     --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
+    --muted: 240 4% 12%;
+    --muted-foreground: 240 5% 68%;
+    --accent: 240 4% 12%;
     --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
+    --border: 240 4% 18%;
+    --input: 240 4% 18%;
     --ring: 240 4.9% 83.9%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;

--- a/bifrost/app/layout.tsx
+++ b/bifrost/app/layout.tsx
@@ -5,6 +5,7 @@ import "@mintlify/mdx/dist/styles.css";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { PHProvider } from "./providers";
+import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import dynamic from "next/dynamic";
 import Script from "next/script";
 import Head from "next/head";
@@ -77,9 +78,11 @@ export default async function RootLayout({
       </Head>
       <PHProvider>
         <body>
-          <div className={`bg-white flex flex-col ${inter.className}`}>
-            {children}
-          </div>
+          <ThemeProvider>
+            <div className={`bg-background text-foreground flex flex-col ${inter.className}`}>
+              {children}
+            </div>
+          </ThemeProvider>
           <PostHogPageView />
           <Analytics />
           <SpeedInsights />

--- a/bifrost/app/page.tsx
+++ b/bifrost/app/page.tsx
@@ -22,7 +22,7 @@ const Stats = dynamic(() => import("@/components/home/Stats"));
 
 const LoadingSection = ({ height = "h-96" }: { height?: string }) => (
   <div
-    className={`w-full bg-gray-100 animate-pulse rounded-lg ${height}`}
+    className={`w-full bg-muted animate-pulse rounded-lg ${height}`}
   ></div>
 );
 
@@ -48,12 +48,12 @@ export default async function Home() {
 
   return (
     <Layout>
-      <main className="bg-white text-landing-description">
+      <main className="bg-background text-foreground">
         <div className="max-w-8xl mx-auto">
           <Hero />
           <Prototype />
           <LazyLoadComponent fallback={<LoadingSection height="h-24" />}>
-            <Companies className={cn("bg-[#f2f9fc]")} />
+            <Companies className={cn("bg-muted/30")} />
           </LazyLoadComponent>
           <LazyLoadComponent fallback={<LoadingSection />}>
             <Quote2 />

--- a/bifrost/components/home/AiGateway.tsx
+++ b/bifrost/components/home/AiGateway.tsx
@@ -27,17 +27,17 @@ const AiGateway = () => {
         <div className="flex flex-col items-start md:items-end gap-3 md:gap-9 order-1 md:order-2 pl-4 md:pl-0">
           <div className="flex items-center gap-2.5">
             <p className="text-base sm:text-xl">01</p>
-            <div className="text-base sm:text-lg font-medium text-slate-700">
+            <div className="text-base sm:text-lg font-medium text-muted-foreground">
               Route
             </div>
           </div>
           <div className="flex flex-col items-start md:items-end gap-6 text-left md:text-right">
-            <h2 className="font-semibold text-4xl sm:text-5xl leading-[120%] max-w-[600px] text-wrap text-black">
+            <h2 className="font-semibold text-4xl sm:text-5xl leading-[120%] max-w-[600px] text-wrap text-foreground">
               <span className="text-brand">Smart & Speedy</span>
               <br />
               LLM Routing
             </h2>
-            <p className="text-lg max-w-[520px] text-landing-description font-light leading-relaxed">
+            <p className="text-lg max-w-[520px] text-muted-foreground font-light leading-relaxed">
               We make sure you always have the best model for your request, so
               you can focus on shipping features.
             </p>
@@ -65,7 +65,7 @@ const AiGateway = () => {
           </div>
           <div
             className={cn(
-              "bg-slate-50 border border-slate-200 px-6 py-3 cursor-pointer max-w-[550px] transition-all duration-300 ease-in-out",
+              "bg-muted/50 border border-border px-6 py-3 cursor-pointer max-w-[550px] transition-all duration-300 ease-in-out hover:bg-muted/70",
               isQuestionOpen ? "rounded-2xl" : "rounded-[24px]"
             )}
             onClick={() => setIsQuestionOpen(!isQuestionOpen)}
@@ -75,7 +75,7 @@ const AiGateway = () => {
                 "flex justify-between items-center transition-all duration-300"
               )}
             >
-              <p className="text-lg">What is LLM routing?</p>
+              <p className="text-lg text-foreground">What is LLM routing?</p>
               <div className="transition-transform duration-300">
                 {isQuestionOpen ? (
                   <XIcon className="h-4 w-4 rotate-0" />
@@ -93,7 +93,7 @@ const AiGateway = () => {
               )}
             >
               <div className="overflow-hidden">
-                <p className="text-sm sm:text-lg font-light text-gray-400">
+                <p className="text-sm sm:text-lg font-light text-muted-foreground">
                   LLM routing intelligently directs your requests to the optimal
                   model based on your criteria - whether that&apos;s cost,
                   speed, accuracy, or availability.

--- a/bifrost/components/home/BigDashboard.tsx
+++ b/bifrost/components/home/BigDashboard.tsx
@@ -4,7 +4,7 @@ const BigDashboard = () => {
   return (
     <div className="w-full mx-auto h-full relative">
       <DashboardBig />
-      <div className="h-[100px] bg-[#f2f9fc] hidden md:block absolute bottom-0 w-full"></div>
+      <div className="h-[100px] bg-muted/30 hidden md:block absolute bottom-0 w-full"></div>
     </div>
   );
 };

--- a/bifrost/components/home/CTA.tsx
+++ b/bifrost/components/home/CTA.tsx
@@ -13,7 +13,7 @@ const CTA = () => {
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <div className="bg-[#F2F9FC] h-[80vh] relative overflow-hidden flex flex-col">
+    <div className="bg-muted/30 h-[80vh] relative overflow-hidden flex flex-col">
       <div
         className="hidden md:block absolute inset-0 w-full h-full z-[0]"
         style={{
@@ -43,11 +43,11 @@ const CTA = () => {
             backgroundRepeat: "no-repeat",
           }}
         ></div>
-        <div className="flex flex-col items-center text-wrap text-4xl md:text-5xl font-semibold text-slate-500 leading-snug z-[10]">
+        <div className="flex flex-col items-center text-wrap text-4xl md:text-5xl font-semibold text-muted-foreground leading-snug z-[10]">
           <div className="flex flex-wrap gap-x-3 gap-y-1 items-center justify-center ">
             <div
               className={cn(
-                "bg-[#E7F6FD] border-[3px] border-brand rounded-xl py-2 xl:py-4 px-7 text-brand transition-transform duration-1000",
+                "bg-brand/10 border-[3px] border-brand rounded-xl py-2 xl:py-4 px-7 text-brand transition-transform duration-1000",
                 "rotate-[-3deg]"
               )}
             >

--- a/bifrost/components/home/Companies.tsx
+++ b/bifrost/components/home/Companies.tsx
@@ -9,7 +9,7 @@ const Companies = ({ className }: CompaniesProps) => {
   return (
     <div className={cn("py-16", className)}>
       <div className="max-w-6xl mx-auto px-4">
-        <p className="text-center text-md mb-8">
+        <p className="text-center text-md mb-8 text-foreground font-medium">
           1000+ AI teams use Helicone to build reliable products
         </p>
         <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-8 gap-8 items-center justify-items-center">

--- a/bifrost/components/home/Experiment.tsx
+++ b/bifrost/components/home/Experiment.tsx
@@ -322,7 +322,7 @@ const Experiment = () => {
                 Push <span className="text-brand">high-quality</span> prompt
                 changes to production
               </h2>
-              <p className="text-lg max-w-[520px] text-landing-description font-light leading-relaxed">
+              <p className="text-lg max-w-[520px] text-muted-foreground font-light leading-relaxed">
                 Tune your prompts and justify your iterations with quantifiable
                 data, not just “vibes”.
               </p>

--- a/bifrost/components/home/FAQ.tsx
+++ b/bifrost/components/home/FAQ.tsx
@@ -12,7 +12,7 @@ const FAQ = () => {
   return (
     <div className={cn(ISLAND_WIDTH, "pt-14 sm:pt-20 pb-12 md:pb-14")}>
       <div className="flex flex-col md:flex-row justify-between w-full gap-6 md:gap-10">
-        <h2 className="text-4xl sm:text-5xl font-semibold text-black">
+        <h2 className="text-4xl sm:text-5xl font-semibold text-foreground">
           Questions &amp; Answers
         </h2>
         <Accordion type="multiple" className="w-full">

--- a/bifrost/components/home/Hero.tsx
+++ b/bifrost/components/home/Hero.tsx
@@ -35,12 +35,12 @@ const Hero = () => {
           priority
         />
       </div>
-      <h1 className="text-xl sm:text-7xl md:text-[84px] font-semibold mb-3 w-full max-w-4xl text-wrap text-black z-[10]">
+      <h1 className="text-xl sm:text-7xl md:text-[84px] font-semibold mb-3 w-full max-w-4xl text-wrap text-foreground z-[10]">
         Build Reliable
         <br />
         <span className="text-brand">AI Apps</span>
       </h1>
-      <p className="text-lg sm:text-xl 2xl:text-2xl text-landing-secondary font-light mb-6 lg:mb-12 z-[10]">
+      <p className="text-lg sm:text-xl 2xl:text-2xl text-muted-foreground font-light mb-6 lg:mb-12 z-[10]">
         The world&apos;s fastest-growing AI companies rely on Helicone
         <br />
         to route, debug, and analyze their applications.
@@ -53,7 +53,7 @@ const Hero = () => {
               <ChevronRight className="size-5 md:size-6" />
             </Button>
           </Link>
-          <p className="text-sm text-landing-secondary">
+          <p className="text-sm text-muted-foreground">
             No credit card required, 7-day free trial
           </p>
         </div>

--- a/bifrost/components/home/LLMLifecycle.tsx
+++ b/bifrost/components/home/LLMLifecycle.tsx
@@ -2385,7 +2385,7 @@ const SVG = () => (
 
 const LLMLifecycle = () => {
   return (
-    <div className="bg-[#f1f5f9] relative">
+    <div className="bg-muted/20 relative">
       <div
         className="absolute inset-0 w-full h-full z-[1]"
         style={{
@@ -2409,11 +2409,11 @@ const LLMLifecycle = () => {
         )}
       >
         <div className="flex flex-col flex-1 gap-6">
-          <h2 className="text-4xl sm:text-5xl font-semibold text-black max-w-[520px] text-wrap sm:leading-[57.6px]">
+          <h2 className="text-4xl sm:text-5xl font-semibold text-foreground max-w-[520px] text-wrap sm:leading-[57.6px]">
             The LLMOps platform behind the{" "}
             <span className="text-brand">fastest-growing AI companies</span>
           </h2>
-          <p className="text-lg sm:text-xl max-w-[440px] text-wrap font-light leading-relaxed text-landing-description">
+          <p className="text-lg sm:text-xl max-w-[440px] text-wrap font-light leading-relaxed text-muted-foreground">
             Route intelligently, monitor comprehensively, optimize continuously.
             The platform for every stage of your AI development lifecycle.
           </p>

--- a/bifrost/components/home/Log.tsx
+++ b/bifrost/components/home/Log.tsx
@@ -15,10 +15,10 @@ const Log = () => {
             </div>
           </div>
           <div className="flex flex-col gap-6">
-            <h2 className="font-semibold text-4xl sm:text-5xl leading-[120%] max-w-[600px] text-wrap text-black">
+            <h2 className="font-semibold text-4xl sm:text-5xl leading-[120%] max-w-[600px] text-wrap text-foreground">
               Trace and debug your agent with ease
             </h2>
-            <p className="text-lg max-w-[520px] text-landing-description font-light leading-relaxed">
+                          <p className="text-lg max-w-[520px] text-muted-foreground font-light leading-relaxed">
               Visualize your multi-step LLM interactions, log requests in
               real-time, and pinpoint the root cause of errors.
             </p>

--- a/bifrost/components/home/OpenSource.tsx
+++ b/bifrost/components/home/OpenSource.tsx
@@ -190,10 +190,10 @@ const OpenSource = async () => {
     <div className={cn(ISLAND_WIDTH, "flex flex-col gap-12 pt-32 pb-20")}>
       <div className="flex justify-between items-end">
         <div className="flex flex-col gap-4">
-          <h2 className="font-semibold text-4xl sm:text-5xl leading-[120%]  text-black">
+          <h2 className="font-semibold text-4xl sm:text-5xl leading-[120%]  text-foreground">
             Proudly <span className="text-brand">open-source</span>
           </h2>
-          <p className="text-lg sm:text-xl font-light leading-relaxed text-landing-description">
+          <p className="text-lg sm:text-xl font-light leading-relaxed text-muted-foreground">
             We value transparency and believe the best products are built in
             community.
           </p>
@@ -205,10 +205,10 @@ const OpenSource = async () => {
         >
           <div className="flex items-center">
             <Button
-              className="flex items-center gap-2 rounded-r-none border border-slate-200 text-landing-description"
+              className="flex items-center gap-2 rounded-r-none border border-border text-muted-foreground"
               variant="secondary"
             >
-              <svg fill="black" viewBox="0 0 24 24" className="w-4 h-4">
+              <svg fill="currentColor" viewBox="0 0 24 24" className="w-4 h-4">
                 <path
                   fillRule="evenodd"
                   d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
@@ -218,7 +218,7 @@ const OpenSource = async () => {
               Star us on Github
             </Button>
             <Button
-              className="rounded-l-none border border-l-0 border-slate-200 text-landing-description"
+              className="rounded-l-none border border-l-0 border-border text-muted-foreground"
               variant="secondary"
             >
               {stars.toLocaleString("en-US", {
@@ -233,13 +233,13 @@ const OpenSource = async () => {
         <Link
           href="https://github.com/helicone/helicone"
           target="_blank"
-          className="col-span-1 md:col-span-2 p-6 bg-slate-50 rounded-xl border border-slate-200 relative hover:bg-slate-100 transition-colors flex flex-col h-full justify-between"
+          className="col-span-1 md:col-span-2 p-6 bg-card rounded-xl border border-border relative hover:bg-muted/50 transition-colors flex flex-col h-full justify-between"
         >
           <div className="flex flex-col gap-2">
-            <p className="text-sm text-slate-500">Become a contributor</p>
+            <p className="text-sm text-muted-foreground">Become a contributor</p>
 
             <div className="flex items-center gap-2">
-              <h3 className="text-xl sm:text-2xl font-semibold text-black">
+              <h3 className="text-xl sm:text-2xl font-semibold text-foreground">
                 Join our community
               </h3>
               <ArrowUpRight className="w-4 h-4 text-brand" />
@@ -254,13 +254,13 @@ const OpenSource = async () => {
         <Link
           href="https://docs.helicone.ai/ai-gateway/quickstart"
           target="_blank"
-          className="col-span-1 md:col-span-4 px-6 pt-6 pb-2 sm:pb-6 bg-slate-50 rounded-xl border border-slate-200 flex flex-col sm:flex-row items-center sm:items-stretch gap-y-8 justify-between relative hover:bg-slate-100 transition-colors"
+          className="col-span-1 md:col-span-4 px-6 pt-6 pb-2 sm:pb-6 bg-card rounded-xl border border-border flex flex-col sm:flex-row items-center sm:items-stretch gap-y-8 justify-between relative hover:bg-muted/50 transition-colors"
         >
           <div className="flex flex-col gap-4 sm:gap-10">
             <div className="flex flex-col gap-2">
-              <p className="text-sm text-slate-500">AI Engineers</p>
+              <p className="text-sm text-muted-foreground">AI Engineers</p>
               <div className="flex items-center gap-2">
-                <h3 className="text-xl sm:text-2xl font-semibold text-black">
+                <h3 className="text-xl sm:text-2xl font-semibold text-foreground">
                   Deploy your own AI Gateway
                 </h3>
                 <ArrowUpRight className="w-4 h-4 text-brand" />
@@ -280,13 +280,13 @@ const OpenSource = async () => {
         <Link
           href="/llm-cost"
           target="_blank"
-          className="col-span-1 md:col-span-4 px-6 pt-6 pb-2 sm:pb-6 bg-slate-50 rounded-xl border border-slate-200 flex flex-col sm:flex-row items-center sm:items-stretch gap-y-8 justify-between relative hover:bg-slate-100 transition-colors"
+          className="col-span-1 md:col-span-4 px-6 pt-6 pb-2 sm:pb-6 bg-card rounded-xl border border-border flex flex-col sm:flex-row items-center sm:items-stretch gap-y-8 justify-between relative hover:bg-muted/50 transition-colors"
         >
           <div className="flex flex-col gap-4 sm:gap-10">
             <div className="flex flex-col gap-2">
-              <p className="text-sm text-slate-500">Built by Helicone</p>
+              <p className="text-sm text-muted-foreground">Built by Helicone</p>
               <div className="flex items-center gap-2">
-                <h3 className="text-xl sm:text-2xl font-semibold text-black">
+                <h3 className="text-xl sm:text-2xl font-semibold text-foreground">
                   API Cost Calculator
                 </h3>
                 <ArrowUpRight className="w-4 h-4 text-brand" />
@@ -305,13 +305,13 @@ const OpenSource = async () => {
         <Link
           href="https://us.helicone.ai/open-stats"
           target="_blank"
-          className="col-span-1 md:col-span-2 p-6 bg-slate-50 rounded-xl border border-slate-200 relative hover:bg-slate-100 transition-colors flex flex-col h-full justify-between"
+          className="col-span-1 md:col-span-2 p-6 bg-card rounded-xl border border-border relative hover:bg-muted/50 transition-colors flex flex-col h-full justify-between"
         >
           <div className="flex flex-col gap-2">
-            <p className="text-sm text-slate-500">Check out our data</p>
+            <p className="text-sm text-muted-foreground">Check out our data</p>
 
             <div className="flex items-center gap-2">
-              <h3 className="text-xl sm:text-2xl font-semibold text-black">
+              <h3 className="text-xl sm:text-2xl font-semibold text-foreground">
                 Open Stats
               </h3>
               <ArrowUpRight className="w-4 h-4 text-brand" />

--- a/bifrost/components/home/Production.tsx
+++ b/bifrost/components/home/Production.tsx
@@ -15,11 +15,11 @@ const Production = () => {
           </div>
         </div>
         <div className="flex flex-col items-start md:items-end gap-6 text-left md:text-right">
-          <h2 className="font-semibold text-4xl sm:text-5xl leading-[120%] max-w-[800px] text-wrap text-black">
+                      <h2 className="font-semibold text-4xl sm:text-5xl leading-[120%] max-w-[800px] text-wrap text-foreground">
             Get complete visibility
             <br /> <span className="text-brand">into your AI apps</span>
           </h2>
-          <p className="text-lg max-w-[520px] text-landing-description font-light leading-relaxed">
+                      <p className="text-lg max-w-[520px] text-muted-foreground font-light leading-relaxed">
             Unified insights across all providers to quickly detect
             hallucinations, abuse and performance issues.
           </p>

--- a/bifrost/components/home/Prototype.tsx
+++ b/bifrost/components/home/Prototype.tsx
@@ -32,10 +32,10 @@ const Prototype = () => {
   >("dashboard");
 
   return (
-    <div className=" bg-gradient-to-b from-white from-50% via-[#f2f9fc80] via-[61%] to-[#f2f9fc]">
+    <div className=" bg-gradient-to-b from-background from-50% via-muted/50 via-[61%] to-muted/30">
       <div className={cn(ISLAND_WIDTH, "pt-6 pb-12")}>
-        <div className="bg-white rounded-[20px] p-1 lg:p-3 border border-[#D1D5DC] aspect-[2/1] shadow-md">
-          <div className="hidden lg:grid w-full h-full bg-[#f8fafc] border border-[#f0f0f0] rounded-xl grid-cols-6">
+        <div className="bg-card rounded-[20px] p-1 lg:p-3 border border-border aspect-[2/1] shadow-md">
+          <div className="hidden lg:grid w-full h-full bg-muted/20 border border-border rounded-xl grid-cols-6">
             <PrototypeSidebar
               openedPage={openedPage}
               setOpenedPage={setOpenedPage}
@@ -77,16 +77,16 @@ const PrototypeSidebar = ({
   setOpenedPage: (page: "dashboard" | "requests" | "sessions") => void;
 }) => {
   return (
-    <div className="bg-white border-r border-[#e5e7eb] h-full flex-1 rounded-l-xl overflow-y-auto">
-      <div className="w-full flex flex-col h-full border-r dark:border-slate-800 px-2">
+    <div className="bg-card border-r border-border h-full flex-1 rounded-l-xl overflow-y-auto">
+      <div className="w-full flex flex-col h-full border-r border-border px-2">
         <div className="flex-grow overflow-y-auto pb-14">
-          <div className="flex items-center justify-between gap-2 h-14 border-b dark:border-slate-800 mx-1">
+          <div className="flex items-center justify-between gap-2 h-14 border-b border-border mx-1">
             <Button
               variant="ghost"
               className="flex items-center justify-start w-full p-2 truncate"
             >
               <RocketIcon className="mr-2 flex-shrink-0 h-4 w-4 text-[#5592F8]" />
-              <p className="text-xs text-black font-semibold w-fit text-left">
+              <p className="text-xs text-foreground font-semibold w-fit text-left">
                 Xpedia AI
               </p>
             </Button>
@@ -116,8 +116,8 @@ const PrototypeSidebar = ({
                         Dashboard
                         {openedPage !== "dashboard" && (
                           <>
-                            <div className="absolute w-1.5 h-1.5 bg-[#32ACEB] rounded-full top-[1px] right-[-9px]"></div>
-                            <div className="absolute w-1.5 h-1.5 bg-[#32ACEB] rounded-full top-[1px] right-[-9px] animate-ping"></div>
+                            <div className="absolute w-1.5 h-1.5 bg-primary rounded-full top-[1px] right-[-9px]"></div>
+                            <div className="absolute w-1.5 h-1.5 bg-primary rounded-full top-[1px] right-[-9px] animate-ping"></div>
                           </>
                         )}
                       </div>
@@ -140,14 +140,14 @@ const PrototypeSidebar = ({
                         Requests
                         {openedPage !== "requests" && (
                           <>
-                            <div className="absolute w-1.5 h-1.5 bg-[#32ACEB] rounded-full top-[1px] right-[-9px]"></div>
-                            <div className="absolute w-1.5 h-1.5 bg-[#32ACEB] rounded-full top-[1px] right-[-9px] animate-ping"></div>
+                            <div className="absolute w-1.5 h-1.5 bg-primary rounded-full top-[1px] right-[-9px]"></div>
+                            <div className="absolute w-1.5 h-1.5 bg-primary rounded-full top-[1px] right-[-9px] animate-ping"></div>
                           </>
                         )}
                       </div>
                     </div>
                   </div>
-                  <div className="flex items-center gap-1 font-normal text-slate-400 mt-[10px] text-[11px]">
+                  <div className="flex items-center gap-1 font-normal text-muted-foreground mt-[10px] text-[11px]">
                     <div className="flex items-center">
                       Segments
                       <ChevronDownIcon className="h-3 w-3 transition-transform" />
@@ -170,8 +170,8 @@ const PrototypeSidebar = ({
                         Sessions
                         {openedPage !== "sessions" && (
                           <>
-                            <div className="absolute w-1.5 h-1.5 bg-[#32ACEB] rounded-full top-[1px] right-[-9px]"></div>
-                            <div className="absolute w-1.5 h-1.5 bg-[#32ACEB] rounded-full top-[1px] right-[-9px] animate-ping"></div>
+                            <div className="absolute w-1.5 h-1.5 bg-primary rounded-full top-[1px] right-[-9px]"></div>
+                            <div className="absolute w-1.5 h-1.5 bg-primary rounded-full top-[1px] right-[-9px] animate-ping"></div>
                           </>
                         )}
                       </div>

--- a/bifrost/components/home/Quote.tsx
+++ b/bifrost/components/home/Quote.tsx
@@ -4,12 +4,12 @@ import Image from "next/image";
 
 const Quote = () => {
   return (
-    <div className="bg-[#f2f9fc] pt-20 pb-16 lg:pb-40 lg:px-16">
+    <div className="bg-muted/30 pt-20 pb-16 lg:pb-40 lg:px-16">
       <div className={cn(ISLAND_WIDTH)}>
         <div className="flex flex-col gap-y-8 lg:flex-row justify-between items-start lg:items-end">
-          <h2 className="text-2xl md:text-[40px] tracking-tight leading-normal md:leading-[52px] font-semibold text-[#ACB3BA] w-full lg:max-w-[780px] text-wrap lg:mr-20">
+          <h2 className="text-2xl md:text-[40px] tracking-tight leading-normal md:leading-[52px] font-semibold text-muted-foreground w-full lg:max-w-[780px] text-wrap lg:mr-20">
             Thank you for an excellent observability platform!{" "}
-            <span className="text-black">
+            <span className="text-foreground">
               I use it for all of my AI applications now.
             </span>
           </h2>
@@ -22,10 +22,10 @@ const Quote = () => {
               className="w-12 h-12"
             />
             <div className="flex flex-col gap-2">
-              <h4 className="text-[17px] sm:text-xl font-medium whitespace-nowrap">
+              <h4 className="text-[17px] sm:text-xl font-medium whitespace-nowrap text-foreground">
                 Hassan El Mghari
               </h4>
-              <p className="text-[12px] sm:text-base w-auto">
+              <p className="text-[12px] sm:text-base w-auto text-muted-foreground">
                 Director of Developer Relations
               </p>
             </div>

--- a/bifrost/components/home/Quote2.tsx
+++ b/bifrost/components/home/Quote2.tsx
@@ -8,12 +8,12 @@ import Image from "next/image";
 
 const Quote2 = () => {
   return (
-    <div className="bg-[#f2f9fc] pt-12 pb-14 lg:pb-24 lg:px-16">
+    <div className="bg-muted/30 pt-12 pb-14 lg:pb-24 lg:px-16">
       <div className={cn(ISLAND_WIDTH)}>
         <div className="flex flex-col gap-y-8 items-center">
-          <h2 className="text-2xl md:text-[40px] tracking-tight leading-normal md:leading-[52px] font-semibold text-[#ACB3BA] w-full max-w-[816px] text-wrap text-center mx-auto">
+          <h2 className="text-2xl md:text-[40px] tracking-tight leading-normal md:leading-[52px] font-semibold text-muted-foreground w-full max-w-[816px] text-wrap text-center mx-auto">
             <span className="hidden md:inline">&ldquo;</span>The{" "}
-            <span className="text-black">most impactful one-line change</span>{" "}
+            <span className="text-foreground">most impactful one-line change</span>{" "}
             I&apos;ve seen applied to our codebase.
             <span className="hidden md:inline">&rdquo;</span>
           </h2>
@@ -26,10 +26,10 @@ const Quote2 = () => {
               className="w-12 h-12"
             />
             <div className="flex flex-col gap-2">
-              <h4 className="text-[17px] sm:text-xl font-medium whitespace-nowrap">
+              <h4 className="text-[17px] sm:text-xl font-medium whitespace-nowrap text-foreground">
                 Nishant Shukla
               </h4>
-              <p className="text-[15px] sm:text-lg w-auto">
+              <p className="text-[15px] sm:text-lg w-auto text-muted-foreground">
                 Sr. Director of AI
               </p>
             </div>

--- a/bifrost/components/home/Quote3.tsx
+++ b/bifrost/components/home/Quote3.tsx
@@ -4,12 +4,12 @@ import Image from "next/image";
 
 const Quote3 = () => {
   return (
-    <div className="bg-white sm:bg-gradient-to-b sm:from-white sm:to-[#F2F9FC] pt-10 pb-20 sm:pb-40">
+    <div className="bg-gradient-to-b from-background to-muted/20 pt-10 pb-20 sm:pb-40">
       <div className={cn(ISLAND_WIDTH)}>
         <div className="flex flex-col gap-y-9 lg:flex-row justify-between items-start lg:items-end">
-          <h2 className="text-2xl md:text-[40px] tracking-tight leading-normal md:leading-[52px] font-semibold text-[#ACB3BA] w-full lg:max-w-[780px] text-wrap mr-20">
+          <h2 className="text-2xl md:text-[40px] tracking-tight leading-normal md:leading-[52px] font-semibold text-muted-foreground w-full lg:max-w-[780px] text-wrap mr-20">
             Helicone is{" "}
-            <span className="text-black">
+            <span className="text-foreground">
               essential for debugging our complex agentic flows
             </span>{" "}
             for AI code reviews. Can&apos;t imagine building without it.
@@ -30,10 +30,10 @@ const Quote3 = () => {
                 height={28}
                 className="w-28 pb-2"
               />
-              <h4 className="text-[17px] sm:text-xl font-medium whitespace-nowrap">
+              <h4 className="text-[17px] sm:text-xl font-medium whitespace-nowrap text-foreground">
                 Soohoon Choi
               </h4>
-              <p className="text-[15px] sm:text-lg w-auto">CTO</p>
+              <p className="text-[15px] sm:text-lg w-auto text-muted-foreground">CTO</p>
             </div>
           </div>
         </div>

--- a/bifrost/components/home/Stats.tsx
+++ b/bifrost/components/home/Stats.tsx
@@ -52,19 +52,19 @@ const Stats = ({
   }, []);
 
   return (
-    <div className="bg-[#f2f9fc]">
+    <div className="bg-muted/30">
       <div
         className={cn(
           ISLAND_WIDTH,
           "flex justify-between items-start pt-0 pb-32"
         )}
       >
-        <h1 className="gap-y-4 text-3xl md:text-6xl font-semibold !leading-[150%] text-black max-w-[1100px] text-wrap">
+        <h1 className="gap-y-4 text-3xl md:text-6xl font-semibold !leading-[150%] text-foreground max-w-[1100px] text-wrap">
           Today,{" "}
           <span
             ref={elementRef}
             className={cn(
-              "inline-block bg-[#E7F6FD] border-[3px] border-brand rounded-xl py-1 px-5 text-brand translate-y-[-10px] transition-transform duration-500 text-nowrap",
+              "inline-block bg-brand/10 border-[3px] border-brand rounded-xl py-1 px-5 text-brand translate-y-[-10px] transition-transform duration-500 text-nowrap",
               isVisible ? "rotate-[-3deg]" : "rotate-[0  deg]"
             )}
           >

--- a/bifrost/components/layout/footer.tsx
+++ b/bifrost/components/layout/footer.tsx
@@ -55,8 +55,8 @@ const Footer = () => {
     <footer
       className={`grid grid-cols-2 md:grid-cols-5 gap-y-8 pl-8 md:pl-0 md:justify-items-center items-start ${
         path === "/"
-          ? " bg-white text-slate-700 fill-slate-700 stroke-slate-700 py-16"
-          : "bg-inherit text-black/60 fill-[#5D6673] stroke-[#5D6673] py-6"
+          ? " bg-background text-muted-foreground fill-muted-foreground stroke-muted-foreground py-16"
+          : "bg-inherit text-muted-foreground fill-muted-foreground stroke-muted-foreground py-6"
       }`}
     >
       <div className="flex flex-col items-start font-light text-sm tracking-wide gap-1 col-span-2 md:col-span-1 justify-self-start md:justify-self-center">

--- a/bifrost/components/layout/navbar.tsx
+++ b/bifrost/components/layout/navbar.tsx
@@ -35,6 +35,8 @@ import { BlogStructureMetaData } from "../templates/blog/getMetaData";
 import { Button } from "../ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { ThemeAwareLogo } from "@/components/ui/theme-aware-logo";
 
 interface NavBarProps {
   stars?: number;
@@ -57,25 +59,11 @@ const MobileHeader = (props: {
       <div className="flex items-center col-span-7 lg:col-span-1 order-1">
         <Link href="/" className="-m-1.5">
           <span className="sr-only">Helicone</span>
-          <Image
-            src={"/static/logo.svg"}
-            alt={
-              "Helicone - Open-source LLM observability and monitoring platform for developers"
-            }
-            height={150}
-            width={150}
+          <ThemeAwareLogo 
+            width={150} 
+            height={150} 
             priority={true}
-            className="w-auto h-auto lg:block hidden"
-          />
-          <Image
-            src={"/static/logo.svg"}
-            alt={
-              "Helicone - Open-source LLM observability and monitoring platform for developers"
-            }
-            height={150}
-            width={150}
-            priority={true}
-            className="block lg:hidden"
+            className="transition-all duration-200 hover:opacity-80"
           />
         </Link>
       </div>
@@ -147,14 +135,14 @@ const MobileNav = () => {
 
   return (
     <nav className="lg:hidden" aria-label="Global">
-      <div className="fixed inset-x-0 top-0 z-50 bg-background">
+      <div className="fixed inset-x-0 top-0 z-50 bg-background/95 backdrop-blur-md">
         <MobileHeader
           menuDispatch={[menuOpen, setMenuOpen]}
           className="pl-2 pr-4"
         />
       </div>
       {menuOpen && (
-        <div className="fixed inset-0 top-[57px] z-50 bg-background">
+        <div className="fixed inset-0 top-[57px] z-50 bg-background/98 backdrop-blur-lg">
           <div className="h-full pb-10 overflow-y-auto">
             <div className="flex flex-col gap-4 pt-3 px-4">
               {/* Login and Contact Buttons */}
@@ -169,6 +157,9 @@ const MobileNav = () => {
                     Log In
                   </Button>
                 </Link>
+                <div className="flex justify-center">
+                  <ThemeToggle />
+                </div>
               </div>
 
               {renderLinks(mainComponents)}
@@ -337,7 +328,7 @@ const NavBar = (props: NavBarProps) => {
   return (
     <div
       ref={headerRef}
-      className="bg-background top-0 sticky z-30 border-b border-border mb-10"
+      className="bg-background/95 backdrop-blur-md top-0 sticky z-30 border-b border-border mb-10 transition-all duration-200"
     >
       <MobileNav />
 
@@ -349,25 +340,11 @@ const NavBar = (props: NavBarProps) => {
         <div className="flex items-center lg:col-span-1 order-1">
           <Link href="/" className="-m-1.5 w-[154px]">
             <span className="sr-only">Helicone</span>
-            <Image
-              src={"/static/logo.svg"}
-              alt={
-                "Helicone - Open-source LLM observability and monitoring platform for developers"
-              }
-              height={150}
-              width={150}
+            <ThemeAwareLogo 
+              width={150} 
+              height={150} 
               priority={true}
-              className="w-auto h-auto lg:block hidden"
-            />
-            <Image
-              src={"/static/logo.svg"}
-              alt={
-                "Helicone - Open-source LLM observability and monitoring platform for developers"
-              }
-              height={150}
-              width={150}
-              priority={true}
-              className="block lg:hidden"
+              className="transition-all duration-200 hover:opacity-80"
             />
           </Link>
         </div>
@@ -480,8 +457,9 @@ const NavBar = (props: NavBarProps) => {
           {/* Old Nav Links */}
           {/* <NavLinks /> */}
 
-          {/* Github, contact, login */}
+          {/* Theme toggle, Github, contact, login */}
           <div className="flex items-center gap-x-3">
+            <ThemeToggle />
             <a
               href="https://github.com/helicone/helicone"
               target="_blank"

--- a/bifrost/components/providers/ThemeProvider.tsx
+++ b/bifrost/components/providers/ThemeProvider.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+  defaultTheme?: Theme;
+}
+
+interface ThemeProviderState {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const initialState: ThemeProviderState = {
+  theme: "light",
+  setTheme: () => null,
+  toggleTheme: () => null,
+};
+
+const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
+
+export function ThemeProvider({
+  children,
+  defaultTheme = "light",
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(defaultTheme);
+
+  useEffect(() => {
+    // Check localStorage and system preference on mount
+    const stored = localStorage.getItem("helicone-theme") as Theme | null;
+    
+    if (stored) {
+      setTheme(stored);
+    } else {
+      // Check system preference
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+      setTheme(systemTheme);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Update document class and localStorage when theme changes
+    const root = window.document.documentElement;
+    root.classList.remove("light", "dark");
+    root.classList.add(theme);
+    localStorage.setItem("helicone-theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(theme === "light" ? "dark" : "light");
+  };
+
+  const value = {
+    theme,
+    setTheme,
+    toggleTheme,
+  };
+
+  return (
+    <ThemeProviderContext.Provider value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  );
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext);
+
+  if (context === undefined)
+    throw new Error("useTheme must be used within a ThemeProvider");
+
+  return context;
+}; 

--- a/bifrost/components/ui/theme-aware-logo.tsx
+++ b/bifrost/components/ui/theme-aware-logo.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Image from "next/image";
+
+import { cn } from "@/lib/utils";
+
+interface ThemeAwareLogoProps {
+  className?: string;
+  width?: number;
+  height?: number;
+  priority?: boolean;
+}
+
+export function ThemeAwareLogo({ 
+  className,
+  width = 150, 
+  height = 150, 
+  priority = true 
+}: ThemeAwareLogoProps) {
+  return (
+    <div className={cn("relative", className)}>
+      {/* Logo stays the same in both themes - maintains blue branding */}
+      <Image
+        src="/static/logo.svg"
+        alt="Helicone - Open-source LLM observability and monitoring platform for developers"
+        height={height}
+        width={width}
+        priority={priority}
+        className="w-auto h-auto"
+      />
+    </div>
+  );
+} 

--- a/bifrost/components/ui/theme-toggle.tsx
+++ b/bifrost/components/ui/theme-toggle.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useTheme } from "@/components/providers/ThemeProvider";
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={toggleTheme}
+      className="h-9 w-9 p-0 border-border hover:bg-accent hover:text-accent-foreground transition-all duration-200 hover:scale-105 active:scale-95"
+      aria-label={`Switch to ${theme === "light" ? "dark" : "light"} theme`}
+    >
+      <Sun className="h-4 w-4 rotate-0 scale-100 transition-all duration-300 dark:-rotate-90 dark:scale-0 text-amber-500" />
+      <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all duration-300 dark:rotate-0 dark:scale-100 text-blue-400" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+} 


### PR DESCRIPTION
Implemented dark theme functionality for the website's homepage and signup page.

**Theme Management:**
- React Context (`ThemeProvider`) for global state management
- Custom `useTheme` hook for easy theme access
- CSS variables with Tailwind's semantic color system

**UI Enhancements:**
- Replaced hardcoded colors with semantic variables (`text-foreground`, `bg-background`, etc.)
- Enhanced navbar with `glassmorphism` effects and backdrop blur
- Fixed visibility issues in customer quote sections

closes: #2982 

this might require changes, but would love to get soem feedbacks in order to ship this @chitalian @devinat1 

https://github.com/user-attachments/assets/3072c0ac-9ea3-45c4-acd7-ab38db639ac5




