### PR TITLE
fix: Enable flyway repair and password to ch_hcone.py for clickhouse

### DIFF
--- a/clickhouse/ch_hcone.py
+++ b/clickhouse/ch_hcone.py
@@ -185,6 +185,9 @@ def main():
         "--list-migrations", action="store_true", help="List applied migrations"
     )
     parser.add_argument(
+        "--password", help="ClickHouse server password"
+    )
+    parser.add_argument(
         "--no-password", action="store_true", help="Do not prompt for password"
     )
     parser.add_argument(
@@ -200,7 +203,8 @@ def main():
     port = 19001 if test_env else 19000
     dynamic_container_name = container_name if not test_env else container_test_name
 
-    password = os.getenv("CLICKHOUSE_PASSWORD")
+    # Use command line password if provided, otherwise use environment variable
+    password = args.password if args.password else os.getenv("CLICKHOUSE_PASSWORD")
 
     if args.user and not password and not args.no_password:
         password = getpass.getpass(

--- a/docker/dockerfiles/dockerfile_migrations
+++ b/docker/dockerfiles/dockerfile_migrations
@@ -34,6 +34,8 @@ RUN chmod +x /app/clickhouse/ch_hcone.py
 # Create a script to run migrations
 RUN echo '#!/bin/sh \n\
     echo "Running PostgreSQL migrations..." \n\
+    echo "Repairing migration checksums..." \n\
+    flyway repair -configFiles=/app/supabase/flyway.conf \n\
     flyway migrate -configFiles=/app/supabase/flyway.conf \n\
     echo "PostgreSQL migrations completed" \n\
     \n\


### PR DESCRIPTION
This pull request introduces enhancements to the ClickHouse password handling in `ch_hcone.py` and updates the migration process in the Dockerfile for improved reliability. The most important changes include adding a command-line option for specifying the ClickHouse password, improving the fallback logic for password retrieval, and adding a repair step to the migration process.

### Enhancements to ClickHouse password handling:
* Added a `--password` command-line argument to allow users to specify the ClickHouse server password directly. (`clickhouse/ch_hcone.py`, [clickhouse/ch_hcone.pyR187-R189](diffhunk://#diff-e51c85794840d19ed7355d816dcb709118e4c24758addff757cfefe01abdf704R187-R189))
* Updated the password retrieval logic to prioritize the command-line argument over the `CLICKHOUSE_PASSWORD` environment variable, ensuring more flexible configuration. (`clickhouse/ch_hcone.py`, [clickhouse/ch_hcone.pyL203-R207](diffhunk://#diff-e51c85794840d19ed7355d816dcb709118e4c24758addff757cfefe01abdf704L203-R207))

### Improvements to migration process:
* Added a `flyway repair` step to the migration script in the Dockerfile to repair migration checksums before running migrations, improving reliability in case of checksum mismatches. (`docker/dockerfiles/dockerfile_migrations`, [docker/dockerfiles/dockerfile_migrationsR37-R38](diffhunk://#diff-eb141d4222a541e8bef3f6649227bd4a5e8b1ed3442decd0befe98a1bb64e768R37-R38))