### PR TITLE
feat: open image from drawer in modal

### DIFF
--- a/web/components/templates/requests/components/chatComponent/ChatMessage.tsx
+++ b/web/components/templates/requests/components/chatComponent/ChatMessage.tsx
@@ -16,6 +16,7 @@ import AssistantToolCalls from "./single/AssistantToolCalls";
 import { JsonRenderer } from "./single/JsonRenderer";
 import TextMessage from "./single/TextMessage";
 import ToolMessage from "./ToolMessage";
+import { ImageModal } from "./single/images/ImageModal";
 
 type MessageType = "image" | "tool" | "text" | "pdf" | "contentArray";
 function base64UrlToBase64(base64url: string) {
@@ -178,14 +179,16 @@ const renderToolMessage = (
 
 const MESSAGE_LENGTH_THRESHOLD = 1000; // Characters before truncating
 
-const renderImageContent = (
-  message: Message,
-  options: {
+const ImageContent: React.FC<{
+  message: Message;
+  options?: {
     showDeleteButton?: boolean;
     onDelete?: () => void;
     wrapperClassName?: string;
-  } = {},
-) => {
+  };
+}> = ({ message, options = {} }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  
   let imageSrc = message.image_url;
   if (message.content && message.mime_type?.startsWith("image/")) {
     imageSrc = `data:${message.mime_type};base64,${message.content}`;
@@ -213,7 +216,7 @@ const renderImageContent = (
         height={1000}
         className="h-auto max-h-[200px] w-auto max-w-full cursor-pointer object-contain transition-opacity hover:opacity-90"
         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-        onClick={() => {}}
+        onClick={() => setIsModalOpen(true)}
         title="Click to view full size"
       />
     </div>
@@ -229,8 +232,25 @@ const renderImageContent = (
       >
         {imageElement}
       </ContentWrapper>
+      
+      <ImageModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        imageSrc={processedImageSrc}
+      />
     </>
   );
+};
+
+const renderImageContent = (
+  message: Message,
+  options: {
+    showDeleteButton?: boolean;
+    onDelete?: () => void;
+    wrapperClassName?: string;
+  } = {},
+) => {
+  return <ImageContent message={message} options={options} />;
 };
 
 const renderTextContent = (

--- a/web/components/templates/requests/components/chatComponent/ChatMessage.tsx
+++ b/web/components/templates/requests/components/chatComponent/ChatMessage.tsx
@@ -188,7 +188,7 @@ const ImageContent: React.FC<{
   };
 }> = ({ message, options = {} }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  
+
   let imageSrc = message.image_url;
   if (message.content && message.mime_type?.startsWith("image/")) {
     imageSrc = `data:${message.mime_type};base64,${message.content}`;
@@ -232,7 +232,7 @@ const ImageContent: React.FC<{
       >
         {imageElement}
       </ContentWrapper>
-      
+
       <ImageModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}

--- a/web/components/templates/requests/components/chatComponent/single/RenderImageWithPrettyInputKeys.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/RenderImageWithPrettyInputKeys.tsx
@@ -6,7 +6,10 @@ export const RenderImageWithPrettyInputKeys = (props: {
   selectedProperties: Record<string, string> | undefined;
 }) => {
   const { text, selectedProperties } = props;
-  const [modalState, setModalState] = useState<{ isOpen: boolean; imageSrc: string }>({
+  const [modalState, setModalState] = useState<{
+    isOpen: boolean;
+    imageSrc: string;
+  }>({
     isOpen: false,
     imageSrc: "",
   });
@@ -40,13 +43,13 @@ export const RenderImageWithPrettyInputKeys = (props: {
 
       // eslint-disable-next-line @next/next/no-img-element
       parts.push(
-        <img 
+        <img
           key={`img-${keyName}-${offset}`}
-          src={renderText} 
-          alt={keyName} 
+          src={renderText}
+          alt={keyName}
           className="max-h-24 cursor-pointer transition-opacity hover:opacity-90"
           onClick={() => setModalState({ isOpen: true, imageSrc: renderText })}
-        />
+        />,
       );
 
       // Update lastIndex to the end of the current match
@@ -68,7 +71,7 @@ export const RenderImageWithPrettyInputKeys = (props: {
       <div className="text-md leading-8 text-black dark:text-white">
         {replaceInputKeysWithComponents(text)}
       </div>
-      
+
       <ImageModal
         isOpen={modalState.isOpen}
         onClose={() => setModalState({ isOpen: false, imageSrc: "" })}

--- a/web/components/templates/requests/components/chatComponent/single/RenderImageWithPrettyInputKeys.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/RenderImageWithPrettyInputKeys.tsx
@@ -1,8 +1,15 @@
+import React, { useState } from "react";
+import { ImageModal } from "./images/ImageModal";
+
 export const RenderImageWithPrettyInputKeys = (props: {
   text: string;
   selectedProperties: Record<string, string> | undefined;
 }) => {
   const { text, selectedProperties } = props;
+  const [modalState, setModalState] = useState<{ isOpen: boolean; imageSrc: string }>({
+    isOpen: false,
+    imageSrc: "",
+  });
 
   // Function to replace matched patterns with JSX components
   const replaceInputKeysWithComponents = (inputText: string) => {
@@ -32,7 +39,15 @@ export const RenderImageWithPrettyInputKeys = (props: {
       const renderText = getRenderText();
 
       // eslint-disable-next-line @next/next/no-img-element
-      parts.push(<img src={renderText} alt={keyName} className="max-h-24" />);
+      parts.push(
+        <img 
+          key={`img-${keyName}-${offset}`}
+          src={renderText} 
+          alt={keyName} 
+          className="max-h-24 cursor-pointer transition-opacity hover:opacity-90"
+          onClick={() => setModalState({ isOpen: true, imageSrc: renderText })}
+        />
+      );
 
       // Update lastIndex to the end of the current match
       lastIndex = offset + match.length;
@@ -49,8 +64,16 @@ export const RenderImageWithPrettyInputKeys = (props: {
   };
 
   return (
-    <div className="text-md leading-8 text-black dark:text-white">
-      {replaceInputKeysWithComponents(text)}
-    </div>
+    <>
+      <div className="text-md leading-8 text-black dark:text-white">
+        {replaceInputKeysWithComponents(text)}
+      </div>
+      
+      <ImageModal
+        isOpen={modalState.isOpen}
+        onClose={() => setModalState({ isOpen: false, imageSrc: "" })}
+        imageSrc={modalState.imageSrc}
+      />
+    </>
   );
 };

--- a/web/components/templates/requests/components/chatComponent/single/images/ClaudeImage.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/images/ClaudeImage.tsx
@@ -9,7 +9,7 @@ export const ClaudeImage: React.FC<{
 }> = ({ item, selectedProperties, isHeliconeTemplate }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const imageUrl = item.source.data;
-  
+
   if (isHeliconeTemplate) {
     return (
       <RenderImageWithPrettyInputKeys
@@ -18,19 +18,19 @@ export const ClaudeImage: React.FC<{
       />
     );
   }
-  
+
   return (
     <>
       {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img 
-        src={imageUrl} 
-        alt="" 
-        width={600} 
+      <img
+        src={imageUrl}
+        alt=""
+        width={600}
         height={600}
         className="cursor-pointer transition-opacity hover:opacity-90"
         onClick={() => setIsModalOpen(true)}
       />
-      
+
       <ImageModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}

--- a/web/components/templates/requests/components/chatComponent/single/images/ClaudeImage.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/images/ClaudeImage.tsx
@@ -1,12 +1,15 @@
-import React from "react";
+import React, { useState } from "react";
 import { RenderImageWithPrettyInputKeys } from "../RenderImageWithPrettyInputKeys";
+import { ImageModal } from "./ImageModal";
 
 export const ClaudeImage: React.FC<{
   item: any;
   selectedProperties?: Record<string, string>;
   isHeliconeTemplate?: boolean;
 }> = ({ item, selectedProperties, isHeliconeTemplate }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const imageUrl = item.source.data;
+  
   if (isHeliconeTemplate) {
     return (
       <RenderImageWithPrettyInputKeys
@@ -15,6 +18,24 @@ export const ClaudeImage: React.FC<{
       />
     );
   }
-  // eslint-disable-next-line @next/next/no-img-element
-  return <img src={imageUrl} alt="" width={600} height={600} />;
+  
+  return (
+    <>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img 
+        src={imageUrl} 
+        alt="" 
+        width={600} 
+        height={600}
+        className="cursor-pointer transition-opacity hover:opacity-90"
+        onClick={() => setIsModalOpen(true)}
+      />
+      
+      <ImageModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        imageSrc={imageUrl}
+      />
+    </>
+  );
 };

--- a/web/components/templates/requests/components/chatComponent/single/images/ImageItem.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/images/ImageItem.tsx
@@ -56,7 +56,7 @@ export const ImageItem: React.FC<{
       <button
         onClick={handleOpenModal}
         onKeyDown={handleKeyDown}
-        className="cursor-pointer transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded p-0 border-0 bg-transparent"
+        className="cursor-pointer rounded border-0 bg-transparent p-0 transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
         aria-label="Open image in modal dialog"
         type="button"
       >
@@ -68,7 +68,7 @@ export const ImageItem: React.FC<{
           className="rounded"
         />
       </button>
-      
+
       <ImageModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}

--- a/web/components/templates/requests/components/chatComponent/single/images/ImageItem.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/images/ImageItem.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import { RenderImageWithPrettyInputKeys } from "../RenderImageWithPrettyInputKeys";
+import { ImageModal } from "./ImageModal";
 
 const isBase64 = (str: string): boolean => {
   try {
@@ -17,6 +18,8 @@ export const ImageItem: React.FC<{
   selectedProperties?: Record<string, string>;
   isHeliconeTemplate?: boolean;
 }> = ({ imageUrl, selectedProperties, isHeliconeTemplate }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   if (isHeliconeTemplate) {
     return (
       <RenderImageWithPrettyInputKeys
@@ -30,6 +33,23 @@ export const ImageItem: React.FC<{
     ? `data:image/jpeg;base64,${imageUrl}`
     : imageUrl;
 
-  // eslint-disable-next-line @next/next/no-img-element
-  return <img src={imageSrc} alt="" width={600} height={600} />;
+  return (
+    <>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img 
+        src={imageSrc} 
+        alt="" 
+        width={600} 
+        height={600}
+        className="cursor-pointer transition-opacity hover:opacity-90"
+        onClick={() => setIsModalOpen(true)}
+      />
+      
+      <ImageModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        imageSrc={imageSrc}
+      />
+    </>
+  );
 };

--- a/web/components/templates/requests/components/chatComponent/single/images/ImageItem.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/images/ImageItem.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import Image from "next/image";
 import { RenderImageWithPrettyInputKeys } from "../RenderImageWithPrettyInputKeys";
 import { ImageModal } from "./ImageModal";
 
@@ -33,17 +34,40 @@ export const ImageItem: React.FC<{
     ? `data:image/jpeg;base64,${imageUrl}`
     : imageUrl;
 
+  const handleOpenModal = () => setIsModalOpen(true);
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      handleOpenModal();
+    }
+  };
+
+  // Generate a descriptive alt text based on the image source
+  const getImageDescription = () => {
+    if (isBase64(imageUrl)) {
+      return "Base64 encoded image from API request or response - click or press Enter/Space to view full size";
+    }
+    return `Image from ${new URL(imageSrc).hostname} - click or press Enter/Space to view full size`;
+  };
+
   return (
     <>
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img 
-        src={imageSrc} 
-        alt="" 
-        width={600} 
-        height={600}
-        className="cursor-pointer transition-opacity hover:opacity-90"
-        onClick={() => setIsModalOpen(true)}
-      />
+      <button
+        onClick={handleOpenModal}
+        onKeyDown={handleKeyDown}
+        className="cursor-pointer transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded p-0 border-0 bg-transparent"
+        aria-label="Open image in modal dialog"
+        type="button"
+      >
+        <Image
+          src={imageSrc}
+          alt={getImageDescription()}
+          width={600}
+          height={600}
+          className="rounded"
+        />
+      </button>
       
       <ImageModal
         isOpen={isModalOpen}

--- a/web/components/templates/requests/components/chatComponent/single/images/ImageModal.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/images/ImageModal.tsx
@@ -18,26 +18,29 @@ export const ImageModal: React.FC<ImageModalProps> = ({
 }) => {
   // Store the original overflow value to restore it later
   const originalOverflowRef = useRef<string | null>(null);
-  
+
   // Handle escape key
-  const handleEscape = useCallback((e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      e.preventDefault();
-      e.stopPropagation();
-      onClose();
-    }
-  }, [onClose]);
+  const handleEscape = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    },
+    [onClose],
+  );
 
   useEffect(() => {
     if (isOpen) {
       // Store original overflow value before changing it
       originalOverflowRef.current = document.body.style.overflow || "";
-      
+
       // Use capture phase to handle event before other listeners
       document.addEventListener("keydown", handleEscape, true);
       // Prevent body scroll when modal is open
       document.body.style.overflow = "hidden";
-      
+
       return () => {
         document.removeEventListener("keydown", handleEscape, true);
         // Restore the original overflow value only when modal was open
@@ -52,12 +55,10 @@ export const ImageModal: React.FC<ImageModalProps> = ({
   if (!isOpen) return null;
 
   const modalContent = (
-    <div 
-      className="fixed inset-0 z-[9999] flex items-center justify-center"
-    >
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center">
       {/* Backdrop */}
       <div className="absolute inset-0 bg-black/90" onClick={onClose} />
-      
+
       {/* Content */}
       <div className="relative z-10 flex h-full w-full items-center justify-center">
         <TransformWrapper
@@ -77,7 +78,7 @@ export const ImageModal: React.FC<ImageModalProps> = ({
           {({ zoomIn, zoomOut, resetTransform, centerView }) => (
             <>
               {/* Controls */}
-              <div className="absolute top-4 right-4 z-50 flex flex-col gap-2">
+              <div className="absolute right-4 top-4 z-50 flex flex-col gap-2">
                 {/* Close button */}
                 <button
                   onClick={onClose}
@@ -86,7 +87,7 @@ export const ImageModal: React.FC<ImageModalProps> = ({
                 >
                   <X className="h-5 w-5 text-white" />
                 </button>
-                
+
                 {/* Zoom controls */}
                 <div className="flex flex-col gap-2 rounded-lg bg-white/10 p-2 backdrop-blur-sm">
                   <button
@@ -119,14 +120,14 @@ export const ImageModal: React.FC<ImageModalProps> = ({
                   </button>
                 </div>
               </div>
-              
+
               {/* Instructions */}
-              <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-50 rounded-lg bg-white/10 px-4 py-2 backdrop-blur-sm">
+              <div className="absolute bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-white/10 px-4 py-2 backdrop-blur-sm">
                 <p className="text-sm text-white/80">
                   Scroll to zoom • Drag to pan • Double-click to zoom
                 </p>
               </div>
-              
+
               {/* Image container */}
               <TransformComponent
                 wrapperStyle={{
@@ -141,10 +142,10 @@ export const ImageModal: React.FC<ImageModalProps> = ({
                   justifyContent: "center",
                 }}
               >
-                <img 
-                  src={imageSrc} 
+                <img
+                  src={imageSrc}
                   alt={alt}
-                  className="max-w-[90vw] max-h-[90vh] object-contain"
+                  className="max-h-[90vh] max-w-[90vw] object-contain"
                   style={{ userSelect: "none" }}
                   draggable={false}
                 />
@@ -157,8 +158,5 @@ export const ImageModal: React.FC<ImageModalProps> = ({
   );
 
   // Render modal at document body level using Portal
-  return ReactDOM.createPortal(
-    modalContent,
-    document.body
-  );
+  return ReactDOM.createPortal(modalContent, document.body);
 };

--- a/web/components/templates/requests/components/chatComponent/single/images/ImageModal.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/images/ImageModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from "react";
+import React, { useEffect, useCallback, useRef } from "react";
 import ReactDOM from "react-dom";
 import { X, ZoomIn, ZoomOut, RotateCw, Maximize2 } from "lucide-react";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
@@ -16,6 +16,9 @@ export const ImageModal: React.FC<ImageModalProps> = ({
   imageSrc,
   alt = "",
 }) => {
+  // Store the original overflow value to restore it later
+  const originalOverflowRef = useRef<string | null>(null);
+  
   // Handle escape key
   const handleEscape = useCallback((e: KeyboardEvent) => {
     if (e.key === "Escape") {
@@ -27,16 +30,23 @@ export const ImageModal: React.FC<ImageModalProps> = ({
 
   useEffect(() => {
     if (isOpen) {
+      // Store original overflow value before changing it
+      originalOverflowRef.current = document.body.style.overflow || "";
+      
       // Use capture phase to handle event before other listeners
       document.addEventListener("keydown", handleEscape, true);
       // Prevent body scroll when modal is open
       document.body.style.overflow = "hidden";
+      
+      return () => {
+        document.removeEventListener("keydown", handleEscape, true);
+        // Restore the original overflow value only when modal was open
+        if (originalOverflowRef.current !== null) {
+          document.body.style.overflow = originalOverflowRef.current;
+          originalOverflowRef.current = null;
+        }
+      };
     }
-    
-    return () => {
-      document.removeEventListener("keydown", handleEscape, true);
-      document.body.style.overflow = "unset";
-    };
   }, [isOpen, handleEscape]);
 
   if (!isOpen) return null;

--- a/web/components/templates/requests/components/chatComponent/single/images/ImageModal.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/images/ImageModal.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useCallback } from "react";
+import ReactDOM from "react-dom";
+import { X, ZoomIn, ZoomOut, RotateCw, Maximize2 } from "lucide-react";
+import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
+
+interface ImageModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  imageSrc: string;
+  alt?: string;
+}
+
+export const ImageModal: React.FC<ImageModalProps> = ({
+  isOpen,
+  onClose,
+  imageSrc,
+  alt = "",
+}) => {
+  // Handle escape key
+  const handleEscape = useCallback((e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      onClose();
+    }
+  }, [onClose]);
+
+  useEffect(() => {
+    if (isOpen) {
+      // Use capture phase to handle event before other listeners
+      document.addEventListener("keydown", handleEscape, true);
+      // Prevent body scroll when modal is open
+      document.body.style.overflow = "hidden";
+    }
+    
+    return () => {
+      document.removeEventListener("keydown", handleEscape, true);
+      document.body.style.overflow = "unset";
+    };
+  }, [isOpen, handleEscape]);
+
+  if (!isOpen) return null;
+
+  const modalContent = (
+    <div 
+      className="fixed inset-0 z-[9999] flex items-center justify-center"
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/90" onClick={onClose} />
+      
+      {/* Content */}
+      <div className="relative z-10 flex h-full w-full items-center justify-center">
+        <TransformWrapper
+          initialScale={1}
+          minScale={0.5}
+          maxScale={5}
+          centerOnInit={true}
+          limitToBounds={false}
+          doubleClick={{
+            mode: "toggle",
+            step: 1,
+          }}
+          panning={{
+            excluded: ["button"],
+          }}
+        >
+          {({ zoomIn, zoomOut, resetTransform, centerView }) => (
+            <>
+              {/* Controls */}
+              <div className="absolute top-4 right-4 z-50 flex flex-col gap-2">
+                {/* Close button */}
+                <button
+                  onClick={onClose}
+                  className="flex items-center justify-center rounded-lg bg-white/10 p-2 backdrop-blur-sm transition-colors hover:bg-white/20"
+                  title="Close (Esc)"
+                >
+                  <X className="h-5 w-5 text-white" />
+                </button>
+                
+                {/* Zoom controls */}
+                <div className="flex flex-col gap-2 rounded-lg bg-white/10 p-2 backdrop-blur-sm">
+                  <button
+                    onClick={() => zoomIn()}
+                    className="flex items-center justify-center rounded p-1.5 transition-colors hover:bg-white/20"
+                    title="Zoom In"
+                  >
+                    <ZoomIn className="h-5 w-5 text-white" />
+                  </button>
+                  <button
+                    onClick={() => zoomOut()}
+                    className="flex items-center justify-center rounded p-1.5 transition-colors hover:bg-white/20"
+                    title="Zoom Out"
+                  >
+                    <ZoomOut className="h-5 w-5 text-white" />
+                  </button>
+                  <button
+                    onClick={() => resetTransform()}
+                    className="flex items-center justify-center rounded p-1.5 transition-colors hover:bg-white/20"
+                    title="Reset"
+                  >
+                    <RotateCw className="h-5 w-5 text-white" />
+                  </button>
+                  <button
+                    onClick={() => centerView()}
+                    className="flex items-center justify-center rounded p-1.5 transition-colors hover:bg-white/20"
+                    title="Center"
+                  >
+                    <Maximize2 className="h-5 w-5 text-white" />
+                  </button>
+                </div>
+              </div>
+              
+              {/* Instructions */}
+              <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-50 rounded-lg bg-white/10 px-4 py-2 backdrop-blur-sm">
+                <p className="text-sm text-white/80">
+                  Scroll to zoom • Drag to pan • Double-click to zoom
+                </p>
+              </div>
+              
+              {/* Image container */}
+              <TransformComponent
+                wrapperStyle={{
+                  width: "100%",
+                  height: "100%",
+                }}
+                contentStyle={{
+                  width: "100%",
+                  height: "100%",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <img 
+                  src={imageSrc} 
+                  alt={alt}
+                  className="max-w-[90vw] max-h-[90vh] object-contain"
+                  style={{ userSelect: "none" }}
+                  draggable={false}
+                />
+              </TransformComponent>
+            </>
+          )}
+        </TransformWrapper>
+      </div>
+    </div>
+  );
+
+  // Render modal at document body level using Portal
+  return ReactDOM.createPortal(
+    modalContent,
+    document.body
+  );
+};

--- a/web/components/templates/requests/components/chatComponent/single/renderingUtils.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/renderingUtils.tsx
@@ -1,15 +1,35 @@
 import { Message } from "@helicone-package/llm-mapper/types";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { JsonRenderer } from "./JsonRenderer";
 import { isJSON } from "@helicone-package/llm-mapper/utils/contentHelpers";
+import { ImageModal } from "./images/ImageModal";
 
 export const OpenAIImage: React.FC<{
   imageUrl: string;
   selectedProperties?: Record<string, string>;
   isHeliconeTemplate?: boolean;
 }> = ({ imageUrl, selectedProperties, isHeliconeTemplate }) => {
-  // eslint-disable-next-line @next/next/no-img-element
-  return <img src={imageUrl} alt="" width={600} height={600} />;
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  
+  return (
+    <>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img 
+        src={imageUrl} 
+        alt="" 
+        width={600} 
+        height={600}
+        className="cursor-pointer transition-opacity hover:opacity-90"
+        onClick={() => setIsModalOpen(true)}
+      />
+      
+      <ImageModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        imageSrc={imageUrl}
+      />
+    </>
+  );
 };
 
 export const UnsupportedImage: React.FC = () => (

--- a/web/components/templates/requests/components/chatComponent/single/renderingUtils.tsx
+++ b/web/components/templates/requests/components/chatComponent/single/renderingUtils.tsx
@@ -10,19 +10,19 @@ export const OpenAIImage: React.FC<{
   isHeliconeTemplate?: boolean;
 }> = ({ imageUrl, selectedProperties, isHeliconeTemplate }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  
+
   return (
     <>
       {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img 
-        src={imageUrl} 
-        alt="" 
-        width={600} 
+      <img
+        src={imageUrl}
+        alt=""
+        width={600}
         height={600}
         className="cursor-pointer transition-opacity hover:opacity-90"
         onClick={() => setIsModalOpen(true)}
       />
-      
+
       <ImageModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}

--- a/web/package.json
+++ b/web/package.json
@@ -129,6 +129,7 @@
     "react-markdown": "^9.0.3",
     "react-resizable-panels": "^2.1.7",
     "react-simple-code-editor": "^0.13.1",
+    "react-zoom-pan-pinch": "^3.7.0",
     "recharts": "^2.13.3",
     "rss-parser": "^3.13.0",
     "sonner": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14848,6 +14848,11 @@ react-transition-state@^2.1.2:
   resolved "https://registry.npmjs.org/react-transition-state/-/react-transition-state-2.3.1.tgz"
   integrity sha512-Z48el73x+7HUEM131dof9YpcQ5IlM4xB+pKWH/lX3FhxGfQaNTZa16zb7pWkC/y5btTZzXfCtglIJEGc57giOw==
 
+react-zoom-pan-pinch@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz#7db4d2ec49c316eb20f71c56e9012eeb3ef4b504"
+  integrity sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==
+
 react@18.3.1, react@^18:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react/-/react-18.3.1.tgz"


### PR DESCRIPTION
This pull request introduces a new, accessible image modal component for viewing images in chat messages and related components. The modal supports zoom, pan, and keyboard navigation, and is now integrated across all image displays in the chat UI for a consistent and improved user experience.

**Major improvements:**

**1. New Image Modal Component**
- Added a reusable `ImageModal` component (`web/components/templates/requests/components/chatComponent/single/images/ImageModal.tsx`) that enables zooming, panning, keyboard navigation (Escape to close), and disables background scrolling when open. The modal uses a portal for rendering and includes controls for zooming, resetting, and centering the image.

**2. Integration of Image Modal Across Components**
- Refactored all image displays in chat components (`ClaudeImage`, `ImageItem`, `OpenAIImage`, and inline images in `RenderImageWithPrettyInputKeys` and `ChatMessage`) to use the new `ImageModal` for full-size viewing on click, improving consistency and accessibility. [[1]](diffhunk://#diff-e5b69a19ebaf82db458f2bd00c38220a6d8585350743f6ec27082fc1b247e555L1-R12) [[2]](diffhunk://#diff-e5b69a19ebaf82db458f2bd00c38220a6d8585350743f6ec27082fc1b247e555L18-R40) [[3]](diffhunk://#diff-0441e140b20fce96eb737b336341e31ee380b007faed92eed1190db0f354b155L1-R4) [[4]](diffhunk://#diff-0441e140b20fce96eb737b336341e31ee380b007faed92eed1190db0f354b155L33-R78) [[5]](diffhunk://#diff-2f88b22ba2dc5b5da04ff3e2ccc3f68a02134bde956f9ce50d8eb66db9a87e69R1-R12) [[6]](diffhunk://#diff-2f88b22ba2dc5b5da04ff3e2ccc3f68a02134bde956f9ce50d8eb66db9a87e69L35-R50) [[7]](diffhunk://#diff-2f88b22ba2dc5b5da04ff3e2ccc3f68a02134bde956f9ce50d8eb66db9a87e69R67-R77) [[8]](diffhunk://#diff-81f24d65e5470a5efe60b0c596ffc17ddb1440b4065f7cd647624b4be4a25609R19) [[9]](diffhunk://#diff-81f24d65e5470a5efe60b0c596ffc17ddb1440b4065f7cd647624b4be4a25609L181-R191) [[10]](diffhunk://#diff-81f24d65e5470a5efe60b0c596ffc17ddb1440b4065f7cd647624b4be4a25609L216-R219) [[11]](diffhunk://#diff-81f24d65e5470a5efe60b0c596ffc17ddb1440b4065f7cd647624b4be4a25609R235-R255) [[12]](diffhunk://#diff-87787d647db6ed19a8779bc0ceee49155914df03abbce917a452eebe4bff7bbcL2-R32)

**3. Dependency Addition**
- Added `react-zoom-pan-pinch` to `package.json` to enable zoom and pan functionality in the modal.