### PR TITLE
fix: frozen lockfile issue, and speedup through multi stage builds

### DIFF
--- a/docker/dockerfiles/dockerfile_web
+++ b/docker/dockerfiles/dockerfile_web
@@ -1,17 +1,34 @@
-FROM node:20-bookworm-slim
-
-# Apply security updates
-RUN apt-get update && apt-get upgrade -y && apt-get autoremove -y && apt-get clean
+FROM node:20-bookworm-slim AS builder
 
 WORKDIR /app
 
 COPY package.json yarn.lock ./
+COPY packages/cost/package.json ./packages/cost/
+COPY packages/filters/package.json ./packages/filters/
+COPY packages/llm-mapper/package.json ./packages/llm-mapper/
+COPY packages/prompts/package.json ./packages/prompts/
+COPY web/package.json ./web/
+COPY valhalla/jawn/package.json ./valhalla/jawn/
+COPY bifrost/package.json ./bifrost/
+
+RUN yarn install --frozen-lockfile --network-timeout 300000
+
 COPY packages/ ./packages/
 COPY web/ ./web/
 
-RUN chmod -R o+w /app/web/public
-
-RUN yarn install --frozen-lockfile
 RUN cd web && yarn build
+
+FROM node:20-bookworm-slim
+
+RUN apt-get update && apt-get upgrade -y && apt-get autoremove -y && apt-get clean
+
+WORKDIR /app
+
+COPY --from=builder /app/package.json /app/yarn.lock ./
+COPY --from=builder /app/packages/ ./packages/
+COPY --from=builder /app/web/ ./web/
+COPY --from=builder /app/node_modules/ ./node_modules/
+
+RUN chmod -R o+w /app/web/public
 
 CMD ["yarn", "--cwd", "web", "start"]


### PR DESCRIPTION
This pull request refactors the `docker/dockerfiles/dockerfile_web` build process to use a multi-stage Docker build. The changes aim to optimize dependency installation, improve build efficiency, and keep the final image smaller and more secure.

**Docker build process improvements:**

* Refactored the Dockerfile to use a multi-stage build, separating the build environment (`builder`) from the final runtime image for better efficiency and security.
* Moved the `yarn install` step to the builder stage and included only the necessary files in the final image, reducing image size and potential attack surface.
* Added explicit copying of `package.json` files from various package directories before installing dependencies, ensuring all workspace dependencies are correctly resolved during the build.
* Retained the security update commands (`apt-get update && apt-get upgrade ...`) in the final runtime image stage to ensure up-to-date packages.
* Adjusted the order and location of `chmod` and build commands to match the new multi-stage workflow.