### PR TITLE
fix: resolve Docker build issues

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -126,9 +126,7 @@ services:
   # =============================================================================
 
   aigateway:
-    build:
-      context: ../aigateway
-      dockerfile: Dockerfile
+    image: helicone/ai-gateway:latest
     restart: unless-stopped
     ports:
       - "5678:5678"

--- a/web/components/templates/requests/RequestDrawer.tsx
+++ b/web/components/templates/requests/RequestDrawer.tsx
@@ -241,7 +241,7 @@ export default function RequestDrawer(props: RequestDivProps) {
             value: request.heliconeMetadata.promptCacheWriteTokens || 0,
           }
         : null,
-    ].filter((item) => item !== null);
+    ].filter((item): item is NonNullable<typeof item> => item !== null);
 
     // Parameter Information (only include defined parameters)
     const parameterInfo = Object.entries(requestParameters)


### PR DESCRIPTION
# Fix Docker Build Issues


## Issues Fixed (#4186)

### Issue 1: TypeScript Compilation Error in Web Build
**Error:**

```
Type error: 'item' is possibly 'null'.
./components/templates/requests/RequestDrawer.tsx:692:28
```


**Reproduction:**
```bash
docker compose build web
# OR
cd web && yarn build
```

**Root Cause:** 
The `tokenInfo` array in `RequestDrawer.tsx` contained conditional items that could be `null`. Even though they were filtered with `.filter((item) => item !== null)`, TypeScript's type system didn't understand that this removes all null values from the array.

**Fix:**
Added a proper type guard to the filter function:
```typescript
// Before
].filter((item) => item !== null);

// After  
].filter((item): item is NonNullable<typeof item> => item !== null);
```

This explicitly tells TypeScript that after filtering, all items are guaranteed to be non-null.

### Issue 2: Missing aigateway Dockerfile (#4185)
**Error:**
```
[+] Building 0.1s (1/1) FINISHED
=> [internal] load local bake definitions
ERROR: failed to solve: failed to read dockerfile: open /context/Dockerfile: no such file or directory
```


**Reproduction:**
```bash
docker compose build aigateway
```

**Root Cause:**
The `docker-compose.yml` was configured to build aigateway from source using a local Dockerfile, but the aigateway service was migrated to use a pre-built Docker Hub image (as per [PR #4113](https://github.com/Helicone/helicone/pull/4113)).

**Fix:**
Updated the aigateway service configuration in `docker-compose.yml`:
```yaml
# Before
aigateway:
  build:
    context: ../aigateway
    dockerfile: Dockerfile
  # ... rest of config

# After
aigateway:
  image: helicone/ai-gateway:latest
  # ... rest of config
```

## Verification

Both fixes have been tested and verified:

1. **Web build**: Successfully completes TypeScript compilation and Docker build
2. **aigateway service**: Successfully pulls and configures the Docker Hub image
3. **Full docker-compose**: All services build and start correctly

## 🔍 Files Changed

- `web/components/templates/requests/RequestDrawer.tsx` - Added type guard for null filtering
- `docker/docker-compose.yml` - Updated aigateway to use Docker Hub image

## Testing

```bash
# Test individual services
docker compose build web
docker compose build aigateway

# Test full stack
docker compose build --parallel
```

All builds now complete successfully without errors.


