### PR TITLE
fix: make dockerfile migrations runner env var friendly

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -114,8 +114,7 @@ services:
       FLYWAY_URL: jdbc:postgresql://db:5432/helicone_test
       FLYWAY_USER: postgres
       FLYWAY_PASSWORD: testpassword
-      CLICKHOUSE_HOST: clickhouse
-      CLICKHOUSE_PORT: 8123
+      CLICKHOUSE_HOST: http://clickhouse:8123
       CLICKHOUSE_USER: default
     volumes:
       - ../supabase:/app/supabase

--- a/docker/dockerfiles/dockerfile_migrations
+++ b/docker/dockerfiles/dockerfile_migrations
@@ -42,9 +42,9 @@ RUN echo '#!/bin/sh \n\
     \n\
     echo "Running ClickHouse migrations..." \n\
     if [ -n "${CLICKHOUSE_PASSWORD}" ]; then \n\
-        python3 /app/clickhouse/ch_hcone.py --upgrade --host ${CLICKHOUSE_HOST:-helicone-core-clickhouse} --port ${CLICKHOUSE_PORT:-8123} --user ${CLICKHOUSE_USER:-default} --password "${CLICKHOUSE_PASSWORD}" \n\
+        python3 /app/clickhouse/ch_hcone.py --upgrade --password "${CLICKHOUSE_PASSWORD}" \n\
     else \n\
-        python3 /app/clickhouse/ch_hcone.py --upgrade --host ${CLICKHOUSE_HOST:-helicone-core-clickhouse} --port ${CLICKHOUSE_PORT:-8123} --user ${CLICKHOUSE_USER:-default} --no-password \n\
+        python3 /app/clickhouse/ch_hcone.py --upgrade --no-password \n\
     fi \n\
     echo "ClickHouse migrations completed" \n\
     \n\

--- a/docs/getting-started/self-host/manual.mdx
+++ b/docs/getting-started/self-host/manual.mdx
@@ -50,10 +50,10 @@ npm install -g yarn
 ```bash
 python3 -m venv env
 source env/bin/activate
-pip install tabulate requests minio
+pip install tabulate requests minio yarl
 
 # Start Clickhouse (time-series database)
-python3 clickhouse/ch_hcone.py --restart --no-password --host localhost
+python3 clickhouse/ch_hcone.py --restart --no-password --url http://localhost:18123
 
 # Start Minio (S3 compatible object storage)
 python3 minio_hcone.py --restart


### PR DESCRIPTION
the ch_hcone.py script already can parse the host and port from a url, which is much easier to pass in than to maintain variables for each constituent part, thus this PR updates the calling of the ch_hcone.py script so that the URL can be parsed without needing the two separate varibales for host and port

