### PR TITLE
chore: improve dark mode on gateway pages and label component

### DIFF
--- a/web/components/templates/gateway/gatewayPage.tsx
+++ b/web/components/templates/gateway/gatewayPage.tsx
@@ -120,7 +120,7 @@ const GatewayPage = () => {
               {providerKeys.length === 0 && (
                 <Badge
                   variant="helicone"
-                  className="gap-2 bg-yellow-200/70 text-yellow-500 hover:bg-yellow-200/70"
+                  className="gap-2 bg-yellow-200/70 text-yellow-500 hover:bg-yellow-200/70 dark:bg-yellow-900/70 dark:text-yellow-500 dark:hover:bg-yellow-900/70"
                 >
                   <TriangleAlertIcon className="h-3 w-3" />
                   <span>

--- a/web/components/ui/drawer.tsx
+++ b/web/components/ui/drawer.tsx
@@ -41,7 +41,7 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border border-slate-200 bg-slate-100 dark:border-slate-800 dark:bg-slate-900",
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border border-border bg-background dark:border-border dark:bg-background",
         className,
       )}
       {...props}

--- a/web/components/ui/label.tsx
+++ b/web/components/ui/label.tsx
@@ -9,7 +9,7 @@ const labelVariants = cva(
   {
     variants: {
       variant: {
-        default: "text-sm font-medium text-slate-800",
+        default: "text-sm font-medium text-muted-foreground",
         badge: [
           "h-5 px-2.5 py-0.5 bg-sky-500 text-xs text-sky-50",
           "shadow shadow-[0px_1px_2px_0px_rgba(0,0,0,0.06)]",

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -16,37 +16,37 @@
   */
   :root {
     /* Background Colors */
-    --background: 210 40% 98%;
-    --foreground: 222 47% 11%;
-    --card: 0 0% 100%;
-    --card-foreground: 222 47% 11%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222 47% 11%;
+    --background: 210 40% 98%; /* hsl(210, 40%, 98%) */
+    --foreground: 222 47% 11%; /* hsl(222, 47%, 11%) */
+    --card: 0 0% 100%; /* hsl(0, 0%, 100%) */
+    --card-foreground: 222 47% 11%; /* hsl(222, 47%, 11%) */
+    --popover: 0 0% 100%; /* hsl(0, 0%, 100%) */
+    --popover-foreground: 222 47% 11%; /* hsl(222, 47%, 11%) */
 
     /* Primary Colors */
-    --primary: 199 89% 48%;
-    --primary-foreground: 204 100% 97%;
+    --primary: 199 89% 48%; /* hsl(199, 89%, 48%) */
+    --primary-foreground: 204 100% 97%; /* hsl(204, 100%, 97%) */
 
     /* Secondary Colors */
-    --secondary: 210 40% 96%;
-    --secondary-foreground: 222 47% 11%;
+    --secondary: 210 40% 96%; /* hsl(210, 40%, 96%) */
+    --secondary-foreground: 222 47% 11%; /* hsl(222, 47%, 11%) */
 
     /* Muted Colors */
-    --muted: 210 40% 96%;
-    --muted-foreground: 215 16% 47%;
+    --muted: 210 40% 96%; /* hsl(210, 40%, 96%) */
+    --muted-foreground: 215 16% 47%; /* hsl(215, 16%, 47%) */
 
     /* Accent Colors */
-    --accent: 210 40% 96%;
-    --accent-foreground: 222 47% 11%;
+    --accent: 210 40% 96%; /* hsl(210, 40%, 96%) */
+    --accent-foreground: 222 47% 11%; /* hsl(222, 47%, 11%) */
 
     /* Destructive Colors */
-    --destructive: 0 72% 51%;
-    --destructive-foreground: 0 75% 15%;
+    --destructive: 0 72% 51%; /* hsl(0, 72%, 51%) */
+    --destructive-foreground: 0 75% 15%; /* hsl(0, 75%, 15%) */
 
     /* Border Colors */
-    --border: 214 32% 91%;
-    --input: 214 32% 91%;
-    --ring: 222 47% 11%;
+    --border: 214 32% 91%; /* hsl(214, 32%, 91%) */
+    --input: 214 32% 91%; /* hsl(214, 32%, 91%) */
+    --ring: 222 47% 11%; /* hsl(222, 47%, 11%) */
 
     /* Chart Colors */
     --chart-1: 0.852 0.199 91.936; /* oklch(0.852 0.199 91.936) */


### PR DESCRIPTION
- the label component wasn't visible on dark mode - changed it to use the text-muted-foreground class instead of using manual color classes
- changed the drawer to not use slate color and use bg-background to appear less blue which looked off with our ui
- improved visibility of the badge which says no provider keys
- added components with the hsl colors on the global.css file so that color related extensions can pick that up on show a preview