### PR TITLE
Fix low severity vulnerabilities in container packages

### DIFF
--- a/docker/dockerfiles/dockerfile_migrations
+++ b/docker/dockerfiles/dockerfile_migrations
@@ -17,7 +17,8 @@ RUN wget -q -O flyway.tar.gz https://repo1.maven.org/maven2/org/flywaydb/flyway-
     && ln -s /opt/flyway/flyway /usr/local/bin/flyway \
     && flyway -v
 
-# Install Python dependencies
+# Install Python dependencies  
+RUN pip install --no-cache-dir --upgrade pip>=24.3.0
 RUN pip install --no-cache-dir requests clickhouse-driver tabulate yarl
 
 WORKDIR /app

--- a/valhalla/dockerfile
+++ b/valhalla/dockerfile
@@ -17,6 +17,15 @@ RUN apt-get update && apt-get install -y supervisor
 # Apply security updates
 RUN apt-get update && apt-get upgrade -y && apt-get autoremove -y && apt-get clean
 
+# Install patched versions to fix security vulnerabilities
+# CVE-2023-26819: libcjson vulnerability 
+# CVE-2025-6170: libxml2 vulnerability
+RUN apt-get update && \
+    apt-get install -y \
+    libcjson-dev=1.7.15-1+deb12u3 \
+    libxml2-dev \
+    && apt-get clean
+
 # Fix CVE-2023-6879 by installing fixed aom version from testing
 RUN echo "deb https://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list && \
     apt-get update && \

--- a/valhalla/jawn/package.json
+++ b/valhalla/jawn/package.json
@@ -31,6 +31,7 @@
     "better-auth": "^1.2.7",
     "body-parser": "^1.20.3",
     "bottleneck": "^2.19.5",
+    "brace-expansion": "^2.0.2",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "cross-spawn": "^7.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7953,6 +7953,13 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
+brace-expansion@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
+  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz"


### PR DESCRIPTION
- Upgraded pip to >=24.3.0 to fix CVE-2023-5752
- Updated brace-expansion to 2.0.2 to fix CVE-2025-5889
- Added libcjson-dev patch for CVE-2023-26819
- Added libxml2-dev updates for CVE-2025-6170
- Transformers already updated to 4.55.0 (fixes CVE-2025-3777)

These fixes address the low severity vulnerabilities identified in AWS container scanning for the Helicone application containers.

🤖 Generated with [Claude Code](https://claude.ai/code)

