### PR TITLE
fix: remove ai-gateway section from supervisord.conf

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -40,7 +40,7 @@ stdout_logfile=/var/log/supervisor/jawn.out.log
 stdout_logfile_maxbytes=50MB
 stderr_logfile_maxbytes=50MB
 user=root
-environment=S3_ACCESS_KEY="minioadmin",S3_SECRET_KEY="minioadmin",S3_ENDPOINT="http://localhost:9080",S3_BUCKET_NAME="request-response-storage",KAFKA_CREDS='{"KAFKA_ENABLED": "false", "UPSTASH_KAFKA_BROKER": "localhost:9092", "UPSTASH_KAFKA_URL": "http://localhost:9092", "LOCAL_KAFKA": true}',OPENROUTER_WORKER_URL="http://localhost:8788",OPENAI_API_KEY="sk-...",OPENROUTER_API_KEY="sk-....",PROVIDER_KEYS='{ "DEMO_OPENAI_API_KEY": "sk-..." }',CSB_API_KEY="sk-...",TOGETHER_API_KEY="sk-...",STRIPE_SECRET_KEY="sk_dummy_key_12345678901234567890123456789012345678901234567890",NEXT_PUBLIC_BETTER_AUTH="true",BETTER_AUTH_SECRET="MKUcaeqyMD7UBkGeFYY5hwxKS1aB6Vsi",DATABASE_URL="http://localhost:8123",SUPABASE_DATABASE_URL="postgresql://postgres:password@localhost:5432/helicone_test",HELICONE_WORKER_URL="http://localhost:8585/v1/gateway/oai",NODE_ENV="development",LOG_LEVEL="debug"
+environment=S3_ACCESS_KEY="minioadmin",S3_SECRET_KEY="minioadmin",S3_ENDPOINT="http://localhost:9080",S3_BUCKET_NAME="request-response-storage",KAFKA_CREDS='{"KAFKA_ENABLED": "false", "UPSTASH_KAFKA_BROKER": "localhost:9092", "UPSTASH_KAFKA_URL": "http://localhost:9092", "LOCAL_KAFKA": true}',OPENAI_API_KEY="sk-...",OPENROUTER_API_KEY="sk-....",PROVIDER_KEYS='{ "DEMO_OPENAI_API_KEY": "sk-..." }',CSB_API_KEY="sk-...",TOGETHER_API_KEY="sk-...",STRIPE_SECRET_KEY="sk_dummy_key_12345678901234567890123456789012345678901234567890",NEXT_PUBLIC_BETTER_AUTH="true",BETTER_AUTH_SECRET="MKUcaeqyMD7UBkGeFYY5hwxKS1aB6Vsi",DATABASE_URL="http://localhost:8123",SUPABASE_DATABASE_URL="postgresql://postgres:password@localhost:5432/helicone_test",HELICONE_WORKER_URL="http://localhost:8585/v1/gateway/oai",NODE_ENV="development",LOG_LEVEL="debug"
 
 [program:web]
 command=yarn start
@@ -88,16 +88,6 @@ startretries=3
 stderr_logfile=/var/log/supervisor/minio-setup.err.log
 stdout_logfile=/var/log/supervisor/minio-setup.out.log
 environment=MINIO_ROOT_USER="minioadmin",MINIO_ROOT_PASSWORD="minioadmin"
-
-[program:ai-gateway]
-command=yarn start
-directory=/app/gateway
-autostart=true
-autorestart=true
-stderr_logfile=/var/log/supervisor/ai-gateway.err.log
-stdout_logfile=/var/log/supervisor/ai-gateway.out.log
-user=root
-environment=PORT="8788",CLICKHOUSE_HOST="http://localhost:8123",DATABASE_URL="postgresql://postgres:password@localhost:5432/helicone_test"
 
 [program:log-viewer]
 command=/bin/bash -c "echo 'Log viewer started. Available logs:' && ls -la /var/log/supervisor/*.log && echo 'Use: docker exec -it <container> tail -f /var/log/supervisor/<service>.out.log' && sleep infinity"


### PR DESCRIPTION

## Fix: Resolve supervisord parsing errors in helicone-all-in-one Docker image

### Issue
The `helicone-all-in-one` Docker image was failing to start with supervisord parsing errors:
```
Error: Source contains parsing errors: '/etc/supervisor/conf.d/supervisord.conf'
        [line 73]: '"\n'
        [line 98]: '"\n'
```

This affected versions `v2025.08.10` and `v2025.08.11`, while `v2025.08.08` worked correctly.

### Root Cause
The `supervisord.conf` file contained a `[program:ai-gateway]` section that attempted to run `yarn start` in `/app/gateway` directory. However:
- The `/app/gateway` directory doesn't exist in the Docker image
- The worker infrastructure isn't included in the all-in-one build
- This caused supervisord to fail during configuration parsing

### Solution
- **Removed** the problematic `[program:ai-gateway]` section entirely
- **Removed** unused `OPENROUTER_WORKER_URL` environment variable reference
- **Verified** all remaining services (PostgreSQL, ClickHouse, Jawn, Web, MinIO) are properly configured

@chitalian @devinat1 can you pls check this