### PR TITLE
fix: replace RowType with T type

### DIFF
--- a/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
@@ -79,7 +79,7 @@ export class ClickhouseClientWrapper {
           wait_end_of_query: 1,
         },
       });
-      return { data: await queryResult.json<T>(), error: null };
+      return { data: await queryResult.json<T[]>(), error: null };
     } catch (err) {
       console.error("Error executing Clickhouse query: ", query, parameters);
       console.error(err);
@@ -90,7 +90,7 @@ export class ClickhouseClientWrapper {
     }
   }
 
-  async queryWithContext<RowType>({
+  async queryWithContext<T>({
     query,
     organizationId,
     parameters,
@@ -98,7 +98,7 @@ export class ClickhouseClientWrapper {
     query: string;
     organizationId: string;
     parameters: (number | string | boolean | Date)[];
-  }): Promise<Result<RowType[], string>> {
+  }): Promise<Result<T[], string>> {
     try {
       const query_params = paramsToValues(parameters);
 
@@ -128,7 +128,7 @@ export class ClickhouseClientWrapper {
           allow_ddl: 0,
         } as ClickHouseSettings,
       });
-      return { data: await queryResult.json<RowType>(), error: null };
+      return { data: await queryResult.json<T[]>(), error: null };
     } catch (err) {
       console.error(
         "Error executing HQL query with context: ",

--- a/valhalla/jawn/src/lib/db/test/TestClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/test/TestClickhouseWrapper.ts
@@ -57,10 +57,10 @@ export class TestClickhouseClientWrapper {
     }
   }
 
-  async dbQuery<RowType>(
+  async dbQuery<T>(
     query: string,
     parameters: (number | string | boolean | Date)[]
-  ): Promise<Result<RowType[], string>> {
+  ): Promise<Result<T[], string>> {
     try {
       const query_params = this.paramsToValues(parameters);
 
@@ -72,7 +72,7 @@ export class TestClickhouseClientWrapper {
           wait_end_of_query: 1,
         },
       });
-      return { data: await queryResult.json<RowType>(), error: null };
+      return { data: await queryResult.json<T[]>(), error: null };
     } catch (err) {
       return {
         data: null,
@@ -81,10 +81,10 @@ export class TestClickhouseClientWrapper {
     }
   }
 
-  async dbQueryHql<RowType>(
+  async dbQueryHql<T>(
     query: string,
     parameters: (number | string | boolean | Date)[]
-  ): Promise<Result<RowType[], string>> {
+  ): Promise<Result<T[], string>> {
     try {
       const query_params = this.paramsToValues(parameters);
 
@@ -96,7 +96,7 @@ export class TestClickhouseClientWrapper {
           wait_end_of_query: 1,
         },
       });
-      return { data: await queryResult.json<RowType>(), error: null };
+      return { data: await queryResult.json<T[]>(), error: null };
     } catch (err) {
       return {
         data: null,
@@ -105,7 +105,7 @@ export class TestClickhouseClientWrapper {
     }
   }
 
-  async queryWithContext<RowType>({
+  async queryWithContext<T>({
     query,
     organizationId,
     parameters,
@@ -113,7 +113,7 @@ export class TestClickhouseClientWrapper {
     query: string;
     organizationId: string;
     parameters: (number | string | boolean | Date)[];
-  }): Promise<Result<RowType[], string>> {
+  }): Promise<Result<T[], string>> {
     try {
       const query_params = this.paramsToValues(parameters);
       // Align security check with production: block attempts to reference or set our org-id context
@@ -158,9 +158,9 @@ export class TestClickhouseClientWrapper {
       
       if (isDDL) {
         // DDL commands don't return data
-        return { data: [] as RowType[], error: null };
+        return { data: [] as T[], error: null };
       } else {
-        const rows = (await queryResult.json<RowType>()) as unknown as RowType[];
+        const rows = await queryResult.json<T[]>();
         return { data: rows, error: null };
       }
     } catch (err) {


### PR DESCRIPTION
**Type consistency improvements:**

All query methods in both `ClickhouseClientWrapper` and `TestClickhouseClientWrapper` now use the generic type parameter `T` and consistently return `Promise<Result<T[], string>>` instead of sometimes returning single objects or using `RowType` as the generic. [[1]](diffhunk://#diff-6285f1308e9e3889f3c76edc6c2fc36d2bb3de426418c2ce8c5c44986933a2f5L93-R101) [[2]](diffhunk://#diff-50c29d826b97a1f8eb58ef5de04d29de1844cd2f7ca1584f77bbfd5bb7bfdbdeL60-R63) [[3]](diffhunk://#diff-50c29d826b97a1f8eb58ef5de04d29de1844cd2f7ca1584f77bbfd5bb7bfdbdeL84-R87) [[4]](diffhunk://#diff-50c29d826b97a1f8eb58ef5de04d29de1844cd2f7ca1584f77bbfd5bb7bfdbdeL108-R116)