### PR TITLE
fix: added missing cost to RequestResponseRMT interface

### DIFF
--- a/valhalla/jawn/src/lib/stores/ScoreStore.ts
+++ b/valhalla/jawn/src/lib/stores/ScoreStore.ts
@@ -131,6 +131,7 @@ export class ScoreStore extends BaseStore {
       return err("No query params");
     }
 
+    // TODO Use final instead of hand rolling deduplication
     let rowContents = resultMap(
       await clickhouseDb.dbQuery<RequestResponseRMT>(
         `
@@ -231,6 +232,7 @@ export class ScoreStore extends BaseStore {
             scores: validScores,
             cache_enabled: row.cache_enabled,
             cache_reference_id: row.cache_reference_id,
+            cost: row.cost,
           },
         ];
       })


### PR DESCRIPTION
Added the `cost` field to the returned score object, ensuring that cost information is included in query results.