### PR TITLE
feat: also push docker all in one, offload building to docker build cloud

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -12,14 +12,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Build Cloud
+        uses: docker/setup-buildx-action@v3
+        env:
+          DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_BUILD_CLOUD_TOKEN }}
+          DOCKER_ACCOUNT: ${{ vars.DOCKER_USERNAME }}
+        with:
+          driver: cloud
+          endpoint: ${{ env.DOCKER_ACCOUNT }}/default
 
       - name: Push images to Docker Hub
         run: |

--- a/docker/terraform/github-secrets/.terraform.lock.hcl
+++ b/docker/terraform/github-secrets/.terraform.lock.hcl
@@ -1,29 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version     = "6.0.0"
-  constraints = ">= 5.0.0"
-  hashes = [
-    "h1:dbRRZ1NzH1QV/+83xT/X3MLYaZobMXt8DNwbqnJojpo=",
-    "zh:16b1bb786719b7ebcddba3ab751b976ebf4006f7144afeebcb83f0c5f41f8eb9",
-    "zh:1fbc08b817b9eaf45a2b72ccba59f4ea19e7fcf017be29f5a9552b623eccc5bc",
-    "zh:304f58f3333dbe846cfbdfc2227e6ed77041ceea33b6183972f3f8ab51bd065f",
-    "zh:4cd447b5c24f14553bd6e1a0e4fea3c7d7b218cbb2316a3d93f1c5cb562c181b",
-    "zh:589472b56be8277558616075fc5480fcd812ba6dc70e8979375fc6d8750f83ef",
-    "zh:5d78484ba43c26f1ef6067c4150550b06fd39c5d4bfb790f92c4a6f7d9d0201b",
-    "zh:5f470ce664bffb22ace736643d2abe7ad45858022b652143bcd02d71d38d4e42",
-    "zh:7a9cbb947aaab8c885096bce5da22838ca482196cf7d04ffb8bdf7fd28003e47",
-    "zh:854df3e4c50675e727705a0eaa4f8d42ccd7df6a5efa2456f0205a9901ace019",
-    "zh:87162c0f47b1260f5969679dccb246cb528f27f01229d02fd30a8e2f9869ba2c",
-    "zh:9a145404d506b52078cd7060e6cbb83f8fc7953f3f63a5e7137d41f69d6317a3",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a4eab2649f5afe06cc406ce2aaf9fd44dcf311123f48d344c255e93454c08921",
-    "zh:bea09141c6186a3e133413ae3a2e3d1aaf4f43466a6a468827287527edf21710",
-    "zh:d7ea2a35ff55ddfe639ab3b04331556b772a8698eca01f5d74151615d9f336db",
-  ]
-}
-
 provider "registry.terraform.io/integrations/github" {
   version     = "6.6.0"
   constraints = ">= 5.0.0"

--- a/docker/terraform/github-secrets/README.md
+++ b/docker/terraform/github-secrets/README.md
@@ -1,17 +1,19 @@
 # GitHub Secrets Management for Docker Hub
 
-This Terraform module manages GitHub repository secrets for Docker Hub authentication, enabling automated Docker image pushes via GitHub Actions.
+This Terraform module manages GitHub repository secrets for Docker Hub authentication, enabling automated Docker image pushes via GitHub Actions. It can also optionally provision a secret for Docker Build Cloud.
 
 ## Overview
 
 This module creates:
 - GitHub repository secrets for Docker Hub credentials (`DOCKER_USERNAME` and `DOCKER_PASSWORD`)
+- Optionally, a Docker Build Cloud token secret (`DOCKER_BUILD_CLOUD_TOKEN`) when `docker_build_cloud_token` is provided
 - Works with the GitHub Actions workflow at `.github/workflows/docker-push.yml`
 
 ## Prerequisites
 
 1. **GitHub Personal Access Token**: Create a token with `repo` permissions at https://github.com/settings/tokens
 2. **Docker Hub Account**: You need Docker Hub credentials (username and password/access token)
+3. **(Optional) Docker Build Cloud Token**: Organization Access Token (OAT) with `cloud-connect` scope or a Personal Access Token (PAT)
 3. **Terraform**: Version 1.0 or higher
 
 ## Usage
@@ -34,11 +36,16 @@ This module creates:
 
    Alternatively, you can set them in `terraform.tfvars` (less secure).
 
-4. Update `terraform.tfvars` with your values:
+4. (Optional) Set Docker Build Cloud token:
+   ```bash
+   export TF_VAR_docker_build_cloud_token="dbc_xxx_or_access_token"
+   ```
+
+5. Update `terraform.tfvars` with your values:
    - `github_org`: Your GitHub organization
    - `github_repository`: Your repository name
 
-5. Initialize and apply:
+6. Initialize and apply:
    ```bash
    terraform init
    terraform plan
@@ -64,3 +71,4 @@ After applying Terraform:
 1. Check GitHub repository settings to verify secrets are created
 2. Make a test commit to the `main` branch
 3. Monitor the GitHub Actions tab for the workflow execution
+4. If using Docker Build Cloud, verify that the `Set up Docker Build Cloud` step connects successfully

--- a/docker/terraform/github-secrets/README.md
+++ b/docker/terraform/github-secrets/README.md
@@ -14,7 +14,7 @@ This module creates:
 1. **GitHub Personal Access Token**: Create a token with `repo` permissions at https://github.com/settings/tokens
 2. **Docker Hub Account**: You need Docker Hub credentials (username and password/access token)
 3. **(Optional) Docker Build Cloud Token**: Organization Access Token (OAT) with `cloud-connect` scope or a Personal Access Token (PAT)
-3. **Terraform**: Version 1.0 or higher
+4. **Terraform**: Version 1.0 or higher
 
 ## Usage
 

--- a/docker/terraform/github-secrets/main.tf
+++ b/docker/terraform/github-secrets/main.tf
@@ -10,11 +10,11 @@ locals {
 # GitHub Repository Secrets
 #################################################################################
 
-# Docker Hub Username
-resource "github_actions_secret" "docker_username" {
-  repository      = var.github_repository
-  secret_name     = "DOCKER_USERNAME"
-  plaintext_value = var.docker_username
+# Docker Hub Username as a repository variable (non-secret)
+resource "github_actions_variable" "docker_username" {
+  repository    = var.github_repository
+  variable_name = "DOCKER_USERNAME"
+  value         = var.docker_username
 }
 
 # Docker Hub Password
@@ -22,6 +22,14 @@ resource "github_actions_secret" "docker_password" {
   repository      = var.github_repository
   secret_name     = "DOCKER_PASSWORD"
   plaintext_value = var.docker_password
+}
+
+# Docker Build Cloud Token (optional)
+resource "github_actions_secret" "docker_build_cloud_token" {
+  count           = length(var.docker_build_cloud_token) > 0 ? 1 : 0
+  repository      = var.github_repository
+  secret_name     = "DOCKER_BUILD_CLOUD_TOKEN"
+  plaintext_value = var.docker_build_cloud_token
 }
 
 

--- a/docker/terraform/github-secrets/outputs.tf
+++ b/docker/terraform/github-secrets/outputs.tf
@@ -5,8 +5,16 @@
 output "github_repository_secrets" {
   description = "List of GitHub repository secrets created"
   value = [
-    "DOCKER_USERNAME",
-    "DOCKER_PASSWORD"
+    "DOCKER_PASSWORD",
+    length(var.docker_build_cloud_token) > 0 ? "DOCKER_BUILD_CLOUD_TOKEN" : null
+  ]
+  sensitive = true
+}
+
+output "github_repository_variables" {
+  description = "List of GitHub repository variables created"
+  value = [
+    "DOCKER_USERNAME"
   ]
 }
 

--- a/docker/terraform/github-secrets/terraform.tfvars.example
+++ b/docker/terraform/github-secrets/terraform.tfvars.example
@@ -35,6 +35,17 @@ docker_username = "your-dockerhub-username"  # Replace with your Docker Hub user
 docker_password = "your-dockerhub-password"  # Replace with your Docker Hub password or access token
 
 #################################################################################
+# Docker Build Cloud (optional)
+#################################################################################
+
+# Docker Build Cloud token (optional). If set, the module creates the
+# DOCKER_BUILD_CLOUD_TOKEN secret used by the GitHub workflow to connect
+# to Docker Build Cloud.
+# Example values can be an Organization Access Token (OAT) with cloud-connect scope
+# or a personal access token. Leave commented to skip creating the secret.
+# docker_build_cloud_token = "dbc_xxx_or_access_token"
+
+#################################################################################
 # Environment Variables Required
 #################################################################################
 

--- a/docker/terraform/github-secrets/variables.tf
+++ b/docker/terraform/github-secrets/variables.tf
@@ -42,6 +42,17 @@ variable "docker_password" {
 }
 
 #################################################################################
+# Docker Build Cloud (optional)
+#################################################################################
+
+variable "docker_build_cloud_token" {
+  description = "Docker Build Cloud access token (OAT or PAT). If empty, the secret will not be created."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+#################################################################################
 # GitHub Configuration
 #################################################################################
 


### PR DESCRIPTION
This pull request introduces support for Docker Build Cloud in the Docker image build and deployment workflows, and enhances the Terraform module to manage the required secrets and variables for both Docker Hub and Docker Build Cloud. The changes improve CI/CD flexibility, make multi-platform builds more robust, and clarify secret management.

**CI/CD Workflow and Build Improvements:**

- Updated `.github/workflows/docker-push.yml` to use repository variables for `DOCKER_USERNAME` and to add a `Set up Docker Build Cloud` step, which utilizes secrets and variables for cloud-based builds.
- Enhanced `docker/push_docker.sh` to detect and use a Docker Build Cloud builder if present, skip local pruning when using cloud builds, and add support for building and pushing a new `helicone-all-in-one` image. [[1]](diffhunk://#diff-bb484b31e63f28d9e18fd5c6e601bad4c04201bc15c51c1ac51fe97687df3065R14) [[2]](diffhunk://#diff-bb484b31e63f28d9e18fd5c6e601bad4c04201bc15c51c1ac51fe97687df3065L111-R131) [[3]](diffhunk://#diff-bb484b31e63f28d9e18fd5c6e601bad4c04201bc15c51c1ac51fe97687df3065L159-R173) [[4]](diffhunk://#diff-bb484b31e63f28d9e18fd5c6e601bad4c04201bc15c51c1ac51fe97687df3065R214) [[5]](diffhunk://#diff-bb484b31e63f28d9e18fd5c6e601bad4c04201bc15c51c1ac51fe97687df3065R261-R263) [[6]](diffhunk://#diff-bb484b31e63f28d9e18fd5c6e601bad4c04201bc15c51c1ac51fe97687df3065R296) [[7]](diffhunk://#diff-bb484b31e63f28d9e18fd5c6e601bad4c04201bc15c51c1ac51fe97687df3065R356-R358)

**Terraform Module Enhancements:**

- Added optional support for managing a `DOCKER_BUILD_CLOUD_TOKEN` secret in the Terraform module and updated documentation to reflect this new capability. [[1]](diffhunk://#diff-ce95443905c1a857e8bf44b5e2312a39ef770bd7ab1eb6761f555805b5c9add2L3-R16) [[2]](diffhunk://#diff-ce95443905c1a857e8bf44b5e2312a39ef770bd7ab1eb6761f555805b5c9add2L37-R48) [[3]](diffhunk://#diff-ce95443905c1a857e8bf44b5e2312a39ef770bd7ab1eb6761f555805b5c9add2R74) [[4]](diffhunk://#diff-d6158612c6c6d52fde6da61b15a535b2723beea5d35d878922986c2ce3cb1512R44-R54) [[5]](diffhunk://#diff-a23a24cacde6d6b9882d7dadeab2aed2f6770c70b1c2a5eacd65e7f48cac9984R27-R34) [[6]](diffhunk://#diff-5ccd032067a00a4c76f31c6f379f5998b4e9d2a4cb69f736a8b033af869b231bR37-R47)
- Changed `DOCKER_USERNAME` from a secret to a repository variable for better integration with GitHub Actions, and updated outputs to distinguish between secrets and variables. [[1]](diffhunk://#diff-a23a24cacde6d6b9882d7dadeab2aed2f6770c70b1c2a5eacd65e7f48cac9984L13-R17) [[2]](diffhunk://#diff-532b480b2eeccb8ac9afa0b65f4b7a6cd3458dafa6236d118280b13316f5fbb1L8-R17)