### PR TITLE
feat: remove announcement banner

### DIFF
--- a/bifrost/app/components/Layout.tsx
+++ b/bifrost/app/components/Layout.tsx
@@ -1,6 +1,6 @@
 import Footer from "@/components/layout/footer";
 import NavBar from "@/components/layout/navbar";
-import Banner from "@/components/home/Banner";
+// import Banner from "@/components/home/Banner";
 import { getMetadata } from "@/components/templates/blog/getMetaData";
 import { BLOG_CONTENT } from "../blog/page";
 
@@ -22,7 +22,7 @@ export const Layout = async ({
 
   return (
     <>
-      <Banner />
+      {/* <Banner /> */}
 
       <NavBar stars={stars} featuredBlogMetadata={featuredBlogMetadata || {
         title: "Check out our latest blog",


### PR DESCRIPTION
Remove announcement banner for the AI gateway. Commented it out for the next time we want to use it.

<img width="3384" height="2250" alt="CleanShot 2025-08-14 at 17 07 09@2x" src="https://github.com/user-attachments/assets/52f89a07-d639-4369-96dd-24d9157948d8" />


