### PR TITLE
feat(sdk-ts): Enable cost calculation in TS HeliconeManualLogger

### DIFF
--- a/sdk/typescript/helpers/manual_logger/HeliconeManualLogger.ts
+++ b/sdk/typescript/helpers/manual_logger/HeliconeManualLogger.ts
@@ -24,7 +24,12 @@ export class HeliconeManualLogger {
   private getLoggingEndpoint(provider?: string): string {
     let endpoint = this.LOGGING_ENDPOINT;
     const key = provider ? String(provider).toUpperCase() : undefined;
-    const route = key === "OPENAI" ? "oai" : key === "ANTHROPIC" ? "anthropic" : key === "GOOGLE" ? "googleapis" : "custom";
+    const providerRoutes = new Map([
+      ['OPENAI', 'oai'],
+      ['ANTHROPIC', 'anthropic'],
+      ['GOOGLE', 'googleapis']
+    ]);
+    const route = key ? (providerRoutes.get(key) || 'custom') : 'custom';
     const knownRouteRegex = /(\/(custom|oai|anthropic|googleapis)\/v1\/log)$/;
     return knownRouteRegex.test(endpoint)
       ? endpoint.replace(knownRouteRegex, `/${route}/v1/log`)

--- a/sdk/typescript/helpers/manual_logger/HeliconeManualLogger.ts
+++ b/sdk/typescript/helpers/manual_logger/HeliconeManualLogger.ts
@@ -21,6 +21,16 @@ export class HeliconeManualLogger {
     this.LOGGING_ENDPOINT = opts.loggingEndpoint || this.LOGGING_ENDPOINT;
   }
 
+  private getLoggingEndpoint(provider?: string): string {
+    let endpoint = this.LOGGING_ENDPOINT;
+    const key = provider ? String(provider).toUpperCase() : undefined;
+    const route = key === "OPENAI" ? "oai" : key === "ANTHROPIC" ? "anthropic" : key === "GOOGLE" ? "googleapis" : "custom";
+    const knownRouteRegex = /(\/(custom|oai|anthropic|googleapis)\/v1\/log)$/;
+    return knownRouteRegex.test(endpoint)
+      ? endpoint.replace(knownRouteRegex, `/${route}/v1/log`)
+      : endpoint.replace(/\/$/, "") + `/${route}/v1/log`;
+  }
+
   /**
    * Creates a log builder for more flexible stream handling with error management
    * @param request - The request object to log
@@ -44,7 +54,8 @@ export class HeliconeManualLogger {
   public async logRequest<T>(
     request: HeliconeLogRequest,
     operation: (resultRecorder: HeliconeResultRecorder) => Promise<T>,
-    additionalHeaders?: Record<string, string>
+    additionalHeaders?: Record<string, string>,
+    provider?: string
   ): Promise<T> {
     const startTime = Date.now();
     const resultRecorder = new HeliconeResultRecorder();
@@ -58,6 +69,7 @@ export class HeliconeManualLogger {
         endTime,
         additionalHeaders,
         status: 200,
+        provider,
       });
 
       return result;
@@ -197,6 +209,7 @@ export class HeliconeManualLogger {
       additionalHeaders?: Record<string, string>;
       timeToFirstToken?: number;
       status?: number;
+      provider?: string;
     }
   ): Promise<void> {
     const { startTime, endTime, additionalHeaders, status = 200 } = options;
@@ -248,11 +261,12 @@ export class HeliconeManualLogger {
         providerRequest,
         providerResponse,
         timing,
+        provider: options.provider,
       }),
     };
 
     try {
-      const response = await fetch(this.LOGGING_ENDPOINT, fetchOptions);
+      const response = await fetch(this.getLoggingEndpoint(options.provider), fetchOptions);
       if (!response.ok) {
         console.error(
           "Error making request to Helicone log endpoint:",


### PR DESCRIPTION
**Summary**
- Align the TypeScript HeliconeManualLogger with the Python implementation to support per-call provider routing and accurate endpoint selection.

**Changes**
- Add optional provider to logRequest and resolve endpoint via a private method.

**Impact**
- Brings TS manual logger to functional parity with Python implementation and allows for cost calculation when using HeliconeManualLogger




**Test Proof**
<img width="1487" height="392" alt="image" src="https://github.com/user-attachments/assets/ea63888a-e643-49b8-a86b-b36bc2757a17" />

- Most recent 3 requests included 'provider' in the logRequest call and resulted in accurate OpenAI cost calculation
- Previous requests (before the last 3) show the original behavior (no cost calculation even though the model is correctly determined)
