### PR TITLE
Added Groq to AI SDK docs

### DIFF
--- a/docs/getting-started/integration-method/vercelai.mdx
+++ b/docs/getting-started/integration-method/vercelai.mdx
@@ -59,6 +59,9 @@ import { strings } from "/snippets/strings.mdx";
     ```
 
     ```javascript Groq
+    import { createOpenAI } from "@ai-sdk/openai";
+    import { generateText } from "ai";
+
     const groq = createOpenAI({
       baseURL: "https://groq.helicone.ai/openai/v1",
       apiKey: process.env.GROQ_API_KEY,
@@ -73,7 +76,6 @@ import { strings } from "/snippets/strings.mdx";
     });
 
     console.log(response);
-    ```
 
     ```javascript Google Gemini
     import { createGoogleGenerativeAI } from "@ai-sdk/google";


### PR DESCRIPTION
Added groq code example for the Vercel AI SDK.

-- Request from user: https://discord.com/channels/1020597994703310878/1406878700074700821/1407101527788618001

<img width="1444" height="1140" alt="CleanShot 2025-08-19 at 12 00 17" src="https://github.com/user-attachments/assets/b912143a-a7ca-4838-a9e7-98e3949abb12" />


