### PR TITLE
optimize caching keys

### DIFF
--- a/worker/src/lib/managers/APIKeysManager.ts
+++ b/worker/src/lib/managers/APIKeysManager.ts
@@ -18,6 +18,7 @@ export class APIKeysManager {
         apiKeys.map(async (key) => {
           if (key.soft_delete) {
             await removeFromCache(`api_keys_${key.api_key_hash}`, this.env);
+            return;
           }
           await storeInCache(
             `api_keys_${key.api_key_hash}`,

--- a/worker/src/lib/managers/ProviderKeysManager.ts
+++ b/worker/src/lib/managers/ProviderKeysManager.ts
@@ -9,13 +9,15 @@ export class ProviderKeysManager {
     const providerKeys = await this.store.getProviderKeys();
     if (providerKeys) {
       console.log("setting provider keys", providerKeys.length);
-      for (const key of providerKeys) {
-        await storeInCache(
-          `provider_keys_${key.provider}_${key.org_id}`,
-          JSON.stringify(key),
-          this.env
-        );
-      }
+      await Promise.all(
+        providerKeys.map(async (key) => {
+          await storeInCache(
+            `provider_keys_${key.provider}_${key.org_id}`,
+            JSON.stringify(key),
+            this.env
+          );
+        })
+      );
       // await storeInCache(`provider_keys_${provider}`, JSON.stringify(providerKeys), this.env);
     } else {
       console.error("No provider keys found");

--- a/worker/src/lib/util/cache/secureCache.ts
+++ b/worker/src/lib/util/cache/secureCache.ts
@@ -104,6 +104,15 @@ export async function decrypt(
   return new TextDecoder().decode(decryptedContent);
 }
 
+export async function removeFromCache(
+  key: string,
+  env: SecureCacheEnv
+): Promise<void> {
+  const hashedKey = await hash(key);
+  await env.SECURE_CACHE.delete(hashedKey);
+  InMemoryCache.getInstance<string>().delete(hashedKey);
+}
+
 export async function storeInCache(
   key: string,
   value: string,

--- a/worker/src/routers/api/apiRouter.ts
+++ b/worker/src/routers/api/apiRouter.ts
@@ -14,6 +14,7 @@ import { ProviderKeysManager } from "../../lib/managers/ProviderKeysManager";
 import { ProviderKeysStore } from "../../lib/db/ProviderKeysStore";
 import { APIKeysStore } from "../../lib/db/APIKeysStore";
 import { APIKeysManager } from "../../lib/managers/APIKeysManager";
+const RATE_LIMIT_MS = 1000 * 30;
 
 function getAPIRouterV1(
   router: OpenAPIRouterType<
@@ -37,7 +38,7 @@ function getAPIRouterV1(
         if (
           lastFetchedAt &&
           // Every 10 seconds
-          new Date(lastFetchedAt).getTime() + 1000 * 10 > Date.now()
+          new Date(lastFetchedAt).getTime() + RATE_LIMIT_MS > Date.now()
         ) {
           return new Response("rate limited", { status: 429 });
         }
@@ -88,7 +89,7 @@ function getAPIRouterV1(
         if (
           lastFetchedAt &&
           // Every 10 seconds
-          new Date(lastFetchedAt).getTime() + 1000 * 10 > Date.now()
+          new Date(lastFetchedAt).getTime() + RATE_LIMIT_MS > Date.now()
         ) {
           return new Response("rate limited", { status: 429 });
         }


### PR DESCRIPTION

- This PR adds the ability to track removal of keys. (If a user deletes an API key, it should stop working)
- This PR also optimizing how we store keys. We are only ever looking within the last day of both updated and created keys to load into our cache. We call these periodically every 5 minutes and we execute it as well whenever it changes on the frontend. This reducing the overhead the worker needs to do and drastically reduces the number of KV puts and gets. This is okay, because for older keys we will store it into the cache if we cannot find it on the first call. So the first call will be slow but subsequent calls will be faster.
