### PR TITLE
task: Fix many docs, add xAI example

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -140,7 +140,14 @@
                   },
                   "getting-started/integration-method/perplexity",
                   "getting-started/integration-method/together",
-                  "getting-started/integration-method/x"
+                  {
+                    "group": "xAI",
+                    "pages": [
+                      "integrations/xai/curl",
+                      "integrations/xai/javascript",
+                      "integrations/xai/python"
+                    ]
+                  }
                 ]
               },
               {

--- a/docs/faq/openai-fine-tuning-api.mdx
+++ b/docs/faq/openai-fine-tuning-api.mdx
@@ -55,7 +55,7 @@ The OpenAI fine-tuning API allows you to create custom versions of their models 
        ```python
        job = openai.FineTuningJob.create(
            training_file=file.id,
-           model="gpt-3.5-turbo"
+           model="gpt-4o-mini"
        )
        ```
 
@@ -98,7 +98,7 @@ When fine-tuning models, consider these best practices:
 
 1. **Data Quality**: Ensure your training data is high-quality, diverse, and representative of the tasks you want the model to perform. Quality often trumps quantity.
 
-2. **Model Selection**: Choose the appropriate base model. For most use cases, "gpt-3.5-turbo" is recommended, but consider your specific needs and budget. Learn more about [LLM fine-tuning duration](/faq/llm-fine-tuning-time) and [fine-tuning best practices chapter 2: models](https://openpipe.ai/blog/fine-tuning-best-practices-chapter-2-models) to make an informed decision.
+2. **Model Selection**: Choose the appropriate base model. For most use cases, "gpt-4o-mini" is recommended, but consider your specific needs and budget. Learn more about [LLM fine-tuning duration](/faq/llm-fine-tuning-time) and [fine-tuning best practices chapter 2: models](https://openpipe.ai/blog/fine-tuning-best-practices-chapter-2-models) to make an informed decision.
 
 3. **Prompt Engineering**: Craft clear and consistent prompts. Include relevant context and instructions within your prompts to guide the model effectively.
 

--- a/docs/faq/tag/fine-tuning.mdx
+++ b/docs/faq/tag/fine-tuning.mdx
@@ -70,7 +70,7 @@ file = openai.File.create(
 # Create fine-tuning job
 job = openai.FineTuningJob.create(
   training_file=file.id,
-  model="gpt-3.5-turbo"
+  model="gpt-4o-mini"
 )
 ```
 </Step>
@@ -258,7 +258,7 @@ const legalDataset = await helicone.datasets.create({
 
 // Fine-tune with platform-specific parameters
 const fineTuneJob = await openai.fineTuning.create({
-  model: "gpt-3.5-turbo",
+  model: "gpt-4o-mini",
   trainingFile: legalDataset.exportedFileId,
   hyperparameters: {
     nEpochs: 3,
@@ -353,13 +353,13 @@ const qualityDataset = {
 // Track fine-tuned model performance
 const response = await openai.chat.completions.create(
   {
-    model: "ft:gpt-3.5-turbo:org-name:model-name:id",
+    model: "ft:gpt-4o-mini:org-name:model-name:id",
     messages: [{ role: "user", content: prompt }]
   },
   {
     headers: {
       "Helicone-Property-Model-Type": "fine-tuned",
-      "Helicone-Property-Base-Model": "gpt-3.5-turbo",
+      "Helicone-Property-Base-Model": "gpt-4o-mini",
       "Helicone-Property-Training-Job": "ftjob-123"
     }
   }

--- a/docs/features/advanced-usage/custom-properties.mdx
+++ b/docs/features/advanced-usage/custom-properties.mdx
@@ -35,13 +35,24 @@ Use headers to add Custom Properties to your LLM requests.
     <CodeGroup>
 
     ```bash Curl
-    curl https://oai.helicone.ai/v1/completions \
-      -H 'Content-Type: application/json' \
-      -H 'Helicone-Auth: Bearer HELICONE_API_KEY' \
-      -H 'Helicone-Property-Conversation: "support_issue_2"' \
-      -H 'Helicone-Property-App: "mobile"' \
-      -H 'Helicone-Property-Environment: "production"' \
-      -d ...
+    curl https://oai.helicone.ai/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer $OPENAI_API_KEY" \
+      -H "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+      -H "Helicone-Property-Conversation: "support_issue_2"" \
+      -H "Helicone-Property-App: "mobile"" \
+      -H "Helicone-Property-Environment: "production"" \
+      -d '{
+        "model": "gpt-4o-mini",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Hello, how are you?"
+          }
+        ],
+        "max_tokens": 50,
+        "temperature": 0.7
+      }'
     ```
 
     ```python Python

--- a/docs/features/advanced-usage/custom-rate-limits.mdx
+++ b/docs/features/advanced-usage/custom-rate-limits.mdx
@@ -41,16 +41,37 @@ The header follows this format:
 
 <CodeGroup>
 ```bash Curl
-curl https://oai.helicone.ai/v1/completions \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <YOUR_API_KEY>' \
-  -H 'Helicone-Property-IP: 111.1.1.1' \
-  -H 'Helicone-User-Id: user-123' \
-  -H 'Helicone-RateLimit-Policy: 10;w=1000;u=cents;s=user' \
+curl https://oai.helicone.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Helicone-Property-IP: 111.1.1.1" \
+  -H "Helicone-User-Id: user-123" \
+  -H "Helicone-RateLimit-Policy: 10;w=1000;u=cents;s=user" \
   -d '{
     "model": "text-davinci-003",
-    "prompt": "How do I enable custom rate limit policies?",
+    "messages": [
+      
+    ]"How do I enable custom rate limit policies?",
 }'
+
+    curl https://oai.helicone.ai/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer $OPENAI_API_KEY" \
+      -H "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+      -H "Helicone-Property-Conversation: "support_issue_2"" \
+      -H "Helicone-Property-App: "mobile"" \
+      -H "Helicone-Property-Environment: "production"" \
+      -d '{
+        "model": "gpt-4o-mini",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Hello, how are you?"
+          }
+        ],
+        "max_tokens": 50,
+        "temperature": 0.7
+      }'
 ```
 
 ```python Python

--- a/docs/features/advanced-usage/llm-security.mdx
+++ b/docs/features/advanced-usage/llm-security.mdx
@@ -85,14 +85,19 @@ To enable LLM security in Helicone, simply add `Helicone-LLM-Security-Enabled: t
 <CodeGroup>
 
 ```bash Curl
-curl https://oai.helicone.ai/v1/completions \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <YOUR_API_KEY>' \
-  -H 'Helicone-LLM-Security-Enabled: true' \
-  -H 'Helicone-LLM-Security-Advanced: true' \
+curl https://oai.helicone.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Helicone-LLM-Security-Enabled: true" \
+  -H "Helicone-LLM-Security-Advanced: true" \
   -d '{
-    "model": "text-davinci-003",
-    "prompt": "How do I enable LLM security with helicone?",
+    "model": "gpt-4o-mini",
+    "messages": [
+      {
+        "role": "user",
+        "content": "How do I enable LLM security with helicone?"
+      }
+    ]
 }'
 ```
 

--- a/docs/features/advanced-usage/moderations.mdx
+++ b/docs/features/advanced-usage/moderations.mdx
@@ -23,13 +23,19 @@ To enable moderation, set `Helicone-Moderations-Enabled` to `true`.
 
 <CodeGroup>
 ```bash Curl
-curl https://oai.helicone.ai/v1/completions \
-  -H 'Content-Type: application/json' \
-  -H 'Helicone-Auth: Bearer YOUR_API_KEY' \
-  -H 'Helicone-Moderations-Enabled: true' \ # Add this header and set to true
+curl https://oai.helicone.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+  -H "Helicone-Moderations-Enabled: true" \ # Add this header and set to true
   -d '{
-    "model": "text-davinci-003",
-    "prompt": "How do I enable moderations?",
+    "model": "gpt-4o-mini",
+    "messages": [
+      {
+        "role": "user",
+        "content": "How do I enable moderations?"
+      }
+    ]
 }'
 ```
 

--- a/docs/features/advanced-usage/omit-logs.mdx
+++ b/docs/features/advanced-usage/omit-logs.mdx
@@ -45,14 +45,19 @@ To omit logging responses, set `Helicone-Omit-Response` to `true`.
 <CodeGroup>
 
 ```bash Curl
-curl https://oai.helicone.ai/v1/completions \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer YOUR_API_KEY' \
-  -H 'Helicone-Omit-Request: true' \ # Add this header and set to true
-  -H 'Helicone-Omit-Response: true' \ # Add this header and set to true
+curl https://oai.helicone.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Helicone-Omit-Request: true" \
+  -H "Helicone-Omit-Response: true" \
  -d '{
-    "model": "text-davinci-003",
-    "prompt": "How do I enable custom rate limit policies?",
+    "model": "gpt-4o-mini",
+    "messages": [
+      {
+        "role": "user",
+        "content": "How do I enable custom rate limit policies?"
+      }
+    ]
 }'
 ```
 
@@ -108,7 +113,7 @@ logger.disable_content_tracing() # This will omit the request and response from 
 
 # Make the OpenAI call
 response = client.chat.completions.create(
-  model="gpt-3.5-turbo",
+  model="gpt-4o-mini",
   messages=[{"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "Who won the world series in 2020?"},
             {"role": "assistant",

--- a/docs/features/advanced-usage/retries.mdx
+++ b/docs/features/advanced-usage/retries.mdx
@@ -32,14 +32,23 @@ To get started, set `Helicone-Retry-Enabled` to `true`.
 
 <CodeGroup>
 ```bash Curl
-curl https://oai.helicone.ai/v1/completions \
-  -H 'Content-Type: application/json' \
-  -H 'Helicone-Auth: Bearer YOUR_API_KEY' \
-  -H 'Helicone-Retry-Enabled: true' \ # Add this header and set to true
-  -d '{
-    "model": "text-davinci-003",
-    "prompt": "How do I enable retries?",
-}'
+curl --request POST \
+     --url https://oai.helicone.ai/v1/chat/completions \
+     -H "Content-Type: application/json" \
+     -H "Authorization: Bearer $OPENAI_API_KEY" \
+     -H "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+     -H "Helicone-Retry-Enabled: true" \
+     --data '{
+        "model": "gpt-4o-mini",
+        "messages": [
+          {
+            "role": "system",
+            "content": "Say Hello!"
+            }
+        ],
+        "temperature": 1,
+        "max_tokens": 30
+      }'
 ```
 
 ```python Python
@@ -51,7 +60,7 @@ client = OpenAI(
 )
 
 client.chat.completions.create(
-    model="text-davinci-003",
+    model="gpt-4o-mini",
     prompt="How do I enable retries?",
     extra_headers={
       "Helicone-Retry-Enabled": "true", # Add this header and set to true

--- a/docs/features/advanced-usage/user-metrics.mdx
+++ b/docs/features/advanced-usage/user-metrics.mdx
@@ -204,7 +204,7 @@ class AIService {
   async processRequest(userId, prompt, userTier = "free") {
     const response = await this.openai.chat.completions.create(
       {
-        model: userTier === "premium" ? "gpt-4o-mini" : "gpt-3.5-turbo",
+        model: userTier === "premium" ? "o3" : "gpt-4o-mini",
         messages: [{ role: "user", content: prompt }]
       },
       {

--- a/docs/features/jobs/example.mdx
+++ b/docs/features/jobs/example.mdx
@@ -103,7 +103,7 @@ CHAPTER_FUNCTIONS = [
 def run_creation(topic: str, create_course_outline: HeliconeNode):
 
     _course_outline = openai.ChatCompletion.create(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         messages=[
             {"role": "user", "content": f"Generate a course outline on {topic}"}
         ],
@@ -128,7 +128,7 @@ def run_creation(topic: str, create_course_outline: HeliconeNode):
     chapters = []
     for chapter in course_outline["chapters"]:
         _chapter = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
+            model="gpt-4o-mini",
             messages=[
                 {"role": "user",
                     "content": f"Generate a chapter outline on {chapter['name']}, with description {chapter['description']}"}
@@ -156,7 +156,7 @@ def run_creation(topic: str, create_course_outline: HeliconeNode):
             sections = []
             for section in chapter["sections"]:
                 _section = openai.ChatCompletion.create(
-                    model="gpt-3.5-turbo",
+                    model="gpt-4o-mini",
                     messages=[
                         {"role": "user",
                             "content": f"Generate a section outline on {section['name']}, with description {section['description']}"}

--- a/docs/features/jobs/quick-start.mdx
+++ b/docs/features/jobs/quick-start.mdx
@@ -33,7 +33,7 @@ description: "A Job is an assembly of nodes that can be interconnected and evalu
     )
 
     openai.ChatCompletion.create(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         messages=[
             {"role": "user", "content": f"Hello!"}
         ],
@@ -55,8 +55,8 @@ description: "A Job is an assembly of nodes that can be interconnected and evalu
 ```bash
 curl --request POST \
 --url https://api.helicone.ai/job \
---header 'Authorization: Bearer <HELICONE_API_KEY>' \
---header 'Content-Type: application/json' \
+--header "Authorization: Bearer $HELICONE_API_KEY" \
+--header "Content-Type: application/json" \
 --data '{
 "name": "My Job",
 	"description": "This is my job",

--- a/docs/features/prompts-legacy/editor.mdx
+++ b/docs/features/prompts-legacy/editor.mdx
@@ -163,8 +163,8 @@ Bash exmaple
 ```bash
 curl --request POST \
   --url https://api.helicone.ai/v1/prompt/helicone-test/compile \
-  --header 'Content-Type: application/json' \
-  --header 'authorization: sk-helicone-n4vqkhi-gg6exli-teictoi-aw7azyy' \
+  --header "Content-Type: application/json" \
+  --header "authorization: $HELICONE_API_KEY" \
   --data '{
   "filter": "all",
   "includeExperimentVersions": false,

--- a/docs/features/prompts-legacy/import.mdx
+++ b/docs/features/prompts-legacy/import.mdx
@@ -268,7 +268,7 @@ Let's say we have an app that generates a short story, where users are able to i
             content: hpf`Write a story about ${{ character }}`,
           },
         ],
-        model: "gpt-3.5-turbo",
+        model: "gpt-4o-mini",
       },
       {
         // 4. Add Prompt Id Header
@@ -287,7 +287,7 @@ Let's say we have an app that generates a short story, where users are able to i
     from helicone_prompts import hpf, hpstatic
 
     response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         messages=[
             {
                 "role": "system",

--- a/docs/features/streaming.mdx
+++ b/docs/features/streaming.mdx
@@ -20,7 +20,7 @@ In this mode, the request is made synchronously, but the response is streamed.
 
 ```python
 for chunk in openai.ChatCompletion.create(
-    model = 'gpt-3.5-turbo',
+    model = 'gpt-4o-mini',
     messages = [{
         'role': 'user',
         'content': "Hello World!"
@@ -38,7 +38,7 @@ In this mode, both the request is made asynchronously and the response is stream
 
 ```python
 for chunk in await openai.ChatCompletion.acreate(
-    model = 'gpt-3.5-turbo',
+    model = 'gpt-4o-mini',
     messages = [{
         'role': 'user',
         'content': "Hello World!"

--- a/docs/getting-started/integration-method/anthropic.mdx
+++ b/docs/getting-started/integration-method/anthropic.mdx
@@ -54,44 +54,36 @@ max_tokens_to_sample: 300,
 
 </Tab>
 <Tab title="cURL">
-  **Replace the Anthropic Base url with Helicone's**
-```
-
-- POST https://api.anthropic.com
-
-* POST https://anthropic.helicone.ai/v1
-
-```
-
-**Add a Helicone-Auth header into the requests**
-
-```
-
-"Helicone-Auth": "Bearer HELICONE_API_KEY"
-
-```
 
 Example cURL command
 
-<Note>Please make sure to replace API keys with your own</Note>
+<Note>Please make sure to set environment variables for your API keys</Note>
 
 ```
 
 curl --request POST \
- --url https://anthropic.helicone.ai/v1/complete \
- --header 'Content-Type: application/json' \
- --header 'Helicone-Auth: Bearer <<HELICONE_API_KEY>> \
- --header 'x-api-key: <<ANTHROPIC_API_KEY>> \
- --data '{
-"prompt": "\n\nHuman: Tell me a haiku about trees\n\nAssistant:",
-"model": "claude-v1-100k",
-"max_tokens_to_sample": 300,
-"stop_sequences": [
-"\n\nHuman:"
-]
+      --url https://anthropic.helicone.ai/v1/messages \
+      --header 'Content-Type: application/json' \
+      --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+      --header 'anthropic-version: 2023-06-01' \
+      --header "x-api-key: $ANTHROPIC_API_KEY" \
+      --data '{
+        "model": "claude-3-opus-20240229",
+        "max_tokens": 50,
+        "system": "Respond only in Spanish.",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Test"
+                    }
+                ]
+            }
+        ]
 }'
-
-````
+```
 
    </Tab>
 

--- a/docs/getting-started/integration-method/azure.mdx
+++ b/docs/getting-started/integration-method/azure.mdx
@@ -126,7 +126,7 @@ messages = [{
     'role': 'user',
     'content': "Hello World!"
 }],
-max_tokens=15,
+max_tokens=30,
 )
 
 ```
@@ -181,11 +181,11 @@ headers=helicone_headers,
 <Tab title="cURL">
   ```bash
     curl --request POST \
-    --url https://oai.helicone.ai/openai/deployments/DEPLOYMENTNAME/chat/completions?api-version=[API_VERSION] \
-    --header 'Helicone-Auth: Bearer [HELICONE_KEY]' \
-    --header 'Helicone-OpenAI-Api-Base: https://[AZUREDOMAIN].openai.azure.com' \
-    --header 'api-key: [AZURE_API_KEY]' \
-    --header 'content-type: application/json' \
+    --url "https://oai.helicone.ai/openai/deployments/$DEPLOYMENT_NAME/chat/completions?api-version=$API_VERSION" \
+    --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+    --header "Helicone-OpenAI-Api-Base: https://$AZURE_DOMAIN.openai.azure.com" \
+    --header "api-key: $AZURE_API_KEY" \
+    --header "content-type: application/json" \
     --data '{
       "messages": [
         {
@@ -194,7 +194,7 @@ headers=helicone_headers,
         }],
       "max_tokens": 800,
       "temperature": 1,
-      "model": "gpt-3.5-turbo-0613"
+      "model": "gpt-4o-mini-0613"
     }'
   ```
 </Tab>

--- a/docs/getting-started/integration-method/deepseek.mdx
+++ b/docs/getting-started/integration-method/deepseek.mdx
@@ -44,14 +44,22 @@ Now you can access all the models on DeepSeek AI with a simple fetch call:
 ## Example
 
 ```bash
-curl \
-  --header 'Authorization: Bearer <DEEPSEEK_API_KEY>' \
-  --header 'Content-Type: application/json' \
-  --data '{
-    "model": "deepseek-chat",
-    "messages": [{"role": "user", "content": "Say this is a test"}]
-}' \
-  --url https://deepseek.helicone.ai/chat/completions
+curl --request POST \
+      --url https://deepseek.helicone.ai/chat/completions \
+      --header 'Content-Type: application/json' \
+      --header "Authorization: Bearer $DEEPSEEK_API_KEY" \
+      --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+      --data '{
+          "model": "deepseek-chat",
+          "messages": [
+              {
+                  "role": "system",
+                  "content": "Say Hello!"
+              }
+          ],
+          "temperature": 1,
+          "max_tokens": 30
+        }'
 ```
 
 For more information on how to use headers, see [Helicone Headers](https://docs.helicone.ai/helicone-headers/header-directory#utilizing-headers) docs.

--- a/docs/getting-started/integration-method/fireworks.mdx
+++ b/docs/getting-started/integration-method/fireworks.mdx
@@ -45,14 +45,15 @@ Now you can access all the models on FireworksAI with a simple fetch call:
 ## Example
 
 ```bash
-curl \
-  --header 'Authorization: Bearer <FIREWORKS_API_KEY>' \
-  --header 'Content-Type: application/json' \
+curl --request POST \
+  --url https://fireworks.helicone.ai/inference/v1/completions \
+  --header "Authorization: Bearer $FIREWORKS_API_KEY" \
+  --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+  --header "Content-Type: application/json" \
   --data '{
     "model": "accounts/fireworks/models/llama-v3-8b-instruct",
     "prompt": "Say this is a test"
-}' \
-  --url https://fireworks.helicone.ai/inference/v1/completions
+}'
 ```
 
 For more information on how to use headers, see [Helicone Headers](https://docs.helicone.ai/helicone-headers/header-directory#utilizing-headers) docs.

--- a/docs/getting-started/integration-method/gateway.mdx
+++ b/docs/getting-started/integration-method/gateway.mdx
@@ -130,12 +130,12 @@ from helicone.openai_proxy import openai
 openai.api_base = "https://gateway.helicone.ai"
 
 response = openai.ChatCompletion.create(
-  engine = 'gpt-35-turbo',
+  engine = 'gpt-4o-mini',
   messages = [{
       'role': 'user',
       'content': "Hello World!"
   }],
-  max_tokens=15,
+  max_tokens=30,
 )
 
 ```
@@ -180,10 +180,10 @@ llm = ChatOpenAI(
   ```bash
     curl --request POST \
     --url https://gateway.helicone.ai/v1/chat/completetions \
-    --header 'Helicone-Auth: Bearer [HELICONE_KEY]' \
-    --header 'Helicone-Target-Url: https://api.lemonfox.ai' \
-    --header 'Helicone-Target-Provider: LemonFox' \
-    --header 'content-type: application/json' \
+    --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+    --header "Helicone-Target-Url: https://api.lemonfox.ai" \
+    --header "Helicone-Target-Provider: LemonFox" \
+    --header "content-type: application/json" \
     --data '{
       "messages": [
         {
@@ -192,7 +192,7 @@ llm = ChatOpenAI(
         }],
       "max_tokens": 800,
       "temperature": 1,
-      "model": "gpt-3.5-turbo-0613"
+      "model": "gpt-4o-mini"
     }'
   ```
 </Tab>
@@ -206,11 +206,11 @@ Current gateway request
 
 ```bash
 curl --request POST \
-  --url https://gateway.ai.cloudflare.com/v1/[ACCOUNT-ID]/[GATEWAY-ID]/openai/chat/completions \
-  --header 'Authorization: Bearer <API_KEY>' \
-  --header 'Content-Type: application/json' \
+  --url "https://gateway.ai.cloudflare.com/v1/$ACCOUNT-ID/$GATEWAY-ID/openai/chat/completions" \
+  --header "Authorization: Bearer $API_KEY" \
+  --header "Content-Type: application/json" \
   -d ' {
-    "model": "gpt-3.5-turbo",
+    "model": "gpt-4o-mini",
     "messages": [
       {
         "role": "user",
@@ -225,13 +225,13 @@ Simply change `gateway.ai.cloudflare.com` to `gateway.helicone.ai` and add the f
 
 ```bash
 curl --request POST \
-  --url https://gateway.helicone.ai/v1/[ACCOUNT-ID]/[GATEWAY-ID]/openai/chat/completions \
-  --header 'Helicone-Auth: Bearer <Helicone_Auth>' \
-  --header 'Helicone-Target-Url: https://gateway.ai.cloudflare.com' \
-  --header 'Authorization: Bearer <API_KEY>' \
-  --header 'content-type: application/json' \
+  --url "https://gateway.helicone.ai/v1/$ACCOUNT-ID/$GATEWAY-ID/openai/chat/completions" \
+  --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+  --header "Helicone-Target-Url: https://gateway.ai.cloudflare.com" \
+  --header "Authorization: Bearer $API_KEY" \
+  --header "content-type: application/json" \
   -d '{
-    "model": "gpt-3.5-turbo",
+    "model": "gpt-4o-mini",
     "messages": [
       {
         "role": "user",
@@ -248,11 +248,11 @@ curl --request POST \
 ```bash
 curl --request POST \
   --url https://gateway.helicone.ai/v1/chat/completions \
-  --header 'Authorization: Bearer <TOGETHERAI_API_KEY>' \
-  --header 'Content-Type: application/json' \
-  --header 'Helicone-Auth: Bearer <HELICONE_API_KEY>' \
-  --header 'Helicone-Target-Provider: Together-AI' \
-  --header 'Helicone-Target-Url: https://api.together.xyz' \
+  --header "Authorization: Bearer $TOGETHERAI_API_KEY" \
+  --header "Content-Type: application/json" \
+  --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+  --header "Helicone-Target-Provider: Together-AI" \
+  --header "Helicone-Target-Url: https://api.together.xyz" \
   --data '{
   "model": "meta-llama/Llama-2-70b-chat-hf",
   "max_tokens": 512,
@@ -271,11 +271,11 @@ Gemini Pro
 
 ```bash
 curl --request POST \
-  --url https://gateway.helicone.ai/v1/projects/<PROJECT_ID>/locations/<LOCATION>/publishers/google/models/gemini-pro:streamGenerateContent \
-  --header 'Authorization: Bearer <GEMINI_API_KEY>' \
-  --header 'Content-Type: application/json' \
-  --header 'Helicone-Auth: Bearer <HELICONE_API_KEY>' \
-  --header 'Helicone-Target-Url: https://<LOCATION>-aiplatform.googleapis.com' \
+  --url "https://gateway.helicone.ai/v1/projects/$PROJECT_ID/locations/$LOCATION/publishers/google/models/gemini-pro:streamGenerateContent" \
+  --header "Authorization: Bearer $GEMINI_API_KEY" \
+  --header "Content-Type: application/json" \
+  --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+  --header "Helicone-Target-Url: https://$LOCATION-aiplatform.googleapis.com" \
   --data '{
   "contents": {
     "role": "user",
@@ -290,11 +290,11 @@ Gemini Pro Vision
 
 ```bash
 curl --request POST \
-  --url https://gateway.helicone.ai/v1/projects/<PROJECT_ID>/locations/<LOCATION>/publishers/google/models/gemini-pro-vision:streamGenerateContent \
-  --header 'Authorization: Bearer <GEMINI_API_KEY>' \
-  --header 'Content-Type: application/json' \
-  --header 'Helicone-Auth: Bearer <HELICONE_API_KEY>' \
-  --header 'Helicone-Target-Url: https://<LOCATION>-aiplatform.googleapis.com' \
+  --url https://gateway.helicone.ai/v1/projects/$PROJECT_ID/locations/$LOCATION/publishers/google/models/gemini-pro-vision:streamGenerateContent \
+  --header "Authorization: Bearer $GEMINI_API_KEY" \
+  --header "Content-Type: application/json" \
+  --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+  --header "Helicone-Target-Url: https://$LOCATION-aiplatform.googleapis.com" \
   --data '{
   "contents": {
     "role": "user",
@@ -348,7 +348,7 @@ To protect our community from potential threats, we have certain restrictions fo
 The integration is the same as the approved domains, but you will need to add the following header:
 
 ```bash
---header 'Helicone-Target-Url: https://[DOMAIN_NAME]'
+--header "Helicone-Target-Url: https://[DOMAIN_NAME]"
 ```
 
 ## Automated Mappers ("Model is pending mapping")

--- a/docs/getting-started/integration-method/hyperbolic.mdx
+++ b/docs/getting-started/integration-method/hyperbolic.mdx
@@ -77,9 +77,10 @@ main();
 
 ```bash cURL
 curl --request POST \
-    --url https://hyperbolic.helicone.ai/v1/${process.env.HELICONE_WRITE_API_KEY}/chat/completions \
-    --header 'Authorization: Bearer <<HYPERBOLIC_API_KEY>>' \
-    --header 'Content-Type: application/json' \
+    --url "https://hyperbolic.helicone.ai/v1/$HELICONE_WRITE_API_KEY/chat/completions" \
+    --header "Authorization: Bearer $HYPERBOLIC_API_KEY" \
+    --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+    --header "Content-Type: application/json" \
     --data '{
         "messages": [
             {

--- a/docs/getting-started/integration-method/litellm-openllmetry.mdx
+++ b/docs/getting-started/integration-method/litellm-openllmetry.mdx
@@ -36,7 +36,7 @@ client = OpenAI(api_key=OPENAI_API_KEY)
 
 #openai call
 response = completion(
-  model="gpt-3.5-turbo",
+  model="gpt-4o-mini",
   messages=[{"role": "user", "content": "Hi 👋 - i'm openai"}],
   metadata={
     "Helicone-Property-Hello": "World"

--- a/docs/getting-started/integration-method/litellm-proxy.mdx
+++ b/docs/getting-started/integration-method/litellm-proxy.mdx
@@ -43,7 +43,7 @@ Helicone offers native proxy support for OpenAI and Azure through LiteLLM. This 
 
    ```python
    response = litellm.completion(
-       model="gpt-3.5-turbo",
+       model="gpt-4o-mini",
        messages=[{"role": "user", "content": "how does a court case get to the Supreme Court?"}],
        metadata={
            "Helicone-Property-Hello": "World"

--- a/docs/getting-started/integration-method/litellm.mdx
+++ b/docs/getting-started/integration-method/litellm.mdx
@@ -43,7 +43,7 @@ litellm.success_callback=["helicone"]
 
 #openai call
 response = completion(
-  model="gpt-3.5-turbo",
+  model="gpt-4o-mini",
   messages=[{"role": "user", "content": "Hi 👋 - i'm openai"}],
   metadata={
     "Helicone-Property-Hello": "World"

--- a/docs/getting-started/integration-method/manual-logger-curl.mdx
+++ b/docs/getting-started/integration-method/manual-logger-curl.mdx
@@ -76,8 +76,8 @@ Here's a complete example of logging a request to a custom model:
 
 ```bash
 curl -X POST https://api.worker.helicone.ai/custom/v1/log \
--H 'Authorization: Bearer your_api_key' \
--H 'Content-Type: application/json' \
+-H "Authorization: Bearer your_api_key" \
+-H "Content-Type: application/json" \
 -d '{
   "providerRequest": {
     "url": "custom-model-nopath",

--- a/docs/getting-started/integration-method/manual-logger-python.mdx
+++ b/docs/getting-started/integration-method/manual-logger-python.mdx
@@ -361,7 +361,7 @@ client = openai.OpenAI(api_key="your-openai-api-key")
 
 # Define your request
 request_body = {
-    "model": "gpt-3.5-turbo",
+    "model": "gpt-4o-mini",
     "messages": [{"role": "user", "content": "Write a story about a robot"}],
     "stream": True,
     "stream_options": {

--- a/docs/getting-started/integration-method/mistral.mdx
+++ b/docs/getting-started/integration-method/mistral.mdx
@@ -45,8 +45,8 @@ Now you can access all the models on Mistral AI with a simple fetch call:
 
 ```bash
 curl \
-  --header 'Authorization: Bearer <MISTRAL_API_KEY>' \
-  --header 'Content-Type: application/json' \
+  --header "Authorization: Bearer $MISTRAL_API_KEY" \
+  --header "Content-Type: application/json" \
   --data '{
     "model": "mistral-large-latest",
     "messages": [{"role": "user", "content": "Say this is a test"}]

--- a/docs/getting-started/integration-method/nebius.mdx
+++ b/docs/getting-started/integration-method/nebius.mdx
@@ -45,8 +45,8 @@ Now you can access all the models on Nebius AI with a simple fetch call:
 
 ```bash
 curl \
-  --header 'Authorization: Bearer <NEBIUS_API_KEY>' \
-  --header 'Content-Type: application/json' \
+  --header "Authorization: Bearer $NEBIUS_API_KEY" \
+  --header "Content-Type: application/json" \
   --data '{
     "model": "stable-diffusion-xl",
     "prompt": "A beautiful sunset over a mountain landscape"

--- a/docs/getting-started/integration-method/novita.mdx
+++ b/docs/getting-started/integration-method/novita.mdx
@@ -45,8 +45,8 @@ Now you can access all the models on Novita AI with a simple fetch call:
 
 ```bash
 curl \
-  --header 'Authorization: Bearer <NOVITA_API_KEY>' \
-  --header 'Content-Type: application/json' \
+  --header "Authorization: Bearer $NOVITA_API_KEY" \
+  --header "Content-Type: application/json" \
   --data '{
     "model": "deepseek/deepseek-r1",
     "messages": [

--- a/docs/getting-started/integration-method/openai-proxy.mdx
+++ b/docs/getting-started/integration-method/openai-proxy.mdx
@@ -183,7 +183,7 @@ const openai = new OpenAI({
       });
 
       const chatCompletion = await openai.chat.completion.create({
-        model: "gpt-3.5-turbo",
+        model: "gpt-4o-mini",
         messages: [{ role: "user", content: "Hello world" }],
       });
 
@@ -197,7 +197,7 @@ const openai = new OpenAI({
 
     ```typescript
     const { data, response } = await openai.chat.completion.create({
-      model: "gpt-3.5-turbo",
+      model: "gpt-4o-mini",
       messages: [{ role: "user", content: "Hello world" }],
     }).withResponse();
 
@@ -248,11 +248,11 @@ Here is an example cURL command:
   ```bash
         curl --request POST \
             --url https://oai.helicone.ai/v1/chat/completions \
-            --header 'Authorization: Bearer <<YOUR_OPENAI_API_KEY>>' \
-            --header 'Content-Type: application/json' \
-            --header 'Helicone-Auth: Bearer <<YOUR_HELICONE_API_KEY>>' \
+            --header "Authorization: Bearer $OPENAI_API_KEY" \
+            --header "Content-Type: application/json" \
+            --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
             --data '{
-                "model": "gpt-3.5-turbo",
+                "model": "gpt-4o-mini",
                 "messages": [
                     {
                         "role": "system",
@@ -260,7 +260,7 @@ Here is an example cURL command:
                     }
                 ],
                 "temperature": 1,
-                "max_tokens": 10
+                "max_tokens": 30
         }'
   ```
 
@@ -298,7 +298,7 @@ Modify the API base and add a Helicone-Auth header
 
     ```typescript
     const llm = new OpenAI({
-      modelName: "gpt-3.5-turbo",
+      modelName: "gpt-4o-mini",
       configuration: {
         basePath: "https://oai.helicone.ai/v1",
         defaultHeaders: {

--- a/docs/getting-started/integration-method/openai.mdx
+++ b/docs/getting-started/integration-method/openai.mdx
@@ -43,7 +43,7 @@ from helicone.openai_async import openai, Meta
 # helicone_global.api_key = "sk-<your-api-key>"
 
 x = openai.ChatCompletion.create(
-  model="gpt-3.5-turbo",
+  model="gpt-4o-mini",
   messages=[{
   "role": "system",
   "content": "This will be logged"
@@ -97,7 +97,7 @@ x = openai.ChatCompletion.create(
       });
 
       const chatCompletion = await openai.chat.completion.create({
-        model: "gpt-3.5-turbo",
+        model: "gpt-4o-mini",
         messages: [{ role: "user", content: "Hello world" }],
       });
 
@@ -212,8 +212,8 @@ Here's an example using curl:
 
 ```sh
 curl -X POST https://api.helicone.ai/oai/v1/log \
--H 'Authorization: Bearer your_api_key' \
--H 'Content-Type: application/json' \
+-H "Authorization: Bearer your_api_key" \
+-H "Content-Type: application/json" \
 -d '{
   "providerRequest": {
     "url": "https://example.com",

--- a/docs/getting-started/integration-method/openllmetry.mdx
+++ b/docs/getting-started/integration-method/openllmetry.mdx
@@ -45,7 +45,7 @@ path. This ensures that an issue with Helicone will not cause an outage to your 
               {"role": "assistant", "content": "The Los Angeles Dodgers won the World Series in 2020."},
               {"role": "user", "content": "Where was it played?"}
             ],
-            model: "gpt-3.5-turbo",
+            model: "gpt-4o-mini",
           });
 
           console.log(completion.choices[0]);
@@ -96,7 +96,7 @@ path. This ensures that an issue with Helicone will not cause an outage to your 
 
         # Make the OpenAI call
         response = client.chat.completions.create(
-          model="gpt-3.5-turbo",
+          model="gpt-4o-mini",
           messages=[
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "Who won the world series in 2020?"},

--- a/docs/getting-started/integration-method/openrouter.mdx
+++ b/docs/getting-started/integration-method/openrouter.mdx
@@ -57,7 +57,7 @@ fetch("https://openrouter.helicone.ai/api/v1/chat/completions", {
     "Content-Type": "application/json",
   },
   body: JSON.stringify({
-    model: "openai/gpt-3.5-turbo", // Optional (user controls the default),
+    model: "openai/gpt-4o-mini", // Optional (user controls the default),
     messages: [{ role: "user", content: "What is the meaning of life?" }],
     stream: true,
   }),

--- a/docs/getting-started/integration-method/perplexity.mdx
+++ b/docs/getting-started/integration-method/perplexity.mdx
@@ -44,14 +44,15 @@ Now you can access all the models on Perplexity AI with a simple fetch call:
 ## Example
 
 ```bash
-curl \
-  --header 'Authorization: Bearer <PERPLEXITY_API_KEY>' \
-  --header 'Content-Type: application/json' \
+curl --request POST \
+  --url https://perplexity.helicone.ai/chat/completions \
+  --header "Authorization: Bearer $PERPLEXITY_API_KEY" \
+  --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+  --header "Content-Type: application/json" \
   --data '{
     "model": "sonar-pro",
     "messages": [{"role": "user", "content": "Say this is a test"}]
-}' \
-  --url https://perplexity.helicone.ai/chat/completions
+}'
 ```
 
 For more information on how to use headers, see [Helicone Headers](https://docs.helicone.ai/helicone-headers/header-directory#utilizing-headers) docs.

--- a/docs/getting-started/integration-method/posthog.mdx
+++ b/docs/getting-started/integration-method/posthog.mdx
@@ -53,13 +53,13 @@ description: "Combine Helicone's LLM analytics with PostHog, a comprehensive pro
     		```bash
     		curl --request POST \
     			--url https://oai.helicone.ai/v1/chat/completions \
-    			--header 'Authorization: Bearer <<YOUR_OPENAI_API_KEY>>' \
-    			--header 'Content-Type: application/json' \
-    			--header 'Helicone-Posthog-Key: Bearer <ph_project_api_key>' \
-    			--header 'Helicone-Posthog-Host: Bearer <ph_client_api_host>' \
-    			--header 'Helicone-Auth: Bearer <<YOUR_HELICONE_API_KEY>>' \
+    			--header "Authorization: Bearer $OPENAI_API_KEY" \
+    			--header "Content-Type: application/json" \
+    			--header "Helicone-Posthog-Key: Bearer $POSTHOG_PROJECT_API_KEY" \
+    			--header "Helicone-Posthog-Host: Bearer $POSTHOG_CLIENT_API_HOST" \
+    			--header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
     			--data '{
-    				"model": "gpt-3.5-turbo",
+    				"model": "gpt-4o-mini",
     				"messages": [
     					{
     						"role": "system",
@@ -67,7 +67,7 @@ description: "Combine Helicone's LLM analytics with PostHog, a comprehensive pro
     					}
     				],
     				"temperature": 1,
-    				"max_tokens": 10
+    				"max_tokens": 30
     			}'
     		```
     	</Tab>

--- a/docs/getting-started/integration-method/vercel-ai-gateway.mdx
+++ b/docs/getting-started/integration-method/vercel-ai-gateway.mdx
@@ -217,7 +217,7 @@ The `@ai-sdk/gateway` integration (recommended) supports all Vercel AI Gateway f
         'Authorization': `Bearer ${process.env.VERCEL_AI_GATEWAY_API_KEY}`,
       },
       body: JSON.stringify({
-        model: 'openai/gpt-3.5-turbo',
+        model: 'openai/gpt-4o-mini',
         messages: [
           { role: 'user', content: 'What is the meaning of life?' }
         ],

--- a/docs/getting-started/integration-method/x.mdx
+++ b/docs/getting-started/integration-method/x.mdx
@@ -18,10 +18,10 @@ You can follow their documentation here: [https://api-docs.x.ai/](https://api-do
     Log into https://console.x.ai/ or create an account. Once you have an account, you
     can generate an API key from your dashboard.
   </Step>
-  <Step title="Set HELICONE_API_KEY and X_API_KEY as environment variable">
+  <Step title="Set HELICONE_API_KEY and XAI_API_KEY as environment variables">
 ```javascript
 HELICONE_API_KEY=<your API key>
-X_API_KEY=<your API key>
+XAI_API_KEY=<your API key>
 ```
   </Step>
   <Step title="Modify the base URL and add Auth headers">
@@ -33,7 +33,8 @@ Replace the following X AI URL with the Helicone Gateway URL:
 and then add the following authentication headers:
 
 ```javascript
-Authorization: Bearer <your API key>
+Authorization: Bearer $XAI_API_KEY
+Helicone-Auth: Bearer $HELICONE_API_KEY
 ```
 
 </Step>
@@ -44,14 +45,25 @@ Now you can access all the models on X AI with a simple fetch call:
 ## Example
 
 ```bash
-curl \
-  --header 'Authorization: Bearer <X_API_KEY>' \
-  --header 'Content-Type: application/json' \
-  --data '{
-    "model": "grok-beta",
-    "messages": [{"role": "user", "content": "Say this is a test"}]
-}' \
-  --url https://x.helicone.ai/chat/completions
+curl --request POST \
+      --url https://x.helicone.ai/v1/chat/completions \
+      --header "Content-Type: application/json" \
+      --header "Authorization: Bearer $XAI_API_KEY" \
+      --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+      --data '{
+          "model": "grok-4-latest",
+          "messages": [
+              {
+                  "role": "system",
+                  "content": "You are a robot called Marvin with a brain the size of the planet."
+              },
+              {
+                  "role": "user",
+                  "content": "Say this is a test"
+              }
+          ],
+          "temperature": 1
+        }'
 ```
 
 For more information on how to use headers, see [Helicone Headers](https://docs.helicone.ai/helicone-headers/header-directory#utilizing-headers) docs.

--- a/docs/getting-started/self-host/cloud.mdx
+++ b/docs/getting-started/self-host/cloud.mdx
@@ -74,11 +74,11 @@ curl localhost:8787/helicone/test
 # Example log command
 curl --request POST \
     --url http://localhost:8787/v1/chat/completions \
-    --header 'Authorization: Bearer <<YOUR_OPENAI_API_KEY>>' \
-    --header 'Content-Type: application/json' \
-    --header 'Helicone-Auth: Bearer <<YOUR_HELICONE_API_KEY>>' \
+    --header "Authorization: Bearer <<YOUR_OPENAI_API_KEY>>" \
+    --header "Content-Type: application/json" \
+    --header "Helicone-Auth: Bearer <<YOUR_HELICONE_API_KEY>>" \
     --data '{
-        "model": "gpt-3.5-turbo",
+        "model": "gpt-4o-mini",
         "messages": [
             {
                 "role": "system",
@@ -86,7 +86,7 @@ curl --request POST \
             }
         ],
         "temperature": 1,
-        "max_tokens": 10
+        "max_tokens": 30
  }'
 ```
 

--- a/docs/getting-started/self-host/docker.mdx
+++ b/docs/getting-started/self-host/docker.mdx
@@ -15,9 +15,9 @@ docker run -d --name helicone-all-in-one -p 3000:3000 -p 8585:8585 -p 5432:5432 
 ## Example to test the Jawn service
 ```bash
 curl --location 'https://localhost:8585/jawn/v1/gateway/oai/v1/completions' \
---header 'Content-Type: application/json' \
---header 'Authorization: Bearer {{OPENAI_API_KEY}}' \
---header 'Helicone-Auth: Bearer {{HELICONE_API_KEY}}' \
+--header "Content-Type: application/json" \
+--header "Authorization: Bearer {{OPENAI_API_KEY}}" \
+--header "Helicone-Auth: Bearer {{HELICONE_API_KEY}}" \
 --data '{
     "model": "gpt-4o-mini",
     "prompt": "Count to 5",

--- a/docs/getting-started/self-host/manual.mdx
+++ b/docs/getting-started/self-host/manual.mdx
@@ -103,9 +103,9 @@ curl --request POST \
   --url http://localhost:8585/v1/gateway/oai/v1/chat/completions \
   --header "Authorization: Bearer $OPENAI_API_KEY" \
   --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
-  --header 'Content-Type: application/json' \
-  --header 'Accept-Encoding: identity' \
-  --header 'helicone-property-hello: world' \
+  --header "Content-Type: application/json" \
+  --header "Accept-Encoding: identity" \
+  --header "helicone-property-hello: world" \
   --data '{
     "model": "gpt-4o-mini",
     "messages": [

--- a/docs/guides/cookbooks/getting-user-requests.mdx
+++ b/docs/guides/cookbooks/getting-user-requests.mdx
@@ -30,8 +30,8 @@ Here's an example to get all the requests where `user_id` is `abc@email.com`.
 ```bash
 curl --request POST \
   --url https://api.helicone.ai/v1/request/query \
-  --header 'Content-Type: application/json' \
-  --header 'authorization: Bearer sk-<your-helicone-api-key>' \
+  --header "Content-Type: application/json" \
+  --header "authorization: Bearer $HELICONE_API_KEY" \
   --data '{
   "filter": {
     "request": {
@@ -57,8 +57,8 @@ You can structure your query to add any number of filters.
 ```bash
 curl --request POST \
   --url https://api.helicone.ai/v1/request/query \
-  --header 'Content-Type: application/json' \
-  --header 'authorization: Bearer sk-<your-helicone-api-key>' \
+  --header "Content-Type: application/json" \
+  --header "authorization: Bearer $HELICONE_API_KEY" \
   --data '{
   "filter": {
     "operator": "and",

--- a/docs/guides/cookbooks/replay-session.mdx
+++ b/docs/guides/cookbooks/replay-session.mdx
@@ -48,7 +48,7 @@ Understanding how changes impact your AI agents in real-world interactions is cr
 
     ````javascript Including Helicone Session Headers
     const completionParams = {
-      model: "gpt-3.5-turbo",
+      model: "gpt-4o-mini",
       messages: conversation,
     };
 
@@ -123,7 +123,7 @@ Understanding how changes impact your AI agents in real-world interactions is cr
       sessionPath
     ) {
       const completionParams = {
-        model: "gpt-3.5-turbo",
+        model: "gpt-4o-mini",
         messages: conversation,
       };
 
@@ -166,8 +166,8 @@ Understanding how changes impact your AI agents in real-world interactions is cr
     ````bash Querying Session Data
     curl --request POST \
       --url https://api.helicone.ai/v1/request/query \
-      --header 'Content-Type: application/json' \
-      --header 'authorization: Bearer sk-<your-helicone-api-key>' \
+      --header "Content-Type: application/json" \
+      --header "authorization: Bearer $HELICONE_API_KEY" \
       --data '{
         "limit": 100,
         "offset": 0,

--- a/docs/helicone-headers/header-directory.mdx
+++ b/docs/helicone-headers/header-directory.mdx
@@ -8,10 +8,10 @@ description: "Comprehensive guide to all Helicone headers. Learn how to access a
 <CodeGroup>
 
 ```bash Curl
-curl https://gateway.helicone.ai/v1/completions \
-  -H 'Content-Type: application/json' \
-  -H 'Helicone-Auth: Bearer HELICONE_API_KEY' \ # required header
-  -H 'Helicone-<HEADER>: <VALUE>' # all headers will follow this format
+curl https://gateway.helicone.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+  -H "Helicone-<HEADER>: <VALUE>"
   -d ...
 ```
 

--- a/docs/integrations/anthropic/curl.mdx
+++ b/docs/integrations/anthropic/curl.mdx
@@ -25,14 +25,14 @@ import { strings } from "/snippets/strings.mdx";
     ```bash
     curl --request POST \
       --url https://anthropic.helicone.ai/v1/messages \
-      --header 'Content-Type: application/json' \
-      --header 'Helicone-Auth: Bearer <<YOUR_HELICONE_API_KEY>>' \
-      --header 'User-Agent: insomnia/8.6.1' \
-      --header 'anthropic-version: 2023-06-01' \
-      --header 'x-api-key: <<YOUR_ANTHROPIC_API_KEY>>' \
+      --header "Content-Type: application/json" \
+      --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+      --header "User-Agent: insomnia/8.6.1" \
+      --header "anthropic-version: 2023-06-01" \
+      --header "x-api-key: $ANTHROPIC_API_KEY" \
       --data '{
             "model": "claude-3-opus-20240229",
-            "max_tokens": 1,
+            "max_tokens": 50,
             "system": "Respond only in Spanish.",
             "messages": [
                 {

--- a/docs/integrations/azure/curl.mdx
+++ b/docs/integrations/azure/curl.mdx
@@ -20,11 +20,11 @@ import { strings } from "/snippets/strings.mdx";
   <Step title={strings.modifyBasePath}>
     ```bash
     curl --request POST \
-        --url https://oai.helicone.ai/openai/deployments/[DEPLOYMENT_NAME]/chat/completions?api-version=[API_VERSION] \
-        --header 'Helicone-Auth: Bearer [HELICONE_KEY]' \
-        --header 'Helicone-OpenAI-Api-Base: https://[AZUREDOMAIN].azure.com' \
-        --header 'api-key: [AZURE_API_KEY]' \
-        --header 'content-type: application/json' \
+        --url "https://oai.helicone.ai/openai/deployments/$DEPLOYMENT_NAME/chat/completions?api-version=$API_VERSION" \
+        --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+        --header "Helicone-OpenAI-Api-Base: https://$AZURE_DOMAIN.azure.com" \
+        --header "api-key: $AZURE_API_KEY" \
+        --header "content-type: application/json" \
         --data '{
             "messages": [
                 {
@@ -34,7 +34,7 @@ import { strings } from "/snippets/strings.mdx";
             ],
             "max_tokens": 800,
             "temperature": 1,
-            "model": "gpt-3.5-turbo-0613"
+            "model": "gpt-4o-mini-0613"
         }'
     ```
   </Step>

--- a/docs/integrations/gemini/api/curl.mdx
+++ b/docs/integrations/gemini/api/curl.mdx
@@ -28,9 +28,9 @@ iconType: "solid"
     Use the following cURL command to send a request to the Google Generative AI API through the Helicone proxy:
     ```bash
     curl --request POST \
-      --url "https://gateway.helicone.ai/v1beta/models/model-name:generateContent?key=${GOOGLE_GENERATIVE_API_KEY}" \
+      --url "https://gateway.helicone.ai/v1beta/models/$MODEL_NAME:generateContent?key=$GOOGLE_GENERATIVE_API_KEY" \
       --header "Content-Type: application/json" \
-      --header "Helicone-Auth: Bearer ${HELICONE_API_KEY}" \
+      --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
       --header "Helicone-Target-URL: https://generativelanguage.googleapis.com" \
       --data '{
         "contents": [{

--- a/docs/integrations/gemini/vertex/curl.mdx
+++ b/docs/integrations/gemini/vertex/curl.mdx
@@ -24,12 +24,12 @@ iconType: "solid"
     Use the following CURL command to send a request to the Vertex AI API through the Helicone proxy:
     ```bash
     curl --request POST \
-      --url https://gateway.helicone.ai/v1/projects/your-project-id/locations/your-location/publishers/google/models/model-name:streamGenerateContent \
-      --header 'Authorization: Bearer ${GCLOUD_API_KEY}' \
-      --header 'Content-Type: application/json' \
-      --header 'Helicone-Auth: Bearer ${HELICONE_API_KEY}' \
-      --header 'Helicone-Target-URL: https://${LOCATION}-aiplatform.googleapis.com' \
-      --header 'User-Agent: curl/7.64.1' \
+      --url "https://gateway.helicone.ai/v1/projects/$PROJECT_ID/locations/$LOCATION/publishers/google/models/$MODEL_NAME:streamGenerateContent" \
+      --header "Authorization: Bearer $GCLOUD_API_KEY" \
+      --header "Content-Type: application/json" \
+      --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+      --header "Helicone-Target-URL: https://$LOCATION-aiplatform.googleapis.com" \
+      --header "User-Agent: curl/7.64.1" \
       --data '{
       "contents": {
         "role": "user",

--- a/docs/integrations/openai/curl.mdx
+++ b/docs/integrations/openai/curl.mdx
@@ -20,11 +20,11 @@ import { strings } from "/snippets/strings.mdx";
     ```bash
     curl --request POST \
         --url https://oai.helicone.ai/v1/chat/completions \
-        --header 'Authorization: Bearer <<YOUR_OPENAI_API_KEY>>' \
-        --header 'Content-Type: application/json' \
-        --header 'Helicone-Auth: Bearer <<YOUR_HELICONE_API_KEY>>' \
+        --header "Authorization: Bearer $OPENAI_API_KEY" \
+        --header "Content-Type: application/json" \
+        --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
         --data '{
-            "model": "gpt-3.5-turbo",
+            "model": "gpt-4o-mini",
             "messages": [
                 {
                     "role": "system",
@@ -32,7 +32,7 @@ import { strings } from "/snippets/strings.mdx";
                 }
             ],
             "temperature": 1,
-            "max_tokens": 10
+            "max_tokens": 30
     }'
     ```
   </Step>

--- a/docs/integrations/tools/curl.mdx
+++ b/docs/integrations/tools/curl.mdx
@@ -10,8 +10,8 @@ iconType: "solid"
 
 ```bash
 curl -X POST https://api.worker.helicone.ai/custom/v1/log \
--H 'Authorization: Bearer your_api_key' \
--H 'Content-Type: application/json' \
+-H "Authorization: Bearer your_api_key" \
+-H "Content-Type: application/json" \
 -d '{
   "providerRequest": {
     "url": "custom-model-nopath",

--- a/docs/integrations/tools/logger-sdk.mdx
+++ b/docs/integrations/tools/logger-sdk.mdx
@@ -85,7 +85,7 @@ import { strings } from "/snippets/strings.mdx";
               "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`
             },
             body: JSON.stringify({
-              model: "gpt-3.5-turbo",
+              model: "gpt-4o-mini",
               messages: [
                 {
                   role: "user",
@@ -146,7 +146,7 @@ import { strings } from "/snippets/strings.mdx";
               "Authorization": f"Bearer {os.getenv('OPENAI_API_KEY')}"
           },
           json={
-              "model": "gpt-3.5-turbo",
+              "model": "gpt-4o-mini",
               "messages": [
                   {
                       "role": "user",

--- a/docs/integrations/vectordb/curl.mdx
+++ b/docs/integrations/vectordb/curl.mdx
@@ -12,8 +12,8 @@ import { strings } from "/snippets/strings.mdx";
 
 ```bash
 curl -X POST https://api.worker.helicone.ai/custom/v1/log \
--H 'Authorization: Bearer <YOUR_HELICONE_API_KEY>' \
--H 'Content-Type: application/json' \
+-H "Authorization: Bearer <YOUR_HELICONE_API_KEY>" \
+-H "Content-Type: application/json" \
 -d '{
   "providerRequest": {
     "url": "custom-model-nopath",

--- a/docs/integrations/xai/curl.mdx
+++ b/docs/integrations/xai/curl.mdx
@@ -1,0 +1,45 @@
+---
+title: "xAI cURL Integration"
+sidebarTitle: "cURL"
+description: "Use cURL to integrate xAI with Helicone to log your xAI LLM usage."
+"twitter:title": "xAI cURL Integration - Helicone OSS LLM Observability"
+icon: "code"
+iconType: "solid"
+---
+
+This integration is used to log usage with the [xAI](https://x.ai) API.
+
+import { strings } from "/snippets/strings.mdx";
+
+## {strings.howToIntegrate}
+
+<Steps>
+  <Step title={strings.generateKey}>
+      <div dangerouslySetInnerHTML={{ __html: strings.generateKeyInstructions }} />
+  </Step>
+<Step title={strings.modifyBasePath}>
+
+    ```bash
+    curl -X POST https://x.helicone.ai/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer $XAI_API_KEY" \
+      -H "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+      -d '{
+        "model": "grok-4-latest",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Hello, how are you?"
+          }
+        ],
+        "max_tokens": 50,
+        "temperature": 0.7
+      }'
+    ```
+
+  </Step>
+  
+  <Step title={strings.verifyInHelicone}>
+    <div dangerouslySetInnerHTML={{ __html: strings.verifyInHeliconeDesciption("xAI") }} />
+  </Step>
+</Steps> 

--- a/docs/integrations/xai/javascript.mdx
+++ b/docs/integrations/xai/javascript.mdx
@@ -1,0 +1,80 @@
+---
+title: "xAI with OpenAI JavaScript SDK"
+sidebarTitle: "JavaScript"
+description: "Use the OpenAI JavaScript SDK to integrate with xAI via Helicone to log your xAI usage."
+"twitter:title": "xAI with OpenAI JavaScript SDK - Helicone OSS LLM Observability"
+icon: "js"
+iconType: "solid"
+---
+
+import GenerateKey from "/snippets/generate-key.mdx";
+import { strings } from "/snippets/strings.mdx";
+
+This integration is used to log usage with the [xAI](https://x.ai) API.
+
+## {strings.howToIntegrate}
+
+<Steps>
+  <Step title={strings.generateKey}>
+    <div dangerouslySetInnerHTML={{ __html: strings.generateKeyInstructions }} />
+  </Step>
+
+  <Step title={strings.setApiKey}>
+    ```javascript
+    HELICONE_API_KEY=<your-helicone-api-key>
+    XAI_API_KEY=<your-xai-api-key>
+    ```
+  </Step>
+
+  <Step title={strings.modifyBasePath}>
+
+    ```javascript OpenAI SDK
+    import OpenAI from "openai";
+
+    const openai = new OpenAI({
+      apiKey: process.env.XAI_API_KEY,
+      baseURL: "https://x.helicone.ai/v1",
+      defaultHeaders: {
+        "Helicone-Auth": `Bearer ${process.env.HELICONE_API_KEY}`
+      }
+    });
+
+    const response = await openai.chat.completions.create({
+      model: "grok-4-latest",
+      messages: [{ role: "user", content: "Hello, how are you?" }],
+      max_tokens: 1024,
+      temperature: 0.7
+    });
+
+    console.log(response);
+    ```
+
+  </Step>
+
+  <Step title={strings.verifyInHelicone}>
+    <div dangerouslySetInnerHTML={{ __html: strings.verifyInHeliconeDesciption("xAI") }} />
+  </Step>
+</Steps>
+
+## {strings.relatedGuides}
+
+<CardGroup cols={2}>
+  <Card
+    title="Building a chatbot with structured outputs"
+    icon="lightbulb"
+    href="/guides/cookbooks/openai-structured-outputs"
+    iconType="light"
+    vertical
+  >
+    {strings.chatbotCookbookDescription}
+  </Card>
+  <Card
+    title="How to Prompt Thinking Models Effectively"
+    icon="arrows-rotate"
+    href="/guides/cookbooks/prompt-thinking-models"
+    iconType="light"
+    vertical
+  >
+    {strings.howToPromptThinkingModelsCookbookDescription}
+  </Card>
+</CardGroup> 

--- a/docs/integrations/xai/python.mdx
+++ b/docs/integrations/xai/python.mdx
@@ -1,0 +1,86 @@
+---
+title: "xAI with OpenAI Python SDK"
+sidebarTitle: "Python"
+description: "Use the OpenAI Python SDK to integrate with xAI via Helicone to log your xAI usage."
+"twitter:title": "xAI with OpenAI Python SDK - Helicone OSS LLM Observability"
+icon: "python"
+iconType: "solid"
+---
+
+import { strings } from "/snippets/strings.mdx";
+
+This integration is used to log usage with the [xAI](https://x.ai) API.
+
+## {strings.howToIntegrate}
+
+<Steps>
+  <Step title={strings.generateKey}>
+    <div dangerouslySetInnerHTML={{ __html: strings.generateKeyInstructions }} />
+  </Step>
+
+  <Step title={strings.setApiKey}>
+    ```bash
+    HELICONE_API_KEY=<your-helicone-api-key>
+    XAI_API_KEY=<your-xai-api-key>
+    ```
+  </Step>
+
+  <Step title={strings.modifyBasePath}>
+
+    ```python OpenAI SDK
+    from openai import OpenAI
+    from dotenv import load_dotenv
+    import os
+
+    load_dotenv()
+
+    helicone_api_key = os.getenv("HELICONE_API_KEY")
+    XAI_API_KEY = os.getenv("XAI_API_KEY")
+
+    client = OpenAI(
+      api_key=XAI_API_KEY,
+      base_url="https://x.helicone.ai/v1",
+      default_headers={
+        "Helicone-Auth": f"Bearer {helicone_api_key}"
+      }
+    )
+
+    chat_completion = client.chat.completions.create(
+      model="grok-4-latest",
+      messages=[{"role": "user", "content": "Hello, how are you?"}],
+      max_tokens=1024,
+      temperature=0.7
+    )
+
+    print(chat_completion)
+    ```
+
+  </Step>
+
+  <Step title={strings.verifyInHelicone}>
+    <div dangerouslySetInnerHTML={{ __html: strings.verifyInHeliconeDesciption("xAI") }} />
+  </Step>
+</Steps>
+
+## {strings.relatedGuides}
+
+<CardGroup cols={2}>
+  <Card
+    title="Building a chatbot with structured outputs"
+    icon="lightbulb"
+    href="/guides/cookbooks/openai-structured-outputs"
+    iconType="light"
+    vertical
+  >
+    {strings.chatbotCookbookDescription}
+  </Card>
+  <Card
+    title="How to Prompt Thinking Models Effectively"
+    icon="arrows-rotate"
+    href="/guides/cookbooks/prompt-thinking-models"
+    iconType="light"
+    vertical
+  >
+    {strings.howToPromptThinkingModelsCookbookDescription}
+  </Card>
+</CardGroup> 

--- a/docs/other-integrations/firecrawl.mdx
+++ b/docs/other-integrations/firecrawl.mdx
@@ -37,11 +37,11 @@ Firecrawl is a powerful web scraping and crawling tool designed for AI applicati
     ```bash
     curl --request POST \
       --url https://firecrawl.helicone.ai/v0/scrape \
-      --header 'Helicone-Auth: YOUR_HELICONE_API_KEY' \
-      --header 'Authorization: Bearer YOUR_FIRECRAWL_API_KEY' \
-      --header 'Helicone-Target-Url: https://api.firecrawl.dev' \
-      --header 'Helicone-Target-Provider: Firecrawl' \
-      --header 'content-type: application/json' \
+      --header "Helicone-Auth: YOUR_HELICONE_API_KEY" \
+      --header "Authorization: Bearer YOUR_FIRECRAWL_API_KEY" \
+      --header "Helicone-Target-Url: https://api.firecrawl.dev" \
+      --header "Helicone-Target-Provider: Firecrawl" \
+      --header "content-type: application/json" \
       --data '{
         "url": "firecrawl.dev"
       }'

--- a/docs/other-integrations/meta-gpt.mdx
+++ b/docs/other-integrations/meta-gpt.mdx
@@ -30,7 +30,7 @@ You can configure your metagpt `config.yaml` and change the base_url to the foll
 ```yaml config.yaml
 llm:
   api_type: "openai"
-  model: "gpt-4-turbo" # or gpt-3.5-turbo
+  model: "gpt-4-turbo" # or gpt-4o-mini
   base_url: "https://oai.helicone.ai/{HELICONE_API_KEY}/v1"
   api_key: "YOUR_API_KEY"
 ```

--- a/docs/other-integrations/upstash-rag.mdx
+++ b/docs/other-integrations/upstash-rag.mdx
@@ -45,7 +45,7 @@ Upstash RAG Chat is a TypeScript toolkit for building powerful retrieval-augment
     import { RAGChat, openai } from "@upstash/rag-chat";
 
     const ragChat = new RAGChat({
-      model: openai("gpt-3.5-turbo", {
+      model: openai("gpt-4o-mini", {
         apiKey: process.env.OPENAI_API_KEY!,
         analytics: { name: "helicone", token: process.env.HELICONE_API_KEY },
       }),

--- a/docs/references/proxy-vs-async.mdx
+++ b/docs/references/proxy-vs-async.mdx
@@ -58,7 +58,7 @@ Since the proxy sits on the edge and is the gatekeeper of the requests, you get 
 
     # Generate a chat completion request
     response = openai.ChatCompletion.create(
-        model="gpt-3.5-turbo",
+        model="gpt-4o-mini",
         messages=[{"role": "user", "content": "Say hi!"}],
         headers={
             "Helicone-Auth": "Bearer [HELICONE_API_KEY]"  # Your Helicone API key

--- a/examples/xai/package-lock.json
+++ b/examples/xai/package-lock.json
@@ -1,0 +1,275 @@
+{
+  "name": "xai-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "xai-example",
+      "version": "1.0.0",
+      "dependencies": {
+        "dotenv": "^17.2.1",
+        "openai": "^5.12.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "ts-node": "^10.9.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/openai": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.0.tgz",
+      "integrity": "sha512-vUdt02xiWgOHiYUmW0Hj1Qu9OKAiVQu5Bd547ktVCiMKC1BkB5L3ImeEnCyq3WpRKR6ZTaPgekzqdozwdPs7Lg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/examples/xai/package.json
+++ b/examples/xai/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "xai-example",
+  "version": "1.0.0",
+  "description": "xAI example Helicone integration",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "ts-node src/index.ts",
+    "dev": "ts-node src/index.ts",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "ts-node": "^10.9.0",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "dotenv": "^17.2.1",
+    "openai": "^5.12.0"
+  }
+}

--- a/examples/xai/src/index.ts
+++ b/examples/xai/src/index.ts
@@ -1,0 +1,30 @@
+import { OpenAI } from "openai";
+import { config } from "dotenv";
+config({
+  path: ".env",
+});
+
+async function main() {
+  const openai = new OpenAI({
+    apiKey: process.env.XAI_API_KEY,
+    baseURL: "https://x.helicone.ai/v1",
+    defaultHeaders: {
+      "Helicone-Auth": `Bearer ${process.env.HELICONE_API_KEY}`
+    }
+  });
+
+  try {
+    const response = await openai.chat.completions.create({
+      model: "grok-4-latest",
+      messages: [{ role: "user", content: "Hello, how are you?" }],
+      max_tokens: 1024,
+      temperature: 0.7
+    });
+
+    console.log(response);
+  } catch (error) {
+    console.error("Error creating completion:", error);
+  }
+}
+
+main();

--- a/examples/xai/tsconfig.json
+++ b/examples/xai/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
overhauls many of the examples by:

- fixing curl examples that were missing either the `authorization` header or the `helicone-auth` header
- updating examples that referenced deprecated models like gpt-3.5-turbo
- adding curl/javascript/python examples for xAI