### PR TITLE
feat: [ENG-2229] Observability and playground for prompt requests

### DIFF
--- a/bifrost/lib/clients/jawnTypes/private.ts
+++ b/bifrost/lib/clients/jawnTypes/private.ts
@@ -171,6 +171,9 @@ export interface paths {
   "/v1/prompt-2025/{promptId}/{versionId}": {
     delete: operations["DeletePrompt2025Version"];
   };
+  "/v1/prompt-2025/id/{promptId}/{versionId}/inputs": {
+    get: operations["GetPrompt2025Inputs"];
+  };
   "/v1/prompt-2025/tags": {
     get: operations["GetPrompt2025Tags"];
   };
@@ -993,6 +996,17 @@ Json: JsonObject;
       error: null;
     };
     "Result_Prompt2025.string_": components["schemas"]["ResultSuccess_Prompt2025_"] | components["schemas"]["ResultError_string_"];
+    Prompt2025Input: {
+      request_id: string;
+      version_id: string;
+      inputs: components["schemas"]["Record_string.any_"];
+    };
+    "ResultSuccess_Prompt2025Input-Array_": {
+      data: components["schemas"]["Prompt2025Input"][];
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result_Prompt2025Input-Array.string_": components["schemas"]["ResultSuccess_Prompt2025Input-Array_"] | components["schemas"]["ResultError_string_"];
     "ResultSuccess_string-Array_": {
       data: string[];
       /** @enum {number|null} */
@@ -16417,6 +16431,22 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["Result_null.string_"];
+        };
+      };
+    };
+  };
+  GetPrompt2025Inputs: {
+    parameters: {
+      path: {
+        promptId: string;
+        versionId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_Prompt2025Input-Array.string_"];
         };
       };
     };

--- a/bifrost/lib/clients/jawnTypes/private.ts
+++ b/bifrost/lib/clients/jawnTypes/private.ts
@@ -1567,6 +1567,7 @@ Json: JsonObject;
       /** Format: double */
       cost: number | null;
       prompt_id: string | null;
+      prompt_version: string | null;
       feedback_created_at?: string | null;
       feedback_id?: string | null;
       feedback_rating?: boolean | null;

--- a/bifrost/lib/clients/jawnTypes/private.ts
+++ b/bifrost/lib/clients/jawnTypes/private.ts
@@ -1001,12 +1001,12 @@ Json: JsonObject;
       version_id: string;
       inputs: components["schemas"]["Record_string.any_"];
     };
