### PR TITLE
Organization update and sidebar UI improvements

### DIFF
--- a/valhalla/jawn/src/lib/stores/OrganizationStore.ts
+++ b/valhalla/jawn/src/lib/stores/OrganizationStore.ts
@@ -124,21 +124,64 @@ export class OrganizationStore extends BaseStore {
     organizationId: string
   ): Promise<Result<string, string>> {
     try {
-      // Prepare the SQL and parameters based on update type
-      let sql = `
+      // Build dynamic SQL based on provided parameters
+      const updateFields = [];
+      const params = [];
+      let paramIndex = 1;
+
+      if (updateOrgParams.name !== undefined) {
+        updateFields.push(`name = $${paramIndex}`);
+        params.push(updateOrgParams.name);
+        paramIndex++;
+      }
+
+      if (updateOrgParams.color !== undefined) {
+        updateFields.push(`color = $${paramIndex}`);
+        params.push(updateOrgParams.color || null);
+        paramIndex++;
+      }
+
+      if (updateOrgParams.icon !== undefined) {
+        updateFields.push(`icon = $${paramIndex}`);
+        params.push(updateOrgParams.icon || null);
+        paramIndex++;
+      }
+
+      if (updateOrgParams.org_provider_key !== undefined) {
+        updateFields.push(`org_provider_key = $${paramIndex}`);
+        params.push(updateOrgParams.org_provider_key || null);
+        paramIndex++;
+      }
+
+      if (updateOrgParams.limits !== undefined) {
+        updateFields.push(`limits = $${paramIndex}`);
+        params.push(updateOrgParams.limits || {});
+        paramIndex++;
+      }
+
+      if (updateOrgParams.organization_type !== undefined) {
+        updateFields.push(`organization_type = $${paramIndex}`);
+        params.push(updateOrgParams.organization_type);
+        paramIndex++;
+      }
+
+      if (updateOrgParams.onboarding_status !== undefined) {
+        updateFields.push(`onboarding_status = $${paramIndex}`);
+        params.push(updateOrgParams.onboarding_status || {});
+        paramIndex++;
+      }
+
+
+      if (updateFields.length === 0) {
+        return err("No fields to update");
+      }
+
+      const sql = `
         UPDATE organization 
-        SET name = $1, 
-            color = $2, 
-            icon = $3`;
-
-      const params = [
-        updateOrgParams.name,
-        updateOrgParams.color || null,
-        updateOrgParams.icon || null,
-      ];
-
-      // Add WHERE clause and RETURNING
-      sql += ` WHERE id = $${params.length + 1} RETURNING id`;
+        SET ${updateFields.join(', ')}
+        WHERE id = $${paramIndex} 
+        RETURNING id`;
+      
       params.push(organizationId);
 
       // Execute the query

--- a/web/components/layout/SidebarHelpDropdown.tsx
+++ b/web/components/layout/SidebarHelpDropdown.tsx
@@ -61,7 +61,7 @@ const SidebarHelpDropdown = ({
     }
   }, [pathname]);
   return (
-    <div className="flex w-full flex-col items-center gap-2">
+    <div className="flex w-full flex-col items-center">
       <DropdownMenu
         modal={false}
         onOpenChange={
@@ -88,9 +88,6 @@ const SidebarHelpDropdown = ({
               >
                 ?
               </span>
-              {hasNewChangelog && (
-                <span className="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full bg-destructive"></span>
-              )}
             </div>
             {!isCollapsed && <span>Help</span>}
           </Button>
@@ -103,6 +100,19 @@ const SidebarHelpDropdown = ({
               <ArrowUpRightIcon className="ml-2 h-3.5 w-3.5 text-slate-400 dark:text-slate-600" />
             </DropdownMenuItem>
           </Link>
+          <DropdownMenuItem 
+            className="cursor-pointer"
+            onSelect={() => {
+              setChatOpen(!chatOpen);
+              Intercom({
+                app_id: INTERCOM_APP_ID,
+                hide_default_launcher: !chatOpen,
+              });
+            }}
+          >
+            <MessageCircleMore className="mr-2 h-4 w-4 text-slate-500" />
+            Message us
+          </DropdownMenuItem>
           <Link href="https://discord.gg/zsSTcH2qhG" target="_blank">
             <DropdownMenuItem className="cursor-pointer">
               <FaDiscord className="mr-2 h-4 w-4 text-slate-500" />
@@ -166,33 +176,6 @@ const SidebarHelpDropdown = ({
           </Link>
         </DropdownMenuContent>
       </DropdownMenu>
-
-      <Button
-        variant="outline"
-        size="none"
-        onClick={() => {
-          setChatOpen(!chatOpen);
-          Intercom({
-            app_id: INTERCOM_APP_ID,
-            hide_default_launcher: !chatOpen,
-          });
-        }}
-        className={clsx(
-          "flex items-center text-xs text-muted-foreground hover:text-foreground",
-          isCollapsed ? "h-9 w-9" : "h-7 w-full gap-1",
-          chatOpen && "text-primary",
-        )}
-      >
-        <MessageCircleMore
-          size={12}
-          className={clsx(
-            chatOpen
-              ? "text-primary"
-              : "text-muted-foreground hover:text-primary",
-          )}
-        />
-        {!isCollapsed && <div>Message us</div>}
-      </Button>
     </div>
   );
 };

--- a/web/components/layout/auth/DesktopSidebar.tsx
+++ b/web/components/layout/auth/DesktopSidebar.tsx
@@ -230,7 +230,7 @@ const DesktopSidebar = ({
         <div className="flex h-full w-full flex-col border-r border-slate-200 dark:border-slate-800">
           {/* Collapse button and OrgDropdown */}
           <div
-            className={`flex flex-row items-center p-2.5 ${isCollapsed ? "justify-center" : "justify-between"}`}
+            className={`h-16 flex flex-row items-center px-4 border-b border-slate-200 dark:border-slate-800 ${isCollapsed ? "justify-center" : "justify-between"}`}
           >
             {/* - OrgDropdown */}
             {!isCollapsed && <OrgDropdown />}

--- a/web/components/layout/auth/NavItem.tsx
+++ b/web/components/layout/auth/NavItem.tsx
@@ -51,14 +51,14 @@ const NavItem: React.FC<NavItemProps> = ({
                 size: "icon",
               }),
               "h-9 w-9",
-              link.current && "bg-accent hover:bg-accent",
+              link.current && "bg-blue-100 dark:bg-blue-900/50 hover:bg-blue-100 dark:hover:bg-blue-900/50",
             )}
           >
             {link.icon && (
               <link.icon
                 className={cn(
                   "h-4 w-4 text-slate-500",
-                  link.current && "text-slate-800 dark:text-slate-200",
+                  link.current && "text-blue-600 dark:text-blue-400",
                 )}
               />
             )}
@@ -88,13 +88,13 @@ const NavItem: React.FC<NavItemProps> = ({
             ? "mt-[14px] flex items-center gap-0.5 pl-2 text-[11px] text-xs font-normal text-slate-400"
             : cn(
                 buttonVariants({
-                  variant: link.current ? "secondary" : "ghost",
+                  variant: "ghost",
                   size: "xs",
                 }),
                 deep && deep > 1 ? "h-6" : "h-8",
                 "w-full justify-start font-normal",
                 "text-[12px] text-slate-500",
-                link.current && "text-slate-800 dark:text-slate-200",
+                link.current && "bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50",
               ),
           "",
         )}
@@ -104,7 +104,7 @@ const NavItem: React.FC<NavItemProps> = ({
             <link.icon
               className={cn(
                 "mr-2 h-3.5 w-3.5 text-slate-500",
-                link.current && "text-slate-800 dark:text-slate-200",
+                link.current && "text-blue-700 dark:text-blue-300",
               )}
             />
           )}

--- a/web/components/templates/organization/settings/orgSettingsPage.tsx
+++ b/web/components/templates/organization/settings/orgSettingsPage.tsx
@@ -14,6 +14,7 @@ import { Separator } from "@/components/ui/separator";
 import { CopyIcon } from "lucide-react";
 import useNotification from "@/components/shared/notification/useNotification";
 import { useHeliconeAuthClient } from "@/packages/common/auth/client/AuthClientFactory";
+import { useOrg } from "../../../layout/org/organizationContext";
 interface OrgSettingsPageProps {
   org: Database["public"]["Tables"]["organization"]["Row"];
   variant?: "organization" | "reseller";
@@ -26,6 +27,7 @@ const OrgSettingsPage = (props: OrgSettingsPageProps) => {
   const [, setOpenDemo] = useLocalStorage("openDemo", false);
   const [, setRemovedDemo] = useLocalStorage("removedDemo", false);
   const { setNotification } = useNotification();
+  const orgContext = useOrg();
 
   const isOwner = org.owner === user?.id;
 
@@ -33,10 +35,24 @@ const OrgSettingsPage = (props: OrgSettingsPageProps) => {
 
   const [debouncedOrgName, setDebouncedOrgName] = useState(org.name);
 
+  const handleOrgUpdate = (updateData: {
+    orgId: string;
+    name: string;
+    color: string;
+    icon: string;
+    variant: string;
+  }) => {
+    updateOrgMutation.mutate(updateData, {
+      onSuccess: () => {
+        orgContext?.refetchOrgs?.();
+      },
+    });
+  };
+
   useEffect(() => {
     if (debouncedOrgName === org.name) return;
     const timeout = setTimeout(() => {
-      updateOrgMutation.mutate({
+      handleOrgUpdate({
         orgId: org.id,
         name: debouncedOrgName,
         color: org.color,
@@ -91,7 +107,7 @@ const OrgSettingsPage = (props: OrgSettingsPageProps) => {
               <RadioGroup
                 defaultValue={org.color}
                 onValueChange={(value) =>
-                  updateOrgMutation.mutate({
+                  handleOrgUpdate({
                     orgId: org.id,
                     color: value,
                     name: debouncedOrgName,
@@ -130,7 +146,7 @@ const OrgSettingsPage = (props: OrgSettingsPageProps) => {
               <RadioGroup
                 defaultValue={org.icon}
                 onValueChange={(value) =>
-                  updateOrgMutation.mutate({
+                  handleOrgUpdate({
                     orgId: org.id,
                     icon: value,
                     name: org.name,

--- a/web/services/hooks/organizations.tsx
+++ b/web/services/hooks/organizations.tsx
@@ -205,12 +205,16 @@ export const useUpdateOrgMutation = () => {
     },
     onSuccess: () => {
       setNotification("Organization updated", "success");
+      // Invalidate queries
       queryClient.invalidateQueries({
-        queryKey: ["Organizations", user?.id ?? ""],
-        refetchType: "all",
-      });
-      queryClient.invalidateQueries({
-        queryKey: ["OrganizationsId"],
+        predicate: (query) => {
+          const queryKey = query.queryKey;
+          return (
+            queryKey.includes("/v1/organization") ||
+            queryKey.includes("organization") ||
+            queryKey.includes("Organizations")
+          );
+        },
         refetchType: "all",
       });
     },


### PR DESCRIPTION

  - Fixed OrganizationStore to properly handle all update fields (removed non-existent variant column)
  - Added immediate org context refetch after successful updates in settings page
  - Improved sidebar styling with divider between org selector and navigation
  - Moved "Message us" button into help dropdown for cleaner sidebar layout
  - Changed help notification dot from red to blue, then removed it entirely

