### PR TITLE
feat: [ENG-2563] Control prompt environments in UI

### DIFF
--- a/bifrost/lib/clients/jawnTypes/private.ts
+++ b/bifrost/lib/clients/jawnTypes/private.ts
@@ -177,6 +177,9 @@ export interface paths {
   "/v1/prompt-2025/tags": {
     get: operations["GetPrompt2025Tags"];
   };
+  "/v1/prompt-2025/environments": {
+    get: operations["GetPrompt2025Environments"];
+  };
   "/v1/prompt-2025": {
     post: operations["CreatePrompt2025"];
   };
@@ -16460,6 +16463,16 @@ export interface operations {
     };
   };
   GetPrompt2025Tags: {
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_string-Array.string_"];
+        };
+      };
+    };
+  };
+  GetPrompt2025Environments: {
     responses: {
       /** @description Ok */
       200: {

--- a/bifrost/lib/clients/jawnTypes/private.ts
+++ b/bifrost/lib/clients/jawnTypes/private.ts
@@ -186,8 +186,8 @@ export interface paths {
   "/v1/prompt-2025/update": {
     post: operations["UpdatePrompt2025"];
   };
-  "/v1/prompt-2025/update/production-version": {
-    post: operations["SetProductionVersion"];
+  "/v1/prompt-2025/update/environment": {
+    post: operations["SetPromptVersionEnvironment"];
   };
   "/v1/prompt-2025/count": {
     get: operations["GetPrompt2025Count"];
@@ -16507,7 +16507,7 @@ export interface operations {
         "application/json": {
           promptBody: components["schemas"]["OpenAIChatRequest"];
           commitMessage: string;
-          setAsProduction: boolean;
+          environment?: string;
           newMajorVersion: boolean;
           promptVersionId: string;
           promptId: string;
@@ -16523,10 +16523,11 @@ export interface operations {
       };
     };
   };
-  SetProductionVersion: {
+  SetPromptVersionEnvironment: {
     requestBody: {
       content: {
         "application/json": {
+          environment: string;
           promptVersionId: string;
           promptId: string;
         };

--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -100,8 +100,8 @@ export interface paths {
   "/v1/prompt-2025/update": {
     post: operations["UpdatePrompt2025"];
   };
-  "/v1/prompt-2025/update/production-version": {
-    post: operations["SetProductionVersion"];
+  "/v1/prompt-2025/update/environment": {
+    post: operations["SetPromptVersionEnvironment"];
   };
   "/v1/prompt-2025/count": {
     get: operations["GetPrompt2025Count"];
@@ -4042,7 +4042,7 @@ export interface operations {
         "application/json": {
           promptBody: components["schemas"]["OpenAIChatRequest"];
           commitMessage: string;
-          setAsProduction: boolean;
+          environment?: string;
           newMajorVersion: boolean;
           promptVersionId: string;
           promptId: string;
@@ -4058,10 +4058,11 @@ export interface operations {
       };
     };
   };
-  SetProductionVersion: {
+  SetPromptVersionEnvironment: {
     requestBody: {
       content: {
         "application/json": {
+          environment: string;
           promptVersionId: string;
           promptId: string;
         };

--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -91,6 +91,9 @@ export interface paths {
   "/v1/prompt-2025/tags": {
     get: operations["GetPrompt2025Tags"];
   };
+  "/v1/prompt-2025/environments": {
+    get: operations["GetPrompt2025Environments"];
+  };
   "/v1/prompt-2025": {
     post: operations["CreatePrompt2025"];
   };
@@ -3995,6 +3998,16 @@ export interface operations {
     };
   };
   GetPrompt2025Tags: {
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_string-Array.string_"];
+        };
+      };
+    };
+  };
+  GetPrompt2025Environments: {
     responses: {
       /** @description Ok */
       200: {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -12027,6 +12027,32 @@
 				"parameters": []
 			}
 		},
+		"/v1/prompt-2025/environments": {
+			"get": {
+				"operationId": "GetPrompt2025Environments",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result_string-Array.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Prompt2025"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": []
+			}
+		},
 		"/v1/prompt-2025": {
 			"post": {
 				"operationId": "CreatePrompt2025",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -12144,8 +12144,8 @@
 									"commitMessage": {
 										"type": "string"
 									},
-									"setAsProduction": {
-										"type": "boolean"
+									"environment": {
+										"type": "string"
 									},
 									"newMajorVersion": {
 										"type": "boolean"
@@ -12160,7 +12160,6 @@
 								"required": [
 									"promptBody",
 									"commitMessage",
-									"setAsProduction",
 									"newMajorVersion",
 									"promptVersionId",
 									"promptId"
@@ -12172,9 +12171,9 @@
 				}
 			}
 		},
-		"/v1/prompt-2025/update/production-version": {
+		"/v1/prompt-2025/update/environment": {
 			"post": {
-				"operationId": "SetProductionVersion",
+				"operationId": "SetPromptVersionEnvironment",
 				"responses": {
 					"200": {
 						"description": "Ok",
@@ -12202,6 +12201,9 @@
 						"application/json": {
 							"schema": {
 								"properties": {
+									"environment": {
+										"type": "string"
+									},
 									"promptVersionId": {
 										"type": "string"
 									},
@@ -12210,6 +12212,7 @@
 									}
 								},
 								"required": [
+									"environment",
 									"promptVersionId",
 									"promptId"
 								],

--- a/valhalla/jawn/src/controllers/public/prompt2025Controller.ts
+++ b/valhalla/jawn/src/controllers/public/prompt2025Controller.ts
@@ -177,7 +177,7 @@ export class Prompt2025Controller extends Controller {
       promptId: string;
       promptVersionId: string;
       newMajorVersion: boolean;
-      setAsProduction: boolean;
+      environment?: string;
       commitMessage: string;
       promptBody: OpenAIChatRequest;
     },
@@ -194,20 +194,21 @@ export class Prompt2025Controller extends Controller {
     return result;
   }
 
-  @Post("update/production-version")
-  public async setProductionVersion(
+  @Post("update/environment")
+  public async setPromptVersionEnvironment(
     @Body()
     requestBody: {
       promptId: string;
       promptVersionId: string;
+      environment: string;
     },
     @Request() request: JawnAuthenticatedRequest
   ): Promise<Result<null, string>> {
     const promptManager = new Prompt2025Manager(request.authParams);
-    const result = await promptManager.setProductionVersion({
+    const result = await promptManager.setPromptVersionEnvironment({
       promptId: requestBody.promptId,
       promptVersionId: requestBody.promptVersionId,
-      environment: 'production',
+      environment: requestBody.environment,
     });
     if (result.error) {
       this.setStatus(500);

--- a/valhalla/jawn/src/controllers/public/prompt2025Controller.ts
+++ b/valhalla/jawn/src/controllers/public/prompt2025Controller.ts
@@ -135,6 +135,20 @@ export class Prompt2025Controller extends Controller {
     return result;
   }
 
+  @Get("environments")
+  public async getPrompt2025Environments(
+    @Request() request: JawnAuthenticatedRequest
+  ): Promise<Result<string[], string>> {
+    const promptManager = new Prompt2025Manager(request.authParams);
+    const result = await promptManager.getPromptEnvironments();
+    if (result.error || !result.data) {
+      this.setStatus(500);
+    } else {
+      this.setStatus(200);
+    }
+    return result;
+  }
+
   @Post("")
   public async createPrompt2025(
     @Body()

--- a/valhalla/jawn/src/managers/prompt/PromptManager.ts
+++ b/valhalla/jawn/src/managers/prompt/PromptManager.ts
@@ -69,6 +69,24 @@ export class Prompt2025Manager extends BaseManager {
     return ok(Number(result.data?.[0]?.count ?? 0));
   }
 
+  async getPromptEnvironments(): Promise<Result<string[], string>> {
+    const result = await dbExecute<{ environment: string }>(
+      `SELECT DISTINCT environment 
+       FROM prompts_2025_versions 
+       WHERE organization = $1 AND soft_delete = false AND environment IS NOT NULL
+       ORDER BY environment`,
+      [this.authParams.organizationId]
+    );
+
+    if (result.error) {
+      return err(result.error);
+    }
+
+    const environments = result.data?.map(row => row.environment) || [];
+    return ok(environments);
+  }
+
+
   async getPromptTags(): Promise<Result<string[], string>> {
     const result = await dbExecute<{ tags: string }>(
       `SELECT DISTINCT UNNEST(tags) as tags FROM prompts_2025 WHERE organization = $1 AND soft_delete is false`,

--- a/valhalla/jawn/src/tsoa-build/private/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/private/routes.ts
@@ -15998,6 +15998,37 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsPrompt2025Controller_getPrompt2025Environments: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+        };
+        app.get('/v1/prompt-2025/environments',
+            authenticateMiddleware([{"api_key":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller)),
+            ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller.prototype.getPrompt2025Environments)),
+
+            async function Prompt2025Controller_getPrompt2025Environments(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsPrompt2025Controller_getPrompt2025Environments, request, response });
+
+                const controller = new Prompt2025Controller();
+
+              await templateService.apiHandler({
+                methodName: 'getPrompt2025Environments',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsPrompt2025Controller_createPrompt2025: Record<string, TsoaRoute.ParameterSchema> = {
                 requestBody: {"in":"body","name":"requestBody","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"promptBody":{"ref":"OpenAIChatRequest","required":true},"tags":{"dataType":"array","array":{"dataType":"string"},"required":true},"name":{"dataType":"string","required":true}}},
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},

--- a/valhalla/jawn/src/tsoa-build/private/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/private/routes.ts
@@ -16062,7 +16062,7 @@ export function RegisterRoutes(app: Router) {
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsPrompt2025Controller_updatePrompt2025: Record<string, TsoaRoute.ParameterSchema> = {
-                requestBody: {"in":"body","name":"requestBody","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"promptBody":{"ref":"OpenAIChatRequest","required":true},"commitMessage":{"dataType":"string","required":true},"setAsProduction":{"dataType":"boolean","required":true},"newMajorVersion":{"dataType":"boolean","required":true},"promptVersionId":{"dataType":"string","required":true},"promptId":{"dataType":"string","required":true}}},
+                requestBody: {"in":"body","name":"requestBody","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"promptBody":{"ref":"OpenAIChatRequest","required":true},"commitMessage":{"dataType":"string","required":true},"environment":{"dataType":"string"},"newMajorVersion":{"dataType":"boolean","required":true},"promptVersionId":{"dataType":"string","required":true},"promptId":{"dataType":"string","required":true}}},
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
         app.post('/v1/prompt-2025/update',
@@ -16093,27 +16093,27 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsPrompt2025Controller_setProductionVersion: Record<string, TsoaRoute.ParameterSchema> = {
-                requestBody: {"in":"body","name":"requestBody","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"promptVersionId":{"dataType":"string","required":true},"promptId":{"dataType":"string","required":true}}},
+        const argsPrompt2025Controller_setPromptVersionEnvironment: Record<string, TsoaRoute.ParameterSchema> = {
+                requestBody: {"in":"body","name":"requestBody","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"environment":{"dataType":"string","required":true},"promptVersionId":{"dataType":"string","required":true},"promptId":{"dataType":"string","required":true}}},
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
-        app.post('/v1/prompt-2025/update/production-version',
+        app.post('/v1/prompt-2025/update/environment',
             authenticateMiddleware([{"api_key":[]}]),
             ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller)),
-            ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller.prototype.setProductionVersion)),
+            ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller.prototype.setPromptVersionEnvironment)),
 
-            async function Prompt2025Controller_setProductionVersion(request: ExRequest, response: ExResponse, next: any) {
+            async function Prompt2025Controller_setPromptVersionEnvironment(request: ExRequest, response: ExResponse, next: any) {
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
             let validatedArgs: any[] = [];
             try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsPrompt2025Controller_setProductionVersion, request, response });
+                validatedArgs = templateService.getValidatedArgs({ args: argsPrompt2025Controller_setPromptVersionEnvironment, request, response });
 
                 const controller = new Prompt2025Controller();
 
               await templateService.apiHandler({
-                methodName: 'setProductionVersion',
+                methodName: 'setPromptVersionEnvironment',
                 controller,
                 response,
                 next,

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -48832,8 +48832,8 @@
 									"commitMessage": {
 										"type": "string"
 									},
-									"setAsProduction": {
-										"type": "boolean"
+									"environment": {
+										"type": "string"
 									},
 									"newMajorVersion": {
 										"type": "boolean"
@@ -48848,7 +48848,6 @@
 								"required": [
 									"promptBody",
 									"commitMessage",
-									"setAsProduction",
 									"newMajorVersion",
 									"promptVersionId",
 									"promptId"
@@ -48860,9 +48859,9 @@
 				}
 			}
 		},
-		"/v1/prompt-2025/update/production-version": {
+		"/v1/prompt-2025/update/environment": {
 			"post": {
-				"operationId": "SetProductionVersion",
+				"operationId": "SetPromptVersionEnvironment",
 				"responses": {
 					"200": {
 						"description": "Ok",
@@ -48890,6 +48889,9 @@
 						"application/json": {
 							"schema": {
 								"properties": {
+									"environment": {
+										"type": "string"
+									},
 									"promptVersionId": {
 										"type": "string"
 									},
@@ -48898,6 +48900,7 @@
 									}
 								},
 								"required": [
+									"environment",
 									"promptVersionId",
 									"promptId"
 								],

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -48715,6 +48715,32 @@
 				"parameters": []
 			}
 		},
+		"/v1/prompt-2025/environments": {
+			"get": {
+				"operationId": "GetPrompt2025Environments",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result_string-Array.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Prompt2025"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": []
+			}
+		},
 		"/v1/prompt-2025": {
 			"post": {
 				"operationId": "CreatePrompt2025",

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -4593,7 +4593,7 @@ export function RegisterRoutes(app: Router) {
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsPrompt2025Controller_updatePrompt2025: Record<string, TsoaRoute.ParameterSchema> = {
-                requestBody: {"in":"body","name":"requestBody","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"promptBody":{"ref":"OpenAIChatRequest","required":true},"commitMessage":{"dataType":"string","required":true},"setAsProduction":{"dataType":"boolean","required":true},"newMajorVersion":{"dataType":"boolean","required":true},"promptVersionId":{"dataType":"string","required":true},"promptId":{"dataType":"string","required":true}}},
+                requestBody: {"in":"body","name":"requestBody","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"promptBody":{"ref":"OpenAIChatRequest","required":true},"commitMessage":{"dataType":"string","required":true},"environment":{"dataType":"string"},"newMajorVersion":{"dataType":"boolean","required":true},"promptVersionId":{"dataType":"string","required":true},"promptId":{"dataType":"string","required":true}}},
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
         app.post('/v1/prompt-2025/update',
@@ -4624,27 +4624,27 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsPrompt2025Controller_setProductionVersion: Record<string, TsoaRoute.ParameterSchema> = {
-                requestBody: {"in":"body","name":"requestBody","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"promptVersionId":{"dataType":"string","required":true},"promptId":{"dataType":"string","required":true}}},
+        const argsPrompt2025Controller_setPromptVersionEnvironment: Record<string, TsoaRoute.ParameterSchema> = {
+                requestBody: {"in":"body","name":"requestBody","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"environment":{"dataType":"string","required":true},"promptVersionId":{"dataType":"string","required":true},"promptId":{"dataType":"string","required":true}}},
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
-        app.post('/v1/prompt-2025/update/production-version',
+        app.post('/v1/prompt-2025/update/environment',
             authenticateMiddleware([{"api_key":[]}]),
             ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller)),
-            ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller.prototype.setProductionVersion)),
+            ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller.prototype.setPromptVersionEnvironment)),
 
-            async function Prompt2025Controller_setProductionVersion(request: ExRequest, response: ExResponse, next: any) {
+            async function Prompt2025Controller_setPromptVersionEnvironment(request: ExRequest, response: ExResponse, next: any) {
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
             let validatedArgs: any[] = [];
             try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsPrompt2025Controller_setProductionVersion, request, response });
+                validatedArgs = templateService.getValidatedArgs({ args: argsPrompt2025Controller_setPromptVersionEnvironment, request, response });
 
                 const controller = new Prompt2025Controller();
 
               await templateService.apiHandler({
-                methodName: 'setProductionVersion',
+                methodName: 'setPromptVersionEnvironment',
                 controller,
                 response,
                 next,

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -4529,6 +4529,37 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsPrompt2025Controller_getPrompt2025Environments: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+        };
+        app.get('/v1/prompt-2025/environments',
+            authenticateMiddleware([{"api_key":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller)),
+            ...(fetchMiddlewares<RequestHandler>(Prompt2025Controller.prototype.getPrompt2025Environments)),
+
+            async function Prompt2025Controller_getPrompt2025Environments(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsPrompt2025Controller_getPrompt2025Environments, request, response });
+
+                const controller = new Prompt2025Controller();
+
+              await templateService.apiHandler({
+                methodName: 'getPrompt2025Environments',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsPrompt2025Controller_createPrompt2025: Record<string, TsoaRoute.ParameterSchema> = {
                 requestBody: {"in":"body","name":"requestBody","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"promptBody":{"ref":"OpenAIChatRequest","required":true},"tags":{"dataType":"array","array":{"dataType":"string"},"required":true},"name":{"dataType":"string","required":true}}},
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -12027,6 +12027,32 @@
 				"parameters": []
 			}
 		},
+		"/v1/prompt-2025/environments": {
+			"get": {
+				"operationId": "GetPrompt2025Environments",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result_string-Array.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Prompt2025"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": []
+			}
+		},
 		"/v1/prompt-2025": {
 			"post": {
 				"operationId": "CreatePrompt2025",

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -12144,8 +12144,8 @@
 									"commitMessage": {
 										"type": "string"
 									},
-									"setAsProduction": {
-										"type": "boolean"
+									"environment": {
+										"type": "string"
 									},
 									"newMajorVersion": {
 										"type": "boolean"
@@ -12160,7 +12160,6 @@
 								"required": [
 									"promptBody",
 									"commitMessage",
-									"setAsProduction",
 									"newMajorVersion",
 									"promptVersionId",
 									"promptId"
@@ -12172,9 +12171,9 @@
 				}
 			}
 		},
-		"/v1/prompt-2025/update/production-version": {
+		"/v1/prompt-2025/update/environment": {
 			"post": {
-				"operationId": "SetProductionVersion",
+				"operationId": "SetPromptVersionEnvironment",
 				"responses": {
 					"200": {
 						"description": "Ok",
@@ -12202,6 +12201,9 @@
 						"application/json": {
 							"schema": {
 								"properties": {
+									"environment": {
+										"type": "string"
+									},
 									"promptVersionId": {
 										"type": "string"
 									},
@@ -12210,6 +12212,7 @@
 									}
 								},
 								"required": [
+									"environment",
 									"promptVersionId",
 									"promptId"
 								],

--- a/web/components/templates/playground/components/PlaygroundActions.tsx
+++ b/web/components/templates/playground/components/PlaygroundActions.tsx
@@ -23,7 +23,7 @@ interface PlaygroundActionsProps {
   onCreatePrompt: (tags: string[], promptName: string) => void;
   onSavePrompt: (
     newMajorVersion: boolean,
-    setAsProduction: boolean,
+    environment: string | undefined,
     commitMessage: string,
   ) => void;
   onRun: () => void;

--- a/web/components/templates/playground/components/PlaygroundHeader.tsx
+++ b/web/components/templates/playground/components/PlaygroundHeader.tsx
@@ -39,7 +39,7 @@ interface PlaygroundHeaderProps {
   onCreatePrompt: (tags: string[], promptName: string) => void;
   onSavePrompt: (
     newMajorVersion: boolean,
-    setAsProduction: boolean,
+    environment: string | undefined,
     commitMessage: string,
   ) => void;
   onRun: () => void;

--- a/web/components/templates/playground/components/PlaygroundMessagesPanel.tsx
+++ b/web/components/templates/playground/components/PlaygroundMessagesPanel.tsx
@@ -24,7 +24,7 @@ interface PlaygroundMessagesPanelProps {
   onCreatePrompt: (tags: string[], promptName: string) => void;
   onSavePrompt: (
     newMajorVersion: boolean,
-    setAsProduction: boolean,
+    environment: string | undefined,
     commitMessage: string,
   ) => void;
   onRun: () => void;

--- a/web/components/templates/playground/components/PromptForm.tsx
+++ b/web/components/templates/playground/components/PromptForm.tsx
@@ -16,7 +16,10 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { InfoIcon, Check, ChevronsUpDown, Crown } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useGetPromptTags, useGetPromptEnvironments } from "@/services/hooks/prompts";
+import {
+  useGetPromptTags,
+  useGetPromptEnvironments,
+} from "@/services/hooks/prompts";
 import TagsFilter from "@/components/templates/prompts2025/TagsFilter";
 import {
   Command,
@@ -48,7 +51,9 @@ export default function PromptForm({
   const [commitMessage, setCommitMessage] = useState("Update.");
   const [isPromptFormPopoverOpen, setIsPromptFormPopoverOpen] = useState(false);
   const [upgradeMajorVersion, setUpgradeMajorVersion] = useState(false);
-  const [selectedEnvironment, setSelectedEnvironment] = useState<string | undefined>(undefined);
+  const [selectedEnvironment, setSelectedEnvironment] = useState<
+    string | undefined
+  >(undefined);
   const [isEnvironmentOpen, setIsEnvironmentOpen] = useState(false);
   const [customEnvironment, setCustomEnvironment] = useState("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -57,7 +62,7 @@ export default function PromptForm({
 
   const { data: existingTags = [], isLoading: isLoadingTags } =
     useGetPromptTags();
-  
+
   const { data: environments = [], isLoading: isLoadingEnvironments } =
     useGetPromptEnvironments();
 
@@ -205,7 +210,7 @@ export default function PromptForm({
                   />
                 </div>
               </div>
-              
+
               <div className="flex flex-col gap-2">
                 <div className="flex items-center gap-2">
                   <Label>Environment</Label>
@@ -214,11 +219,15 @@ export default function PromptForm({
                       <InfoIcon className="h-3 w-3 text-muted-foreground" />
                     </TooltipTrigger>
                     <TooltipContent align="start">
-                      Select an existing environment or create a custom one. Leave empty for no environment assignment.
+                      Select an existing environment or create a custom one.
+                      Leave empty for no environment assignment.
                     </TooltipContent>
                   </Tooltip>
                 </div>
-                <Popover open={isEnvironmentOpen} onOpenChange={setIsEnvironmentOpen}>
+                <Popover
+                  open={isEnvironmentOpen}
+                  onOpenChange={setIsEnvironmentOpen}
+                >
                   <PopoverTrigger asChild>
                     <Button
                       variant="outline"
@@ -227,7 +236,9 @@ export default function PromptForm({
                       className="w-full justify-between"
                       disabled={isLoadingEnvironments}
                     >
-                      {selectedEnvironment || customEnvironment || "Select environment (optional)"}
+                      {selectedEnvironment ||
+                        customEnvironment ||
+                        "Select environment (optional)"}
                       <ChevronsUpDown size={16} className="opacity-50" />
                     </Button>
                   </PopoverTrigger>
@@ -248,7 +259,9 @@ export default function PromptForm({
                               size={16}
                               className={cn(
                                 "mr-2",
-                                !selectedEnvironment && !customEnvironment ? "opacity-100" : "opacity-0"
+                                !selectedEnvironment && !customEnvironment
+                                  ? "opacity-100"
+                                  : "opacity-0",
                               )}
                             />
                             No environment
@@ -266,12 +279,14 @@ export default function PromptForm({
                                 size={16}
                                 className={cn(
                                   "mr-2",
-                                  selectedEnvironment === env ? "opacity-100" : "opacity-0"
+                                  selectedEnvironment === env
+                                    ? "opacity-100"
+                                    : "opacity-0",
                                 )}
                               />
                               {env}
-                              {env === 'production' && (
-                                <Crown className="ml-auto text-muted-foreground/50 h-3 w-3"/>
+                              {env === "production" && (
+                                <Crown className="ml-auto h-3 w-3 text-muted-foreground/50" />
                               )}
                             </CommandItem>
                           ))}

--- a/web/components/templates/playground/playgroundPage.tsx
+++ b/web/components/templates/playground/playgroundPage.tsx
@@ -45,6 +45,7 @@ import { useVariableColorMapStore } from "@/store/features/playground/variableCo
 import { ResponseFormat, ResponseFormatType, VariableInput } from "./types";
 import { useLocalStorage } from "@/services/hooks/localStorage";
 import Link from "next/link";
+import EnvironmentPill from "@/components/templates/prompts2025/EnvironmentPill";
 
 export const DEFAULT_EMPTY_CHAT: MappedLLMRequest = {
   _type: "openai-chat",
@@ -904,6 +905,11 @@ const PlaygroundPage = (props: PlaygroundPageProps) => {
                       ? `v${promptVersionData.promptVersion.major_version}`
                       : `v${promptVersionData.promptVersion.major_version}.${promptVersionData.promptVersion.minor_version}`}
                   </span>
+                  {promptVersionData.promptVersion.environment && (
+                    <EnvironmentPill
+                      environment={promptVersionData.promptVersion.environment}
+                    />
+                  )}
                 </div>
               </>
             )}

--- a/web/components/templates/playground/playgroundPage.tsx
+++ b/web/components/templates/playground/playgroundPage.tsx
@@ -540,7 +540,7 @@ const PlaygroundPage = (props: PlaygroundPageProps) => {
 
   const onSavePrompt = async (
     newMajorVersion: boolean,
-    setAsProduction: boolean,
+    environment: string | undefined,
     commitMessage: string,
   ) => {
     if (!mappedContent) {
@@ -567,7 +567,7 @@ const PlaygroundPage = (props: PlaygroundPageProps) => {
           promptId: promptVersionData.prompt.id,
           promptVersionId: promptVersionData.promptVersion.id,
           newMajorVersion,
-          setAsProduction,
+          environment,
           commitMessage,
           promptBody,
         },

--- a/web/components/templates/prompts2025/EnvironmentPill.tsx
+++ b/web/components/templates/prompts2025/EnvironmentPill.tsx
@@ -1,0 +1,32 @@
+import { Crown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface EnvironmentPillProps {
+  environment: string;
+  className?: string;
+}
+
+const EnvironmentPill = ({ environment, className }: EnvironmentPillProps) => {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ring-1 ring-inset",
+        environment === "production"
+          ? "bg-green-100 text-green-800 ring-green-600/20"
+          : ["dev", "development", "staging"].includes(
+              environment.toLowerCase(),
+            )
+            ? "bg-blue-100 text-blue-800 ring-blue-600/20"
+            : "bg-gray-100 text-gray-800 ring-gray-600/20",
+        className
+      )}
+    >
+      {environment}
+      {environment === "production" && (
+        <Crown className="ml-2 h-3 w-3" />
+      )}
+    </span>
+  );
+};
+
+export default EnvironmentPill; 

--- a/web/components/templates/prompts2025/EnvironmentPill.tsx
+++ b/web/components/templates/prompts2025/EnvironmentPill.tsx
@@ -14,19 +14,17 @@ const EnvironmentPill = ({ environment, className }: EnvironmentPillProps) => {
         environment === "production"
           ? "bg-green-100 text-green-800 ring-green-600/20"
           : ["dev", "development", "staging"].includes(
-              environment.toLowerCase(),
-            )
+                environment.toLowerCase(),
+              )
             ? "bg-blue-100 text-blue-800 ring-blue-600/20"
             : "bg-gray-100 text-gray-800 ring-gray-600/20",
-        className
+        className,
       )}
     >
       {environment}
-      {environment === "production" && (
-        <Crown className="ml-2 h-3 w-3" />
-      )}
+      {environment === "production" && <Crown className="ml-2 h-3 w-3" />}
     </span>
   );
 };
 
-export default EnvironmentPill; 
+export default EnvironmentPill;

--- a/web/components/templates/prompts2025/PromptDetails.tsx
+++ b/web/components/templates/prompts2025/PromptDetails.tsx
@@ -34,7 +34,7 @@ import useNotification from "@/components/shared/notification/useNotification";
 interface PromptDetailsProps {
   promptWithVersions: PromptWithVersions | null;
   onRenamePrompt: (promptId: string, newName: string) => void;
-  onSetProductionVersion: (promptId: string, promptVersionId: string) => void;
+  onSetEnvironment: (promptId: string, promptVersionId: string, environment: string) => void;
   onOpenPromptVersion: (promptVersionId: string) => void;
   onDeletePrompt: (promptId: string) => void;
   onDeletePromptVersion: (promptVersionId: string) => void;
@@ -45,7 +45,7 @@ interface PromptDetailsProps {
 const PromptDetails = ({
   promptWithVersions,
   onRenamePrompt,
-  onSetProductionVersion,
+  onSetEnvironment,
   onOpenPromptVersion,
   onDeletePrompt,
   onDeletePromptVersion,
@@ -224,7 +224,7 @@ const PromptDetails = ({
       <div className="flex-1 overflow-y-auto">
         <PromptVersionHistory
           promptWithVersions={promptWithVersions}
-          onSetProductionVersion={onSetProductionVersion}
+          onSetEnvironment={onSetEnvironment}
           onOpenPromptVersion={onOpenPromptVersion}
           onDeletePromptVersion={onDeletePromptVersion}
         />

--- a/web/components/templates/prompts2025/PromptDetails.tsx
+++ b/web/components/templates/prompts2025/PromptDetails.tsx
@@ -34,7 +34,11 @@ import useNotification from "@/components/shared/notification/useNotification";
 interface PromptDetailsProps {
   promptWithVersions: PromptWithVersions | null;
   onRenamePrompt: (promptId: string, newName: string) => void;
-  onSetEnvironment: (promptId: string, promptVersionId: string, environment: string) => void;
+  onSetEnvironment: (
+    promptId: string,
+    promptVersionId: string,
+    environment: string,
+  ) => void;
   onOpenPromptVersion: (promptVersionId: string) => void;
   onDeletePrompt: (promptId: string) => void;
   onDeletePromptVersion: (promptVersionId: string) => void;

--- a/web/components/templates/prompts2025/PromptVersionCard.tsx
+++ b/web/components/templates/prompts2025/PromptVersionCard.tsx
@@ -35,7 +35,15 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { TestTube2, Rocket, Clock, Trash2, Check, ChevronsUpDown, Crown } from "lucide-react";
+import {
+  TestTube2,
+  Rocket,
+  Clock,
+  Trash2,
+  Check,
+  ChevronsUpDown,
+  Crown,
+} from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -51,7 +59,11 @@ type Prompt2025Version = components["schemas"]["Prompt2025Version"];
 interface PromptVersionCardProps {
   version: Prompt2025Version;
   isProductionVersion?: boolean;
-  onSetEnvironment: (promptId: string, promptVersionId: string, environment: string) => void;
+  onSetEnvironment: (
+    promptId: string,
+    promptVersionId: string,
+    environment: string,
+  ) => void;
   onOpenPromptVersion: (promptVersionId: string) => void;
   onDeletePromptVersion: (promptVersionId: string) => void;
 }
@@ -64,11 +76,15 @@ const PromptVersionCard = ({
   onDeletePromptVersion,
 }: PromptVersionCardProps) => {
   const [isEnvironmentDialogOpen, setIsEnvironmentDialogOpen] = useState(false);
-  const [selectedEnvironment, setSelectedEnvironment] = useState<string | undefined>(undefined);
+  const [selectedEnvironment, setSelectedEnvironment] = useState<
+    string | undefined
+  >(undefined);
   const [customEnvironment, setCustomEnvironment] = useState("");
-  const [isEnvironmentDropdownOpen, setIsEnvironmentDropdownOpen] = useState(false);
+  const [isEnvironmentDropdownOpen, setIsEnvironmentDropdownOpen] =
+    useState(false);
 
-  const { data: environments = [], isLoading: isLoadingEnvironments } = useGetPromptEnvironments();
+  const { data: environments = [], isLoading: isLoadingEnvironments } =
+    useGetPromptEnvironments();
 
   const versionDisplay =
     version.minor_version === 0
@@ -97,16 +113,20 @@ const PromptVersionCard = ({
               {versionDisplay}
             </span>
             {version.environment && (
-              <span className={cn(
-                "inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ring-1 ring-inset",
-                version.environment === 'production' 
-                  ? "bg-green-100 text-green-800 ring-green-600/20"
-                  : ['dev', 'development', 'staging'].includes(version.environment.toLowerCase())
-                  ? "bg-blue-100 text-blue-800 ring-blue-600/20"
-                  : "bg-gray-100 text-gray-800 ring-gray-600/20"
-              )}>
+              <span
+                className={cn(
+                  "inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ring-1 ring-inset",
+                  version.environment === "production"
+                    ? "bg-green-100 text-green-800 ring-green-600/20"
+                    : ["dev", "development", "staging"].includes(
+                          version.environment.toLowerCase(),
+                        )
+                      ? "bg-blue-100 text-blue-800 ring-blue-600/20"
+                      : "bg-gray-100 text-gray-800 ring-gray-600/20",
+                )}
+              >
                 {version.environment}
-                {version.environment === 'production' && (
+                {version.environment === "production" && (
                   <Crown className="ml-2 h-3 w-3" />
                 )}
               </span>
@@ -132,8 +152,11 @@ const PromptVersionCard = ({
               <p>Open in Playground</p>
             </TooltipContent>
           </Tooltip>
-          
-          <Dialog open={isEnvironmentDialogOpen} onOpenChange={setIsEnvironmentDialogOpen}>
+
+          <Dialog
+            open={isEnvironmentDialogOpen}
+            onOpenChange={setIsEnvironmentDialogOpen}
+          >
             <Tooltip delayDuration={100}>
               <TooltipTrigger asChild>
                 <DialogTrigger asChild>
@@ -157,13 +180,18 @@ const PromptVersionCard = ({
               <DialogHeader>
                 <DialogTitle>Set Environment for {versionDisplay}</DialogTitle>
                 <DialogDescription>
-                  Select an environment to deploy this prompt version to. This will immediately point all prompt calls in this environment to this version.
+                  Select an environment to deploy this prompt version to. This
+                  will immediately point all prompt calls in this environment to
+                  this version.
                 </DialogDescription>
               </DialogHeader>
               <div className="flex flex-col gap-4 pb-2">
                 <div className="flex flex-col gap-2">
                   <label className="text-sm font-medium">Environment</label>
-                  <Popover open={isEnvironmentDropdownOpen} onOpenChange={setIsEnvironmentDropdownOpen}>
+                  <Popover
+                    open={isEnvironmentDropdownOpen}
+                    onOpenChange={setIsEnvironmentDropdownOpen}
+                  >
                     <PopoverTrigger asChild>
                       <Button
                         variant="outline"
@@ -172,7 +200,9 @@ const PromptVersionCard = ({
                         className="w-full justify-between"
                         disabled={isLoadingEnvironments}
                       >
-                        {selectedEnvironment || customEnvironment || "Select environment"}
+                        {selectedEnvironment ||
+                          customEnvironment ||
+                          "Select environment"}
                         <ChevronsUpDown size={16} className="opacity-50" />
                       </Button>
                     </PopoverTrigger>
@@ -195,12 +225,14 @@ const PromptVersionCard = ({
                                   size={16}
                                   className={cn(
                                     "mr-2",
-                                    selectedEnvironment === env ? "opacity-100" : "opacity-0"
+                                    selectedEnvironment === env
+                                      ? "opacity-100"
+                                      : "opacity-0",
                                   )}
                                 />
                                 {env}
-                                {env === 'production' && (
-                                  <Crown className="ml-auto text-muted-foreground/50 h-3 w-3"/>
+                                {env === "production" && (
+                                  <Crown className="ml-auto h-3 w-3 text-muted-foreground/50" />
                                 )}
                               </CommandItem>
                             ))}
@@ -224,10 +256,13 @@ const PromptVersionCard = ({
                 </div>
               </div>
               <DialogFooter>
-                <Button variant="outline" onClick={() => setIsEnvironmentDialogOpen(false)}>
+                <Button
+                  variant="outline"
+                  onClick={() => setIsEnvironmentDialogOpen(false)}
+                >
                   Cancel
                 </Button>
-                <Button 
+                <Button
                   onClick={handleSetEnvironment}
                   disabled={!selectedEnvironment && !customEnvironment}
                 >

--- a/web/components/templates/prompts2025/PromptVersionCard.tsx
+++ b/web/components/templates/prompts2025/PromptVersionCard.tsx
@@ -53,6 +53,7 @@ import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { useGetPromptEnvironments } from "@/services/hooks/prompts";
 import { Input } from "@/components/ui/input";
+import EnvironmentPill from "./EnvironmentPill";
 
 type Prompt2025Version = components["schemas"]["Prompt2025Version"];
 
@@ -113,23 +114,7 @@ const PromptVersionCard = ({
               {versionDisplay}
             </span>
             {version.environment && (
-              <span
-                className={cn(
-                  "inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ring-1 ring-inset",
-                  version.environment === "production"
-                    ? "bg-green-100 text-green-800 ring-green-600/20"
-                    : ["dev", "development", "staging"].includes(
-                          version.environment.toLowerCase(),
-                        )
-                      ? "bg-blue-100 text-blue-800 ring-blue-600/20"
-                      : "bg-gray-100 text-gray-800 ring-gray-600/20",
-                )}
-              >
-                {version.environment}
-                {version.environment === "production" && (
-                  <Crown className="ml-2 h-3 w-3" />
-                )}
-              </span>
+              <EnvironmentPill environment={version.environment} />
             )}
           </div>
         </div>

--- a/web/components/templates/prompts2025/PromptVersionCard.tsx
+++ b/web/components/templates/prompts2025/PromptVersionCard.tsx
@@ -13,19 +13,45 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { TestTube2, Crown, Clock, Trash2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { TestTube2, Rocket, Clock, Trash2, Check, ChevronsUpDown, Crown } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { useGetPromptEnvironments } from "@/services/hooks/prompts";
+import { Input } from "@/components/ui/input";
 
 type Prompt2025Version = components["schemas"]["Prompt2025Version"];
 
 interface PromptVersionCardProps {
   version: Prompt2025Version;
   isProductionVersion?: boolean;
-  onSetProductionVersion: (promptId: string, promptVersionId: string) => void;
+  onSetEnvironment: (promptId: string, promptVersionId: string, environment: string) => void;
   onOpenPromptVersion: (promptVersionId: string) => void;
   onDeletePromptVersion: (promptVersionId: string) => void;
 }
@@ -33,14 +59,31 @@ interface PromptVersionCardProps {
 const PromptVersionCard = ({
   version,
   isProductionVersion = false,
-  onSetProductionVersion,
+  onSetEnvironment,
   onOpenPromptVersion,
   onDeletePromptVersion,
 }: PromptVersionCardProps) => {
+  const [isEnvironmentDialogOpen, setIsEnvironmentDialogOpen] = useState(false);
+  const [selectedEnvironment, setSelectedEnvironment] = useState<string | undefined>(undefined);
+  const [customEnvironment, setCustomEnvironment] = useState("");
+  const [isEnvironmentDropdownOpen, setIsEnvironmentDropdownOpen] = useState(false);
+
+  const { data: environments = [], isLoading: isLoadingEnvironments } = useGetPromptEnvironments();
+
   const versionDisplay =
     version.minor_version === 0
       ? `v${version.major_version}`
       : `v${version.major_version}.${version.minor_version}`;
+
+  const handleSetEnvironment = () => {
+    const environmentToSet = selectedEnvironment || customEnvironment;
+    if (environmentToSet) {
+      onSetEnvironment(version.prompt_id, version.id, environmentToSet);
+      setIsEnvironmentDialogOpen(false);
+      setSelectedEnvironment(undefined);
+      setCustomEnvironment("");
+    }
+  };
 
   return (
     <div className="group w-full cursor-pointer border-b border-border bg-background transition-colors hover:bg-muted/50">
@@ -53,9 +96,19 @@ const PromptVersionCard = ({
             <span className="inline-flex items-center rounded-full bg-primary/10 px-2 py-1 text-xs font-medium text-primary ring-1 ring-inset ring-primary/20">
               {versionDisplay}
             </span>
-            {isProductionVersion && (
-              <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-800 ring-1 ring-inset ring-green-600/20">
-                Production
+            {version.environment && (
+              <span className={cn(
+                "inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ring-1 ring-inset",
+                version.environment === 'production' 
+                  ? "bg-green-100 text-green-800 ring-green-600/20"
+                  : ['dev', 'development', 'staging'].includes(version.environment.toLowerCase())
+                  ? "bg-blue-100 text-blue-800 ring-blue-600/20"
+                  : "bg-gray-100 text-gray-800 ring-gray-600/20"
+              )}>
+                {version.environment}
+                {version.environment === 'production' && (
+                  <Crown className="ml-2 h-3 w-3" />
+                )}
               </span>
             )}
           </div>
@@ -79,49 +132,111 @@ const PromptVersionCard = ({
               <p>Open in Playground</p>
             </TooltipContent>
           </Tooltip>
-          {!isProductionVersion && (
-            <AlertDialog>
-              <Tooltip delayDuration={100}>
-                <TooltipTrigger asChild>
-                  <AlertDialogTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                      }}
-                    >
-                      <Crown className="h-4 w-4 text-muted-foreground" />
-                    </Button>
-                  </AlertDialogTrigger>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Set as Production</p>
-                </TooltipContent>
-              </Tooltip>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Set as Production Version</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    Are you sure you want to set {versionDisplay} as the
-                    production version? This will replace the current production
-                    version and affect all future API calls using this prompt.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={() =>
-                      onSetProductionVersion(version.prompt_id, version.id)
-                    }
+          
+          <Dialog open={isEnvironmentDialogOpen} onOpenChange={setIsEnvironmentDialogOpen}>
+            <Tooltip delayDuration={100}>
+              <TooltipTrigger asChild>
+                <DialogTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                    }}
                   >
-                    Set as Production
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          )}
+                    <Rocket className="h-4 w-4 text-muted-foreground" />
+                  </Button>
+                </DialogTrigger>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Set Environment</p>
+              </TooltipContent>
+            </Tooltip>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Set Environment for {versionDisplay}</DialogTitle>
+                <DialogDescription>
+                  Select an environment to deploy this prompt version to. This will immediately point all prompt calls in this environment to this version.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="flex flex-col gap-4 pb-2">
+                <div className="flex flex-col gap-2">
+                  <label className="text-sm font-medium">Environment</label>
+                  <Popover open={isEnvironmentDropdownOpen} onOpenChange={setIsEnvironmentDropdownOpen}>
+                    <PopoverTrigger asChild>
+                      <Button
+                        variant="outline"
+                        role="combobox"
+                        aria-expanded={isEnvironmentDropdownOpen}
+                        className="w-full justify-between"
+                        disabled={isLoadingEnvironments}
+                      >
+                        {selectedEnvironment || customEnvironment || "Select environment"}
+                        <ChevronsUpDown size={16} className="opacity-50" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-full p-0">
+                      <Command>
+                        <CommandInput placeholder="Search environments..." />
+                        <CommandList>
+                          <CommandEmpty>No environments found.</CommandEmpty>
+                          <CommandGroup>
+                            {environments.map((env) => (
+                              <CommandItem
+                                key={env}
+                                onSelect={() => {
+                                  setSelectedEnvironment(env);
+                                  setCustomEnvironment("");
+                                  setIsEnvironmentDropdownOpen(false);
+                                }}
+                              >
+                                <Check
+                                  size={16}
+                                  className={cn(
+                                    "mr-2",
+                                    selectedEnvironment === env ? "opacity-100" : "opacity-0"
+                                  )}
+                                />
+                                {env}
+                                {env === 'production' && (
+                                  <Crown className="ml-auto text-muted-foreground/50 h-3 w-3"/>
+                                )}
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
+                  <div className="mt-2 flex flex-col gap-2">
+                    <Input
+                      placeholder="Or enter custom environment name..."
+                      value={customEnvironment}
+                      onChange={(e) => {
+                        setCustomEnvironment(e.target.value);
+                        if (e.target.value) {
+                          setSelectedEnvironment(undefined);
+                        }
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setIsEnvironmentDialogOpen(false)}>
+                  Cancel
+                </Button>
+                <Button 
+                  onClick={handleSetEnvironment}
+                  disabled={!selectedEnvironment && !customEnvironment}
+                >
+                  Set Environment
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+
           <AlertDialog>
             <Tooltip delayDuration={100}>
               <TooltipTrigger asChild>

--- a/web/components/templates/prompts2025/PromptVersionHistory.tsx
+++ b/web/components/templates/prompts2025/PromptVersionHistory.tsx
@@ -3,7 +3,11 @@ import PromptVersionCard from "./PromptVersionCard";
 
 interface PromptVersionHistoryProps {
   promptWithVersions: PromptWithVersions;
-  onSetEnvironment: (promptId: string, promptVersionId: string, environment: string) => void;
+  onSetEnvironment: (
+    promptId: string,
+    promptVersionId: string,
+    environment: string,
+  ) => void;
   onOpenPromptVersion: (promptVersionId: string) => void;
   onDeletePromptVersion: (promptVersionId: string) => void;
 }

--- a/web/components/templates/prompts2025/PromptVersionHistory.tsx
+++ b/web/components/templates/prompts2025/PromptVersionHistory.tsx
@@ -3,14 +3,14 @@ import PromptVersionCard from "./PromptVersionCard";
 
 interface PromptVersionHistoryProps {
   promptWithVersions: PromptWithVersions;
-  onSetProductionVersion: (promptId: string, promptVersionId: string) => void;
+  onSetEnvironment: (promptId: string, promptVersionId: string, environment: string) => void;
   onOpenPromptVersion: (promptVersionId: string) => void;
   onDeletePromptVersion: (promptVersionId: string) => void;
 }
 
 const PromptVersionHistory = ({
   promptWithVersions,
-  onSetProductionVersion,
+  onSetEnvironment,
   onOpenPromptVersion,
   onDeletePromptVersion,
 }: PromptVersionHistoryProps) => {
@@ -23,7 +23,7 @@ const PromptVersionHistory = ({
           key={version.id}
           version={version}
           isProductionVersion={version.id === productionVersion.id}
-          onSetProductionVersion={onSetProductionVersion}
+          onSetEnvironment={onSetEnvironment}
           onOpenPromptVersion={onOpenPromptVersion}
           onDeletePromptVersion={onDeletePromptVersion}
         />

--- a/web/components/templates/prompts2025/promptsPage.tsx
+++ b/web/components/templates/prompts2025/promptsPage.tsx
@@ -93,7 +93,7 @@ const PromptsPage = (props: PromptsPageProps) => {
     setFilteredMajorVersion(majorVersion);
   };
 
-  const setProductionVersion = useSetPromptVersionEnvironment();
+  const setEnvironment = useSetPromptVersionEnvironment();
   const deletePrompt = useDeletePrompt();
   const deletePromptVersion = useDeletePromptVersion();
   const renamePrompt = useRenamePrompt();
@@ -124,7 +124,7 @@ const PromptsPage = (props: PromptsPageProps) => {
     promptVersionId: string,
     environment: string,
   ) => {
-    const result = await setProductionVersion.mutateAsync({
+    const result = await setEnvironment.mutateAsync({
       body: {
         promptId,
         promptVersionId,

--- a/web/components/templates/prompts2025/promptsPage.tsx
+++ b/web/components/templates/prompts2025/promptsPage.tsx
@@ -12,7 +12,7 @@ import {
 import {
   useGetPromptsWithVersions,
   useGetPromptVersions,
-  useSetProductionVersion,
+  useSetPromptVersionEnvironment,
   useGetPromptTags,
   useDeletePrompt,
   useDeletePromptVersion,
@@ -93,7 +93,7 @@ const PromptsPage = (props: PromptsPageProps) => {
     setFilteredMajorVersion(majorVersion);
   };
 
-  const setProductionVersion = useSetProductionVersion();
+  const setProductionVersion = useSetPromptVersionEnvironment();
   const deletePrompt = useDeletePrompt();
   const deletePromptVersion = useDeletePromptVersion();
   const renamePrompt = useRenamePrompt();
@@ -119,22 +119,24 @@ const PromptsPage = (props: PromptsPageProps) => {
     }
   };
 
-  const handleSetProductionVersion = async (
+  const handleSetPromptVersionEnvironment = async (
     promptId: string,
     promptVersionId: string,
+    environment: string,
   ) => {
     const result = await setProductionVersion.mutateAsync({
       body: {
         promptId,
         promptVersionId,
+        environment,
       },
     });
 
     if (result.error) {
-      setNotification("Error setting production version", "error");
-      console.error("Error setting production version", result.error);
+      setNotification("Error setting environment", "error");
+      console.error("Error setting environment", result.error);
     } else {
-      setNotification("Production version set successfully", "success");
+      setNotification("Environment set successfully", "success");
     }
   };
 
@@ -370,7 +372,7 @@ const PromptsPage = (props: PromptsPageProps) => {
           >
             <PromptDetails
               onRenamePrompt={handleRenamePrompt}
-              onSetProductionVersion={handleSetProductionVersion}
+              onSetEnvironment={handleSetPromptVersionEnvironment}
               onOpenPromptVersion={handleOpenPromptVersion}
               onDeletePrompt={handleDeletePrompt}
               onDeletePromptVersion={handleDeletePromptVersion}

--- a/web/components/templates/properties/propertiesPage.tsx
+++ b/web/components/templates/properties/propertiesPage.tsx
@@ -25,7 +25,7 @@ const PropertiesPage = (props: { initialPropertyKey?: string }) => {
   const filteredProperties = useMemo(() => {
     if (!searchQuery) return properties;
     return properties.filter((property) =>
-      property.toLowerCase().includes(searchQuery.toLowerCase())
+      property.toLowerCase().includes(searchQuery.toLowerCase()),
     );
   }, [properties, searchQuery]);
 
@@ -126,7 +126,7 @@ const PropertiesPage = (props: { initialPropertyKey?: string }) => {
       )}
 
       <div className="flex flex-1 flex-col overflow-hidden">
-        <div className="flex flex-1 flex-col border border-border bg-background lg:flex-row lg:h-full">
+        <div className="flex flex-1 flex-col border border-border bg-background lg:h-full lg:flex-row">
           <div className="flex w-full flex-col border-b border-border bg-background lg:w-72 lg:border-b-0 lg:border-r">
             <div className="border-b border-border p-4">
               <div className="relative">
@@ -142,7 +142,8 @@ const PropertiesPage = (props: { initialPropertyKey?: string }) => {
             <div className="flex-1 overflow-y-auto">
               {filteredProperties.map((property, i) => {
                 const originalIndex = properties.indexOf(property);
-                const requiresPremium = !hasAccess && originalIndex >= freeLimit;
+                const requiresPremium =
+                  !hasAccess && originalIndex >= freeLimit;
                 const isSelected = selectedProperty === property;
 
                 return (

--- a/web/components/templates/properties/propertyPanel.tsx
+++ b/web/components/templates/properties/propertyPanel.tsx
@@ -211,9 +211,8 @@ const PropertyPanel = (props: PropertyPanelProps) => {
                       <div className="mt-0.5 text-lg font-semibold">
                         {
                           +(
-                            keyMetrics.totalRequests?.data?.data?.toFixed(
-                              2,
-                            ) ?? 0
+                            keyMetrics.totalRequests?.data?.data?.toFixed(2) ??
+                            0
                           )
                         }
                       </div>
@@ -226,7 +225,9 @@ const PropertyPanel = (props: PropertyPanelProps) => {
                     <Clock className="h-3 w-3 text-purple-600 dark:text-purple-400" />
                   </div>
                   <div className="min-w-0">
-                    <XSmall className="text-muted-foreground">Avg Latency</XSmall>
+                    <XSmall className="text-muted-foreground">
+                      Avg Latency
+                    </XSmall>
                     {isAnyLoading ? (
                       <Skeleton className="mt-1 h-5 w-16 bg-muted" />
                     ) : (
@@ -245,9 +246,19 @@ const PropertyPanel = (props: PropertyPanelProps) => {
                 <div className="w-full">
                   <div className="space-y-3">
                     <div className="flex items-center gap-4">
-                      {["Value", "Requests", "Cost", "Avg Prompt Tokens", "Avg Comp Tokens", "Avg Latency", "Avg Cost"].map((header) => (
+                      {[
+                        "Value",
+                        "Requests",
+                        "Cost",
+                        "Avg Prompt Tokens",
+                        "Avg Comp Tokens",
+                        "Avg Latency",
+                        "Avg Cost",
+                      ].map((header) => (
                         <div key={header} className="flex-1">
-                          <XSmall className="mb-2 font-medium text-muted-foreground">{header}</XSmall>
+                          <XSmall className="mb-2 font-medium text-muted-foreground">
+                            {header}
+                          </XSmall>
                           <Skeleton className="h-5 w-full bg-muted" />
                         </div>
                       ))}
@@ -266,120 +277,120 @@ const PropertyPanel = (props: PropertyPanelProps) => {
               ) : (
                 <div className="overflow-x-auto">
                   <SimpleTable
-                      className="w-full"
-                      data={cleanedValueData}
-                      columns={[
-                        {
-                          key: "property_value" as keyof (typeof cleanedValueData)[0],
-                          header: "Value",
-                          sortable: true,
-                          render: (propertyValue) => (
-                            <button
-                              className="flex items-center gap-1 text-left font-medium text-foreground hover:text-primary"
-                              title={propertyValue.property_value}
-                              onClick={() => {
-                                const value = propertyValue.property_value;
-                                const filterMapIndex = filterMap.findIndex(
-                                  (f) => f.label === property,
-                                );
-                                const currentAdvancedFilters =
-                                  encodeURIComponent(
-                                    JSON.stringify({
-                                      filter: [
-                                        {
-                                          filterMapIdx: filterMapIndex,
-                                          operatorIdx: 0,
-                                          value,
-                                        },
-                                      ]
-                                        .map(encodeFilter)
-                                        .join("|"),
-                                    }),
-                                  );
+                    className="w-full"
+                    data={cleanedValueData}
+                    columns={[
+                      {
+                        key: "property_value" as keyof (typeof cleanedValueData)[0],
+                        header: "Value",
+                        sortable: true,
+                        render: (propertyValue) => (
+                          <button
+                            className="flex items-center gap-1 text-left font-medium text-foreground hover:text-primary"
+                            title={propertyValue.property_value}
+                            onClick={() => {
+                              const value = propertyValue.property_value;
+                              const filterMapIndex = filterMap.findIndex(
+                                (f) => f.label === property,
+                              );
+                              const currentAdvancedFilters = encodeURIComponent(
+                                JSON.stringify({
+                                  filter: [
+                                    {
+                                      filterMapIdx: filterMapIndex,
+                                      operatorIdx: 0,
+                                      value,
+                                    },
+                                  ]
+                                    .map(encodeFilter)
+                                    .join("|"),
+                                }),
+                              );
 
-                                router.push({
-                                  pathname: "/requests",
-                                  query: {
-                                    t: "3m",
-                                    filters: currentAdvancedFilters,
-                                  },
-                                });
-                              }}
-                            >
-                              <span className="truncate">{propertyValue.property_value}</span>
-                              <ExternalLink className="h-3 w-3 flex-shrink-0 text-muted-foreground" />
-                            </button>
+                              router.push({
+                                pathname: "/requests",
+                                query: {
+                                  t: "3m",
+                                  filters: currentAdvancedFilters,
+                                },
+                              });
+                            }}
+                          >
+                            <span className="truncate">
+                              {propertyValue.property_value}
+                            </span>
+                            <ExternalLink className="h-3 w-3 flex-shrink-0 text-muted-foreground" />
+                          </button>
+                        ),
+                      },
+                      {
+                        key: "total_requests" as keyof (typeof cleanedValueData)[0],
+                        header: "Requests",
+                        sortable: true,
+                        render: (propertyValue) => propertyValue.total_requests,
+                      },
+                      {
+                        key: "total_cost" as keyof (typeof cleanedValueData)[0],
+                        header: "Cost",
+                        sortable: true,
+                        render: (propertyValue) =>
+                          `$${formatNumber(propertyValue.total_cost, 6)}`,
+                      },
+                      {
+                        key: "avg_prompt_tokens_per_request" as keyof (typeof cleanedValueData)[0],
+                        header: "Avg Prompt Tokens",
+                        sortable: true,
+                        render: (propertyValue) =>
+                          formatNumber(
+                            propertyValue.avg_prompt_tokens_per_request,
+                            6,
                           ),
-                        },
-                        {
-                          key: "total_requests" as keyof (typeof cleanedValueData)[0],
-                          header: "Requests",
-                          sortable: true,
-                          render: (propertyValue) =>
-                            propertyValue.total_requests,
-                        },
-                        {
-                          key: "total_cost" as keyof (typeof cleanedValueData)[0],
-                          header: "Cost",
-                          sortable: true,
-                          render: (propertyValue) =>
-                            `$${formatNumber(propertyValue.total_cost, 6)}`,
-                        },
-                        {
-                          key: "avg_prompt_tokens_per_request" as keyof (typeof cleanedValueData)[0],
-                          header: "Avg Prompt Tokens",
-                          sortable: true,
-                          render: (propertyValue) =>
-                            formatNumber(
-                              propertyValue.avg_prompt_tokens_per_request,
-                              6,
-                            ),
-                        },
-                        {
-                          key: "avg_completion_tokens_per_request" as keyof (typeof cleanedValueData)[0],
-                          header: "Avg Comp Tokens",
-                          sortable: true,
-                          render: (propertyValue) =>
-                            formatNumber(
-                              propertyValue.avg_completion_tokens_per_request,
-                              6,
-                            ),
-                        },
-                        {
-                          key: "avg_latency_per_request" as keyof (typeof cleanedValueData)[0],
-                          header: "Avg Latency",
-                          sortable: true,
-                          render: (propertyValue) =>
-                            formatNumber(
-                              propertyValue.avg_latency_per_request,
-                              6,
-                            ),
-                        },
-                        {
-                          key: "average_cost_per_request" as keyof (typeof cleanedValueData)[0],
-                          header: "Avg Cost",
-                          sortable: true,
-                          render: (propertyValue) =>
-                            `$${formatNumber(
-                              propertyValue.average_cost_per_request,
-                              6,
-                            )}`,
-                        },
-                      ]}
-                      emptyMessage="No property data available"
-                      onSort={(
-                        key: keyof (typeof cleanedValueData)[0] | undefined,
-                        direction: "asc" | "desc",
-                      ) => {
-                        setSortConfig({
-                          key: key as string,
-                          direction,
-                        });
-                      }}
-                      currentSortKey={sortConfig.key}
-                      currentSortDirection={sortConfig.direction}
-                    />
-                  </div>
+                      },
+                      {
+                        key: "avg_completion_tokens_per_request" as keyof (typeof cleanedValueData)[0],
+                        header: "Avg Comp Tokens",
+                        sortable: true,
+                        render: (propertyValue) =>
+                          formatNumber(
+                            propertyValue.avg_completion_tokens_per_request,
+                            6,
+                          ),
+                      },
+                      {
+                        key: "avg_latency_per_request" as keyof (typeof cleanedValueData)[0],
+                        header: "Avg Latency",
+                        sortable: true,
+                        render: (propertyValue) =>
+                          formatNumber(
+                            propertyValue.avg_latency_per_request,
+                            6,
+                          ),
+                      },
+                      {
+                        key: "average_cost_per_request" as keyof (typeof cleanedValueData)[0],
+                        header: "Avg Cost",
+                        sortable: true,
+                        render: (propertyValue) =>
+                          `$${formatNumber(
+                            propertyValue.average_cost_per_request,
+                            6,
+                          )}`,
+                      },
+                    ]}
+                    emptyMessage="No property data available"
+                    onSort={(
+                      key: keyof (typeof cleanedValueData)[0] | undefined,
+                      direction: "asc" | "desc",
+                    ) => {
+                      setSortConfig({
+                        key: key as string,
+                        direction,
+                      });
+                    }}
+                    currentSortKey={sortConfig.key}
+                    currentSortDirection={sortConfig.direction}
+                  />
+                </div>
               )}
 
               {propertyValueData.length > 10 && (

--- a/web/lib/clients/jawnTypes/private.ts
+++ b/web/lib/clients/jawnTypes/private.ts
@@ -177,6 +177,9 @@ export interface paths {
   "/v1/prompt-2025/tags": {
     get: operations["GetPrompt2025Tags"];
   };
+  "/v1/prompt-2025/environments": {
+    get: operations["GetPrompt2025Environments"];
+  };
   "/v1/prompt-2025": {
     post: operations["CreatePrompt2025"];
   };
@@ -16460,6 +16463,16 @@ export interface operations {
     };
   };
   GetPrompt2025Tags: {
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_string-Array.string_"];
+        };
+      };
+    };
+  };
+  GetPrompt2025Environments: {
     responses: {
       /** @description Ok */
       200: {

--- a/web/lib/clients/jawnTypes/private.ts
+++ b/web/lib/clients/jawnTypes/private.ts
@@ -186,8 +186,8 @@ export interface paths {
   "/v1/prompt-2025/update": {
     post: operations["UpdatePrompt2025"];
   };
-  "/v1/prompt-2025/update/production-version": {
-    post: operations["SetProductionVersion"];
+  "/v1/prompt-2025/update/environment": {
+    post: operations["SetPromptVersionEnvironment"];
   };
   "/v1/prompt-2025/count": {
     get: operations["GetPrompt2025Count"];
@@ -16507,7 +16507,7 @@ export interface operations {
         "application/json": {
           promptBody: components["schemas"]["OpenAIChatRequest"];
           commitMessage: string;
-          setAsProduction: boolean;
+          environment?: string;
           newMajorVersion: boolean;
           promptVersionId: string;
           promptId: string;
@@ -16523,10 +16523,11 @@ export interface operations {
       };
     };
   };
-  SetProductionVersion: {
+  SetPromptVersionEnvironment: {
     requestBody: {
       content: {
         "application/json": {
+          environment: string;
           promptVersionId: string;
           promptId: string;
         };

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -100,8 +100,8 @@ export interface paths {
   "/v1/prompt-2025/update": {
     post: operations["UpdatePrompt2025"];
   };
-  "/v1/prompt-2025/update/production-version": {
-    post: operations["SetProductionVersion"];
+  "/v1/prompt-2025/update/environment": {
+    post: operations["SetPromptVersionEnvironment"];
   };
   "/v1/prompt-2025/count": {
     get: operations["GetPrompt2025Count"];
@@ -4042,7 +4042,7 @@ export interface operations {
         "application/json": {
           promptBody: components["schemas"]["OpenAIChatRequest"];
           commitMessage: string;
-          setAsProduction: boolean;
+          environment?: string;
           newMajorVersion: boolean;
           promptVersionId: string;
           promptId: string;
@@ -4058,10 +4058,11 @@ export interface operations {
       };
     };
   };
-  SetProductionVersion: {
+  SetPromptVersionEnvironment: {
     requestBody: {
       content: {
         "application/json": {
+          environment: string;
           promptVersionId: string;
           promptId: string;
         };

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -91,6 +91,9 @@ export interface paths {
   "/v1/prompt-2025/tags": {
     get: operations["GetPrompt2025Tags"];
   };
+  "/v1/prompt-2025/environments": {
+    get: operations["GetPrompt2025Environments"];
+  };
   "/v1/prompt-2025": {
     post: operations["CreatePrompt2025"];
   };
@@ -3995,6 +3998,16 @@ export interface operations {
     };
   };
   GetPrompt2025Tags: {
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_string-Array.string_"];
+        };
+      };
+    };
+  };
+  GetPrompt2025Environments: {
     responses: {
       /** @description Ok */
       200: {

--- a/web/services/hooks/prompts.tsx
+++ b/web/services/hooks/prompts.tsx
@@ -23,6 +23,7 @@ export const useCreatePrompt = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["prompts"] });
       queryClient.invalidateQueries({ queryKey: ["promptTags"] });
+      queryClient.invalidateQueries({ queryKey: ["promptEnvironments"] });
     },
   });
 };
@@ -47,6 +48,10 @@ export const usePushPromptVersion = () => {
   return $JAWN_API.useMutation("post", "/v1/prompt-2025/update", {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["prompts"] });
+      queryClient.invalidateQueries({ queryKey: ["promptsWithVersions"] });
+      queryClient.invalidateQueries({ queryKey: ["promptVersions"] });
+      queryClient.invalidateQueries({ queryKey: ["promptVersionWithBody"] });
+      queryClient.invalidateQueries({ queryKey: ["promptEnvironments"] });
     },
   });
 };
@@ -114,18 +119,19 @@ export const useGetPromptInputs = (
   });
 };
 
-export const useSetProductionVersion = () => {
+export const useSetPromptVersionEnvironment = () => {
   const queryClient = useQueryClient();
 
   return $JAWN_API.useMutation(
     "post",
-    "/v1/prompt-2025/update/production-version",
+    "/v1/prompt-2025/update/environment",
     {
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: ["prompts"] });
         queryClient.invalidateQueries({ queryKey: ["promptsWithVersions"] });
         queryClient.invalidateQueries({ queryKey: ["promptVersions"] });
         queryClient.invalidateQueries({ queryKey: ["promptVersionWithBody"] });
+        queryClient.invalidateQueries({ queryKey: ["promptEnvironments"] });
       },
     },
   );

--- a/web/services/hooks/prompts.tsx
+++ b/web/services/hooks/prompts.tsx
@@ -51,6 +51,20 @@ export const usePushPromptVersion = () => {
   });
 };
 
+export const useGetPromptEnvironments = () => {
+  return useQuery<string[]>({
+    queryKey: ["promptEnvironments"],
+    queryFn: async () => {
+      const result = await $JAWN_API.GET("/v1/prompt-2025/environments", {});
+      if (result.error || !result.data?.data) {
+        console.error("Error fetching prompt environments:", result.error);
+        return [];
+      }
+      return result.data.data;
+    },
+  });
+};
+
 export const useGetPromptTags = () => {
   return useQuery<string[]>({
     queryKey: ["promptTags"],


### PR DESCRIPTION
- Add endpoints to retrieve all environments for an organization
- Update all prompt CRUD endpoints for controlling environment upon creation, update, or manual setting.
- Show environment in the playground if loading a prompt
<img width="518" height="536" alt="Screenshot 2025-08-08 at 1 33 05 AM" src="https://github.com/user-attachments/assets/66be9d43-d4ac-42b2-aa06-8b7f513775c9" />
<img width="672" height="290" alt="Screenshot 2025-08-08 at 1 40 16 AM" src="https://github.com/user-attachments/assets/f9d53e4d-b85f-4c26-bb06-659c30c16da4" />