-    "ResultSuccess_Prompt2025Input-Array_": {
-      data: components["schemas"]["Prompt2025Input"][];
+    ResultSuccess_Prompt2025Input_: {
+      data: components["schemas"]["Prompt2025Input"];
       /** @enum {number|null} */
       error: null;
     };
-    "Result_Prompt2025Input-Array.string_": components["schemas"]["ResultSuccess_Prompt2025Input-Array_"] | components["schemas"]["ResultError_string_"];
+    "Result_Prompt2025Input.string_": components["schemas"]["ResultSuccess_Prompt2025Input_"] | components["schemas"]["ResultError_string_"];
     "ResultSuccess_string-Array_": {
       data: string[];
       /** @enum {number|null} */
@@ -16438,6 +16438,9 @@ export interface operations {
   };
   GetPrompt2025Inputs: {
     parameters: {
+      query: {
+        requestId: string;
+      };
       path: {
         promptId: string;
         versionId: string;
@@ -16447,7 +16450,7 @@ export interface operations {
       /** @description Ok */
       200: {
         content: {
-          "application/json": components["schemas"]["Result_Prompt2025Input-Array.string_"];
+          "application/json": components["schemas"]["Result_Prompt2025Input.string_"];
         };
       };
     };

--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -85,6 +85,9 @@ export interface paths {
   "/v1/prompt-2025/{promptId}/{versionId}": {
     delete: operations["DeletePrompt2025Version"];
   };
+  "/v1/prompt-2025/id/{promptId}/{versionId}/inputs": {
+    get: operations["GetPrompt2025Inputs"];
+  };
   "/v1/prompt-2025/tags": {
     get: operations["GetPrompt2025Tags"];
   };
@@ -1100,6 +1103,17 @@ export interface components {
       error: null;
     };
     "Result_Prompt2025.string_": components["schemas"]["ResultSuccess_Prompt2025_"] | components["schemas"]["ResultError_string_"];
+    Prompt2025Input: {
+      request_id: string;
+      version_id: string;
+      inputs: components["schemas"]["Record_string.any_"];
+    };
+    "ResultSuccess_Prompt2025Input-Array_": {
+      data: components["schemas"]["Prompt2025Input"][];
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result_Prompt2025Input-Array.string_": components["schemas"]["ResultSuccess_Prompt2025Input-Array_"] | components["schemas"]["ResultError_string_"];
     "ResultSuccess_string-Array_": {
       data: string[];
       /** @enum {number|null} */
@@ -3912,6 +3926,22 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["Result_null.string_"];
+        };
+      };
+    };
+  };
+  GetPrompt2025Inputs: {
+    parameters: {
+      path: {
+        promptId: string;
+        versionId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_Prompt2025Input-Array.string_"];
         };
       };
     };

--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -1579,6 +1579,7 @@ export interface components {
       /** Format: double */
       cost: number | null;
       prompt_id: string | null;
+      prompt_version: string | null;
       feedback_created_at?: string | null;
       feedback_id?: string | null;
       feedback_rating?: boolean | null;

--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -1108,12 +1108,12 @@ export interface components {
       version_id: string;
       inputs: components["schemas"]["Record_string.any_"];
     };
-    "ResultSuccess_Prompt2025Input-Array_": {
-      data: components["schemas"]["Prompt2025Input"][];
+    ResultSuccess_Prompt2025Input_: {
+      data: components["schemas"]["Prompt2025Input"];
       /** @enum {number|null} */
       error: null;
     };
-    "Result_Prompt2025Input-Array.string_": components["schemas"]["ResultSuccess_Prompt2025Input-Array_"] | components["schemas"]["ResultError_string_"];
+    "Result_Prompt2025Input.string_": components["schemas"]["ResultSuccess_Prompt2025Input_"] | components["schemas"]["ResultError_string_"];
     "ResultSuccess_string-Array_": {
       data: string[];
       /** @enum {number|null} */
@@ -3933,6 +3933,9 @@ export interface operations {
   };
   GetPrompt2025Inputs: {
     parameters: {
+      query: {
+        requestId: string;
+      };
       path: {
         promptId: string;
         versionId: string;
@@ -3942,7 +3945,7 @@ export interface operations {
       /** @description Ok */
       200: {
         content: {
-          "application/json": components["schemas"]["Result_Prompt2025Input-Array.string_"];
+          "application/json": components["schemas"]["Result_Prompt2025Input.string_"];
         };
       };
     };

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1799,13 +1799,10 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"ResultSuccess_Prompt2025Input-Array_": {
+			"ResultSuccess_Prompt2025Input_": {
 				"properties": {
 					"data": {
-						"items": {
-							"$ref": "#/components/schemas/Prompt2025Input"
-						},
-						"type": "array"
+						"$ref": "#/components/schemas/Prompt2025Input"
 					},
 					"error": {
 						"type": "number",
@@ -1822,10 +1819,10 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"Result_Prompt2025Input-Array.string_": {
+			"Result_Prompt2025Input.string_": {
 				"anyOf": [
 					{
-						"$ref": "#/components/schemas/ResultSuccess_Prompt2025Input-Array_"
+						"$ref": "#/components/schemas/ResultSuccess_Prompt2025Input_"
 					},
 					{
 						"$ref": "#/components/schemas/ResultError_string_"
@@ -11816,7 +11813,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Result_Prompt2025Input-Array.string_"
+									"$ref": "#/components/schemas/Result_Prompt2025Input.string_"
 								}
 							}
 						}
@@ -11842,6 +11839,14 @@
 					{
 						"in": "path",
 						"name": "versionId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "requestId",
 						"required": true,
 						"schema": {
 							"type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1779,6 +1779,59 @@
 					}
 				]
 			},
+			"Prompt2025Input": {
+				"properties": {
+					"request_id": {
+						"type": "string"
+					},
+					"version_id": {
+						"type": "string"
+					},
+					"inputs": {
+						"$ref": "#/components/schemas/Record_string.any_"
+					}
+				},
+				"required": [
+					"request_id",
+					"version_id",
+					"inputs"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ResultSuccess_Prompt2025Input-Array_": {
+				"properties": {
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/Prompt2025Input"
+						},
+						"type": "array"
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result_Prompt2025Input-Array.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_Prompt2025Input-Array_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
 			"ResultSuccess_string-Array_": {
 				"properties": {
 					"data": {
@@ -11716,6 +11769,49 @@
 							"application/json": {
 								"schema": {
 									"$ref": "#/components/schemas/Result_null.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Prompt2025"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "promptId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "versionId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/v1/prompt-2025/id/{promptId}/{versionId}/inputs": {
+			"get": {
+				"operationId": "GetPrompt2025Inputs",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result_Prompt2025Input-Array.string_"
 								}
 							}
 						}

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3544,6 +3544,10 @@
 						"type": "string",
 						"nullable": true
 					},
+					"prompt_version": {
+						"type": "string",
+						"nullable": true
+					},
 					"feedback_created_at": {
 						"type": "string",
 						"nullable": true
@@ -3660,6 +3664,7 @@
 					"completion_audio_tokens",
 					"cost",
 					"prompt_id",
+					"prompt_version",
 					"llmSchema",
 					"country_code",
 					"asset_ids",

--- a/packages/llm-mapper/types.ts
+++ b/packages/llm-mapper/types.ts
@@ -240,6 +240,8 @@ type HeliconeMetadata = {
   scores?: Record<string, { value: number; valueType: string } | number> | null;
   gatewayRouterId?: string | null;
   gatewayDeploymentTarget?: string | null;
+  promptId?: string | null;
+  promptVersion?: string | null;
 };
 
 // UNORGANZIED
@@ -333,6 +335,7 @@ export interface HeliconeRequest {
   completion_audio_tokens: number | null;
   cost: number | null;
   prompt_id: string | null;
+  prompt_version: string | null;
   feedback_created_at?: string | null;
   feedback_id?: string | null;
   feedback_rating?: boolean | null;

--- a/packages/llm-mapper/utils/getMappedContent.ts
+++ b/packages/llm-mapper/utils/getMappedContent.ts
@@ -93,6 +93,8 @@ const metaDataFromHeliconeRequest = (
     scores: heliconeRequest.scores,
     gatewayRouterId: heliconeRequest.gateway_router_id,
     gatewayDeploymentTarget: heliconeRequest.gateway_deployment_target,
+    promptId: heliconeRequest.prompt_id ?? null,
+    promptVersion: heliconeRequest.prompt_version ?? null,
   };
 };
 

--- a/packages/prompts/types.ts
+++ b/packages/prompts/types.ts
@@ -39,3 +39,9 @@ export interface Prompt2025 {
   tags: string[];
   created_at: string;
 }
+
+export interface Prompt2025Input {
+  request_id: string;
+  version_id: string;
+  inputs: Record<string, any>;
+}

--- a/valhalla/jawn/src/controllers/public/prompt2025Controller.ts
+++ b/valhalla/jawn/src/controllers/public/prompt2025Controller.ts
@@ -16,7 +16,7 @@ import { Result } from "../../packages/common/result";
 import { Prompt2025Manager } from "../../managers/prompt/PromptManager";
 import type { JawnAuthenticatedRequest } from "../../types/request";
 import { type OpenAIChatRequest } from "@helicone-package/llm-mapper/mappers/openai/chat-v2";
-import { Prompt2025Version, Prompt2025 } from "@helicone-package/prompts/types";
+import { Prompt2025Version, Prompt2025, Prompt2025Input } from "@helicone-package/prompts/types";
 
 export interface PromptCreateResponse {
   id: string;
@@ -92,6 +92,22 @@ export class Prompt2025Controller extends Controller {
     const promptManager = new Prompt2025Manager(request.authParams);
     const result = await promptManager.deletePromptVersion({ promptId, promptVersionId: versionId });
     if (result.error) {
+      this.setStatus(500);
+    } else {
+      this.setStatus(200);
+    }
+    return result;
+  }
+
+  @Get("id/{promptId}/{versionId}/inputs")
+  public async getPrompt2025Inputs(
+    @Path() promptId: string,
+    @Path() versionId: string,
+    @Request() request: JawnAuthenticatedRequest,
+  ): Promise<Result<Prompt2025Input[], string>> {
+    const promptManager = new Prompt2025Manager(request.authParams);
+    const result = await promptManager.getPromptInputs({ promptId, versionId });
+    if (result.error || !result.data) {
       this.setStatus(500);
     } else {
       this.setStatus(200);

--- a/valhalla/jawn/src/controllers/public/prompt2025Controller.ts
+++ b/valhalla/jawn/src/controllers/public/prompt2025Controller.ts
@@ -7,6 +7,7 @@ import {
   Patch,
   Path,
   Post,
+  Query,
   Request,
   Route,
   Security,
@@ -103,16 +104,21 @@ export class Prompt2025Controller extends Controller {
   public async getPrompt2025Inputs(
     @Path() promptId: string,
     @Path() versionId: string,
+    @Query() requestId: string,
     @Request() request: JawnAuthenticatedRequest,
-  ): Promise<Result<Prompt2025Input[], string>> {
+  ): Promise<Result<Prompt2025Input, string>> {
     const promptManager = new Prompt2025Manager(request.authParams);
-    const result = await promptManager.getPromptInputs({ promptId, versionId });
-    if (result.error || !result.data) {
+    const result = await promptManager.getPromptInputs({ promptId, versionId, requestId });
+    if (result.error) {
       this.setStatus(500);
-    } else {
-      this.setStatus(200);
+      return result;
     }
-    return result;
+    if (!result.data) {
+      this.setStatus(404);
+      return { error: "Prompt inputs not found", data: null };
+    }
+    this.setStatus(200);
+    return { error: null, data: result.data };
   }
 
   @Get("tags")

--- a/valhalla/jawn/src/lib/handlers/HandlerContext.ts
+++ b/valhalla/jawn/src/lib/handlers/HandlerContext.ts
@@ -193,7 +193,14 @@ export const toHeliconeRequest = (context: HandlerContext): HeliconeRequest => {
       ? 0
       : (context.usage.completionAudioTokens ?? null),
 
-    prompt_id: context.message.log.request.promptId ?? null,
+    /// NOTE: Unfortunately our codebase is running two prompts systems in parallel.
+    // This used to track the legacy feature, but its now the new one.
+    // It does not matter: 
+    // - this function is used to pull request and response bodies (no overlap with prompt IDs)
+    // - evals, which is deprecated and does not seem to access this field.
+    // When the legacy prompts and evals is deprecated, we should strongly consider refactoring and/or deleting this function. 
+    prompt_id: context.message.heliconeMeta.promptId ?? null, // TRACKS LEGACY PROMPTS ID
+    prompt_version: context.message.heliconeMeta.promptVersionId ?? null, // TRACKS LEGACY PROMPT VERSION ID
     llmSchema: null,
     country_code: context.message.log.request.countryCode ?? null,
     asset_ids: null,

--- a/valhalla/jawn/src/lib/stores/request/request.ts
+++ b/valhalla/jawn/src/lib/stores/request/request.ts
@@ -196,6 +196,8 @@ export async function getRequestsClickhouseNoSort(
       gateway_router_id,
       gateway_deployment_target,
       cost / ${COST_PRECISION_MULTIPLIER} as cost,
+      prompt_id,
+      prompt_version,
       updated_at
     FROM request_response_rmt
     WHERE (
@@ -275,6 +277,8 @@ export async function getRequestsClickhouse(
       gateway_router_id,
       gateway_deployment_target,
       cost / ${COST_PRECISION_MULTIPLIER} as cost,
+      prompt_id,
+      prompt_version,
       updated_at
     FROM request_response_rmt
     WHERE (

--- a/valhalla/jawn/src/managers/evaluator/EvaluatorManager.ts
+++ b/valhalla/jawn/src/managers/evaluator/EvaluatorManager.ts
@@ -262,6 +262,7 @@ export class EvaluatorManager extends BaseManager {
           prompt_cache_read_tokens: null,
           completion_tokens: null,
           prompt_id: null,
+          prompt_version: null, // SEE NOTE IN jawn/.../HandlerContext.ts
           llmSchema: null,
           country_code: null,
           asset_ids: null,
@@ -276,6 +277,7 @@ export class EvaluatorManager extends BaseManager {
           completion_audio_tokens: null,
           cache_enabled: false,
           cache_reference_id: null,
+          cost: null,
         },
       });
       if (scoreResult.error) {

--- a/valhalla/jawn/src/managers/prompt/PromptManager.ts
+++ b/valhalla/jawn/src/managers/prompt/PromptManager.ts
@@ -177,7 +177,8 @@ export class Prompt2025Manager extends BaseManager {
   async getPromptInputs(params: {
     promptId: string;
     versionId: string;
-  }): Promise<Result<Prompt2025Input[], string>> {
+    requestId: string;
+  }): Promise<Result<Prompt2025Input | null, string>> {
     const existsResult = await dbExecute<{exists: boolean}>(
       `SELECT EXISTS (
         SELECT 1 FROM prompts_2025_versions 
@@ -200,15 +201,17 @@ export class Prompt2025Manager extends BaseManager {
         version_id,
         inputs
       FROM prompts_2025_inputs
-      WHERE version_id = $1`,
-      [params.versionId]
+      WHERE version_id = $1 AND request_id = $2
+      LIMIT 1
+      `,
+      [params.versionId, params.requestId]
     );
 
     if (result.error) {
       return err(result.error);
     }
 
-    return ok(result.data ?? []);
+    return ok(result.data?.[0] ?? null);
   }
 
 

--- a/valhalla/jawn/src/tsoa-build/private/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/private/routes.ts
@@ -629,18 +629,18 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResultSuccess_Prompt2025Input-Array_": {
+    "ResultSuccess_Prompt2025Input_": {
         "dataType": "refObject",
         "properties": {
-            "data": {"dataType":"array","array":{"dataType":"refObject","ref":"Prompt2025Input"},"required":true},
+            "data": {"ref":"Prompt2025Input","required":true},
             "error": {"dataType":"enum","enums":[null],"required":true},
         },
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Result_Prompt2025Input-Array.string_": {
+    "Result_Prompt2025Input.string_": {
         "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_Prompt2025Input-Array_"},{"ref":"ResultError_string_"}],"validators":{}},
+        "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_Prompt2025Input_"},{"ref":"ResultError_string_"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ResultSuccess_string-Array_": {
@@ -15935,6 +15935,7 @@ export function RegisterRoutes(app: Router) {
         const argsPrompt2025Controller_getPrompt2025Inputs: Record<string, TsoaRoute.ParameterSchema> = {
                 promptId: {"in":"path","name":"promptId","required":true,"dataType":"string"},
                 versionId: {"in":"path","name":"versionId","required":true,"dataType":"string"},
+                requestId: {"in":"query","name":"requestId","required":true,"dataType":"string"},
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
         app.get('/v1/prompt-2025/id/:promptId/:versionId/inputs',

--- a/valhalla/jawn/src/tsoa-build/private/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/private/routes.ts
@@ -1092,6 +1092,7 @@ const models: TsoaRoute.Models = {
             "completion_audio_tokens": {"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},
             "cost": {"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},
             "prompt_id": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
+            "prompt_version": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
             "feedback_created_at": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}]},
             "feedback_id": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}]},
             "feedback_rating": {"dataType":"union","subSchemas":[{"dataType":"boolean"},{"dataType":"enum","enums":[null]}]},

--- a/valhalla/jawn/src/tsoa-build/private/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/private/routes.ts
@@ -619,6 +619,30 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_Prompt2025_"},{"ref":"ResultError_string_"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Prompt2025Input": {
+        "dataType": "refObject",
+        "properties": {
+            "request_id": {"dataType":"string","required":true},
+            "version_id": {"dataType":"string","required":true},
+            "inputs": {"ref":"Record_string.any_","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ResultSuccess_Prompt2025Input-Array_": {
+        "dataType": "refObject",
+        "properties": {
+            "data": {"dataType":"array","array":{"dataType":"refObject","ref":"Prompt2025Input"},"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Result_Prompt2025Input-Array.string_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_Prompt2025Input-Array_"},{"ref":"ResultError_string_"}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ResultSuccess_string-Array_": {
         "dataType": "refObject",
         "properties": {
@@ -15896,6 +15920,39 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'deletePrompt2025Version',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsPrompt2025Controller_getPrompt2025Inputs: Record<string, TsoaRoute.ParameterSchema> = {
+                promptId: {"in":"path","name":"promptId","required":true,"dataType":"string"},
+                versionId: {"in":"path","name":"versionId","required":true,"dataType":"string"},
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+        };
+        app.get('/v1/prompt-2025/id/:promptId/:versionId/inputs',
+            authenticateMiddleware([{"api_key":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller)),
+            ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller.prototype.getPrompt2025Inputs)),
+
+            async function Prompt2025Controller_getPrompt2025Inputs(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsPrompt2025Controller_getPrompt2025Inputs, request, response });
+
+                const controller = new Prompt2025Controller();
+
+              await templateService.apiHandler({
+                methodName: 'getPrompt2025Inputs',
                 controller,
                 response,
                 next,

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -2157,13 +2157,10 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"ResultSuccess_Prompt2025Input-Array_": {
+			"ResultSuccess_Prompt2025Input_": {
 				"properties": {
 					"data": {
-						"items": {
-							"$ref": "#/components/schemas/Prompt2025Input"
-						},
-						"type": "array"
+						"$ref": "#/components/schemas/Prompt2025Input"
 					},
 					"error": {
 						"type": "number",
@@ -2180,10 +2177,10 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"Result_Prompt2025Input-Array.string_": {
+			"Result_Prompt2025Input.string_": {
 				"anyOf": [
 					{
-						"$ref": "#/components/schemas/ResultSuccess_Prompt2025Input-Array_"
+						"$ref": "#/components/schemas/ResultSuccess_Prompt2025Input_"
 					},
 					{
 						"$ref": "#/components/schemas/ResultError_string_"
@@ -48635,7 +48632,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Result_Prompt2025Input-Array.string_"
+									"$ref": "#/components/schemas/Result_Prompt2025Input.string_"
 								}
 							}
 						}
@@ -48661,6 +48658,14 @@
 					{
 						"in": "path",
 						"name": "versionId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "requestId",
 						"required": true,
 						"schema": {
 							"type": "string"

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -2137,6 +2137,59 @@
 					}
 				]
 			},
+			"Prompt2025Input": {
+				"properties": {
+					"request_id": {
+						"type": "string"
+					},
+					"version_id": {
+						"type": "string"
+					},
+					"inputs": {
+						"$ref": "#/components/schemas/Record_string.any_"
+					}
+				},
+				"required": [
+					"request_id",
+					"version_id",
+					"inputs"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ResultSuccess_Prompt2025Input-Array_": {
+				"properties": {
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/Prompt2025Input"
+						},
+						"type": "array"
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result_Prompt2025Input-Array.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_Prompt2025Input-Array_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
 			"ResultSuccess_string-Array_": {
 				"properties": {
 					"data": {
@@ -48535,6 +48588,49 @@
 							"application/json": {
 								"schema": {
 									"$ref": "#/components/schemas/Result_null.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Prompt2025"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "promptId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "versionId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/v1/prompt-2025/id/{promptId}/{versionId}/inputs": {
+			"get": {
+				"operationId": "GetPrompt2025Inputs",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result_Prompt2025Input-Array.string_"
 								}
 							}
 						}

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -4156,6 +4156,10 @@
 						"type": "string",
 						"nullable": true
 					},
+					"prompt_version": {
+						"type": "string",
+						"nullable": true
+					},
 					"feedback_created_at": {
 						"type": "string",
 						"nullable": true
@@ -4272,6 +4276,7 @@
 					"completion_audio_tokens",
 					"cost",
 					"prompt_id",
+					"prompt_version",
 					"llmSchema",
 					"country_code",
 					"asset_ids",

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -629,18 +629,18 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResultSuccess_Prompt2025Input-Array_": {
+    "ResultSuccess_Prompt2025Input_": {
         "dataType": "refObject",
         "properties": {
-            "data": {"dataType":"array","array":{"dataType":"refObject","ref":"Prompt2025Input"},"required":true},
+            "data": {"ref":"Prompt2025Input","required":true},
             "error": {"dataType":"enum","enums":[null],"required":true},
         },
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Result_Prompt2025Input-Array.string_": {
+    "Result_Prompt2025Input.string_": {
         "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_Prompt2025Input-Array_"},{"ref":"ResultError_string_"}],"validators":{}},
+        "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_Prompt2025Input_"},{"ref":"ResultError_string_"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ResultSuccess_string-Array_": {
@@ -4401,6 +4401,7 @@ export function RegisterRoutes(app: Router) {
         const argsPrompt2025Controller_getPrompt2025Inputs: Record<string, TsoaRoute.ParameterSchema> = {
                 promptId: {"in":"path","name":"promptId","required":true,"dataType":"string"},
                 versionId: {"in":"path","name":"versionId","required":true,"dataType":"string"},
+                requestId: {"in":"query","name":"requestId","required":true,"dataType":"string"},
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
         app.get('/v1/prompt-2025/id/:promptId/:versionId/inputs',

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -1043,6 +1043,7 @@ const models: TsoaRoute.Models = {
             "completion_audio_tokens": {"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},
             "cost": {"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true},
             "prompt_id": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
+            "prompt_version": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
             "feedback_created_at": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}]},
             "feedback_id": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}]},
             "feedback_rating": {"dataType":"union","subSchemas":[{"dataType":"boolean"},{"dataType":"enum","enums":[null]}]},

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -619,6 +619,30 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_Prompt2025_"},{"ref":"ResultError_string_"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Prompt2025Input": {
+        "dataType": "refObject",
+        "properties": {
+            "request_id": {"dataType":"string","required":true},
+            "version_id": {"dataType":"string","required":true},
+            "inputs": {"ref":"Record_string.any_","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ResultSuccess_Prompt2025Input-Array_": {
+        "dataType": "refObject",
+        "properties": {
+            "data": {"dataType":"array","array":{"dataType":"refObject","ref":"Prompt2025Input"},"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Result_Prompt2025Input-Array.string_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_Prompt2025Input-Array_"},{"ref":"ResultError_string_"}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ResultSuccess_string-Array_": {
         "dataType": "refObject",
         "properties": {
@@ -4362,6 +4386,39 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'deletePrompt2025Version',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsPrompt2025Controller_getPrompt2025Inputs: Record<string, TsoaRoute.ParameterSchema> = {
+                promptId: {"in":"path","name":"promptId","required":true,"dataType":"string"},
+                versionId: {"in":"path","name":"versionId","required":true,"dataType":"string"},
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+        };
+        app.get('/v1/prompt-2025/id/:promptId/:versionId/inputs',
+            authenticateMiddleware([{"api_key":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller)),
+            ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller.prototype.getPrompt2025Inputs)),
+
+            async function Prompt2025Controller_getPrompt2025Inputs(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsPrompt2025Controller_getPrompt2025Inputs, request, response });
+
+                const controller = new Prompt2025Controller();
+
+              await templateService.apiHandler({
+                methodName: 'getPrompt2025Inputs',
                 controller,
                 response,
                 next,

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -1799,13 +1799,10 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"ResultSuccess_Prompt2025Input-Array_": {
+			"ResultSuccess_Prompt2025Input_": {
 				"properties": {
 					"data": {
-						"items": {
-							"$ref": "#/components/schemas/Prompt2025Input"
-						},
-						"type": "array"
+						"$ref": "#/components/schemas/Prompt2025Input"
 					},
 					"error": {
 						"type": "number",
@@ -1822,10 +1819,10 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"Result_Prompt2025Input-Array.string_": {
+			"Result_Prompt2025Input.string_": {
 				"anyOf": [
 					{
-						"$ref": "#/components/schemas/ResultSuccess_Prompt2025Input-Array_"
+						"$ref": "#/components/schemas/ResultSuccess_Prompt2025Input_"
 					},
 					{
 						"$ref": "#/components/schemas/ResultError_string_"
@@ -11816,7 +11813,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Result_Prompt2025Input-Array.string_"
+									"$ref": "#/components/schemas/Result_Prompt2025Input.string_"
 								}
 							}
 						}
@@ -11842,6 +11839,14 @@
 					{
 						"in": "path",
 						"name": "versionId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "requestId",
 						"required": true,
 						"schema": {
 							"type": "string"

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -1779,6 +1779,59 @@
 					}
 				]
 			},
+			"Prompt2025Input": {
+				"properties": {
+					"request_id": {
+						"type": "string"
+					},
+					"version_id": {
+						"type": "string"
+					},
+					"inputs": {
+						"$ref": "#/components/schemas/Record_string.any_"
+					}
+				},
+				"required": [
+					"request_id",
+					"version_id",
+					"inputs"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ResultSuccess_Prompt2025Input-Array_": {
+				"properties": {
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/Prompt2025Input"
+						},
+						"type": "array"
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result_Prompt2025Input-Array.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_Prompt2025Input-Array_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
 			"ResultSuccess_string-Array_": {
 				"properties": {
 					"data": {
@@ -11716,6 +11769,49 @@
 							"application/json": {
 								"schema": {
 									"$ref": "#/components/schemas/Result_null.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Prompt2025"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "promptId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "versionId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/v1/prompt-2025/id/{promptId}/{versionId}/inputs": {
+			"get": {
+				"operationId": "GetPrompt2025Inputs",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result_Prompt2025Input-Array.string_"
 								}
 							}
 						}

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -3544,6 +3544,10 @@
 						"type": "string",
 						"nullable": true
 					},
+					"prompt_version": {
+						"type": "string",
+						"nullable": true
+					},
 					"feedback_created_at": {
 						"type": "string",
 						"nullable": true
@@ -3660,6 +3664,7 @@
 					"completion_audio_tokens",
 					"cost",
 					"prompt_id",
+					"prompt_version",
 					"llmSchema",
 					"country_code",
 					"asset_ids",

--- a/web/components/templates/playground/playgroundPage.tsx
+++ b/web/components/templates/playground/playgroundPage.tsx
@@ -33,6 +33,7 @@ import {
   useCreatePrompt,
   usePushPromptVersion,
   useGetPromptVersionWithBody,
+  useGetPromptInputs,
 } from "@/services/hooks/prompts";
 import LoadingAnimation from "@/components/shared/loadingAnimation";
 import { useOrg } from "@/components/layout/org/organizationContext";
@@ -225,8 +226,23 @@ const PlaygroundPage = (props: PlaygroundPageProps) => {
   const { data: requestData, isLoading: isRequestLoading } =
     useGetRequestWithBodies(requestId ?? "");
 
+  const requestPromptId = useMemo(
+    () => requestData?.data?.prompt_id ?? null,
+    [requestData?.data?.prompt_id],
+  );
+  const requestPromptVersionId = useMemo(
+    () => requestData?.data?.prompt_version ?? null,
+    [requestData?.data?.prompt_version],
+  );
+
   const { data: promptVersionData, isLoading: isPromptVersionLoading } =
-    useGetPromptVersionWithBody(promptVersionId);
+    useGetPromptVersionWithBody(promptVersionId || requestPromptVersionId || undefined);
+
+  const promptInputsQuery = useGetPromptInputs(
+    requestPromptId || "",
+    requestPromptVersionId || "",
+    requestId || ""
+  );
 
   const [selectedModel, setSelectedModel] = useState<string>(
     "openai/gpt-4.1-mini",

--- a/web/lib/clients/jawnTypes/private.ts
+++ b/web/lib/clients/jawnTypes/private.ts
@@ -171,6 +171,9 @@ export interface paths {
   "/v1/prompt-2025/{promptId}/{versionId}": {
     delete: operations["DeletePrompt2025Version"];
   };
+  "/v1/prompt-2025/id/{promptId}/{versionId}/inputs": {
+    get: operations["GetPrompt2025Inputs"];
+  };
   "/v1/prompt-2025/tags": {
     get: operations["GetPrompt2025Tags"];
   };
@@ -993,6 +996,17 @@ Json: JsonObject;
       error: null;
     };
     "Result_Prompt2025.string_": components["schemas"]["ResultSuccess_Prompt2025_"] | components["schemas"]["ResultError_string_"];
+    Prompt2025Input: {
+      request_id: string;
+      version_id: string;
+      inputs: components["schemas"]["Record_string.any_"];
+    };
+    "ResultSuccess_Prompt2025Input-Array_": {
+      data: components["schemas"]["Prompt2025Input"][];
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result_Prompt2025Input-Array.string_": components["schemas"]["ResultSuccess_Prompt2025Input-Array_"] | components["schemas"]["ResultError_string_"];
     "ResultSuccess_string-Array_": {
       data: string[];
       /** @enum {number|null} */
@@ -16417,6 +16431,22 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["Result_null.string_"];
+        };
+      };
+    };
+  };
+  GetPrompt2025Inputs: {
+    parameters: {
+      path: {
+        promptId: string;
+        versionId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_Prompt2025Input-Array.string_"];
         };
       };
     };

--- a/web/lib/clients/jawnTypes/private.ts
+++ b/web/lib/clients/jawnTypes/private.ts
@@ -1567,6 +1567,7 @@ Json: JsonObject;
       /** Format: double */
       cost: number | null;
       prompt_id: string | null;
+      prompt_version: string | null;
       feedback_created_at?: string | null;
       feedback_id?: string | null;
       feedback_rating?: boolean | null;

--- a/web/lib/clients/jawnTypes/private.ts
+++ b/web/lib/clients/jawnTypes/private.ts
@@ -1001,12 +1001,12 @@ Json: JsonObject;
       version_id: string;
       inputs: components["schemas"]["Record_string.any_"];
     };
-    "ResultSuccess_Prompt2025Input-Array_": {
-      data: components["schemas"]["Prompt2025Input"][];
+    ResultSuccess_Prompt2025Input_: {
+      data: components["schemas"]["Prompt2025Input"];
       /** @enum {number|null} */
       error: null;
     };
-    "Result_Prompt2025Input-Array.string_": components["schemas"]["ResultSuccess_Prompt2025Input-Array_"] | components["schemas"]["ResultError_string_"];
+    "Result_Prompt2025Input.string_": components["schemas"]["ResultSuccess_Prompt2025Input_"] | components["schemas"]["ResultError_string_"];
     "ResultSuccess_string-Array_": {
       data: string[];
       /** @enum {number|null} */
@@ -16438,6 +16438,9 @@ export interface operations {
   };
   GetPrompt2025Inputs: {
     parameters: {
+      query: {
+        requestId: string;
+      };
       path: {
         promptId: string;
         versionId: string;
@@ -16447,7 +16450,7 @@ export interface operations {
       /** @description Ok */
       200: {
         content: {
-          "application/json": components["schemas"]["Result_Prompt2025Input-Array.string_"];
+          "application/json": components["schemas"]["Result_Prompt2025Input.string_"];
         };
       };
     };

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -85,6 +85,9 @@ export interface paths {
   "/v1/prompt-2025/{promptId}/{versionId}": {
     delete: operations["DeletePrompt2025Version"];
   };
+  "/v1/prompt-2025/id/{promptId}/{versionId}/inputs": {
+    get: operations["GetPrompt2025Inputs"];
+  };
   "/v1/prompt-2025/tags": {
     get: operations["GetPrompt2025Tags"];
   };
@@ -1100,6 +1103,17 @@ export interface components {
       error: null;
     };
     "Result_Prompt2025.string_": components["schemas"]["ResultSuccess_Prompt2025_"] | components["schemas"]["ResultError_string_"];
+    Prompt2025Input: {
+      request_id: string;
+      version_id: string;
+      inputs: components["schemas"]["Record_string.any_"];
+    };
+    "ResultSuccess_Prompt2025Input-Array_": {
+      data: components["schemas"]["Prompt2025Input"][];
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result_Prompt2025Input-Array.string_": components["schemas"]["ResultSuccess_Prompt2025Input-Array_"] | components["schemas"]["ResultError_string_"];
     "ResultSuccess_string-Array_": {
       data: string[];
       /** @enum {number|null} */
@@ -3912,6 +3926,22 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["Result_null.string_"];
+        };
+      };
+    };
+  };
+  GetPrompt2025Inputs: {
+    parameters: {
+      path: {
+        promptId: string;
+        versionId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_Prompt2025Input-Array.string_"];
         };
       };
     };

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -1579,6 +1579,7 @@ export interface components {
       /** Format: double */
       cost: number | null;
       prompt_id: string | null;
+      prompt_version: string | null;
       feedback_created_at?: string | null;
       feedback_id?: string | null;
       feedback_rating?: boolean | null;

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -1108,12 +1108,12 @@ export interface components {
       version_id: string;
       inputs: components["schemas"]["Record_string.any_"];
     };
-    "ResultSuccess_Prompt2025Input-Array_": {
-      data: components["schemas"]["Prompt2025Input"][];
+    ResultSuccess_Prompt2025Input_: {
+      data: components["schemas"]["Prompt2025Input"];
       /** @enum {number|null} */
       error: null;
     };
-    "Result_Prompt2025Input-Array.string_": components["schemas"]["ResultSuccess_Prompt2025Input-Array_"] | components["schemas"]["ResultError_string_"];
+    "Result_Prompt2025Input.string_": components["schemas"]["ResultSuccess_Prompt2025Input_"] | components["schemas"]["ResultError_string_"];
     "ResultSuccess_string-Array_": {
       data: string[];
       /** @enum {number|null} */
@@ -3933,6 +3933,9 @@ export interface operations {
   };
   GetPrompt2025Inputs: {
     parameters: {
+      query: {
+        requestId: string;
+      };
       path: {
         promptId: string;
         versionId: string;
@@ -3942,7 +3945,7 @@ export interface operations {
       /** @description Ok */
       200: {
         content: {
-          "application/json": components["schemas"]["Result_Prompt2025Input-Array.string_"];
+          "application/json": components["schemas"]["Result_Prompt2025Input.string_"];
         };
       };
     };

--- a/web/services/hooks/prompts.tsx
+++ b/web/services/hooks/prompts.tsx
@@ -5,6 +5,7 @@ import type { OpenAIChatRequest } from "@helicone-package/llm-mapper/mappers/ope
 
 type Prompt2025 = components["schemas"]["Prompt2025"];
 type Prompt2025Version = components["schemas"]["Prompt2025Version"];
+type Prompt2025Input = components["schemas"]["Prompt2025Input"];
 
 export interface PromptWithVersions {
   prompt: Prompt2025;
@@ -71,6 +72,31 @@ export const useGetPromptTags = () => {
         console.error("Error fetching prompt tags:", result.error);
         return [];
       }
+      return result.data.data;
+    },
+  });
+};
+
+export const useGetPromptInputs = (promptId: string, versionId: string) => {
+  return useQuery<Prompt2025Input[]>({
+    queryKey: ["promptInputs", promptId, versionId],
+    refetchOnWindowFocus: false,
+    enabled: !!promptId && !!versionId,
+    queryFn: async () => {
+      const result = await $JAWN_API.GET("/v1/prompt-2025/id/{promptId}/{versionId}/inputs", {
+        params: {
+          path: {
+            promptId: promptId,
+            versionId: versionId,
+          },
+        },
+      });
+
+      if (result.error || !result.data?.data) {
+        console.error("Error fetching prompt inputs:", result.error);
+        return [];
+      }
+
       return result.data.data;
     },
   });

--- a/web/services/hooks/prompts.tsx
+++ b/web/services/hooks/prompts.tsx
@@ -77,11 +77,11 @@ export const useGetPromptTags = () => {
   });
 };
 
-export const useGetPromptInputs = (promptId: string, versionId: string) => {
-  return useQuery<Prompt2025Input[]>({
-    queryKey: ["promptInputs", promptId, versionId],
+export const useGetPromptInputs = (promptId: string, versionId: string, requestId: string) => {
+  return useQuery<Prompt2025Input | null>({
+    queryKey: ["promptInputs", promptId, versionId, requestId],
     refetchOnWindowFocus: false,
-    enabled: !!promptId && !!versionId,
+    enabled: !!promptId && !!versionId && !!requestId,
     queryFn: async () => {
       const result = await $JAWN_API.GET("/v1/prompt-2025/id/{promptId}/{versionId}/inputs", {
         params: {
@@ -89,12 +89,15 @@ export const useGetPromptInputs = (promptId: string, versionId: string) => {
             promptId: promptId,
             versionId: versionId,
           },
+          query: {
+            requestId: requestId,
+          },
         },
       });
 
       if (result.error || !result.data?.data) {
         console.error("Error fetching prompt inputs:", result.error);
-        return [];
+        return null;
       }
 
       return result.data.data;


### PR DESCRIPTION
- Change prompt input logging to do batch inserts
- Pull inputs based on request ID and version ID hook
- Track prompt and version ID through HeliconeRequest and MappedLLMRequest types
- Show prompt inputs in drawer where applicable
- Update playground to display inputs and original prompt with variables if the request is compatible