### PR TITLE
fix: [ENG-2760] remove cost_usd naming, fix cost sorting

### DIFF
--- a/bifrost/lib/clients/jawnTypes/private.ts
+++ b/bifrost/lib/clients/jawnTypes/private.ts
@@ -1372,7 +1372,7 @@ Json: JsonObject;
       values?: {
         [key: string]: components["schemas"]["SortDirection"];
       };
-      cost_usd?: components["schemas"]["SortDirection"];
+      cost?: components["schemas"]["SortDirection"];
     };
     RequestQueryParams: {
       filter: components["schemas"]["RequestFilterNode"];

--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -910,10 +910,10 @@ export interface components {
       timeZoneDifferenceMinutes?: number;
       sort?: components["schemas"]["SortLeafUsers"];
     };
-    "ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array_": {
+    "ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array_": {
       data: {
           /** Format: double */
-          cost_usd: number;
+          cost: number;
           user_id: string;
           /** Format: double */
           completion_tokens: number;
@@ -925,7 +925,7 @@ export interface components {
       /** @enum {number|null} */
       error: null;
     };
-    "Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array.string_": components["schemas"]["ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array_"] | components["schemas"]["ResultError_string_"];
+    "Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array.string_": components["schemas"]["ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array_"] | components["schemas"]["ResultError_string_"];
     UserQueryParams: {
       userIds?: string[];
       timeFilter?: {
@@ -1374,7 +1374,7 @@ export interface components {
       values?: {
         [key: string]: components["schemas"]["SortDirection"];
       };
-      cost_usd?: components["schemas"]["SortDirection"];
+      cost?: components["schemas"]["SortDirection"];
     };
     RequestQueryParams: {
       filter: components["schemas"]["RequestFilterNode"];
@@ -3717,7 +3717,7 @@ export interface operations {
       /** @description Ok */
       200: {
         content: {
-          "application/json": components["schemas"]["Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array.string_"];
+          "application/json": components["schemas"]["Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array.string_"];
         };
       };
     };

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -942,12 +942,12 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array_": {
+			"ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array_": {
 				"properties": {
 					"data": {
 						"items": {
 							"properties": {
-								"cost_usd": {
+								"cost": {
 									"type": "number",
 									"format": "double"
 								},
@@ -968,7 +968,7 @@
 								}
 							},
 							"required": [
-								"cost_usd",
+								"cost",
 								"user_id",
 								"completion_tokens",
 								"prompt_tokens",
@@ -993,10 +993,10 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array.string_": {
+			"Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array.string_": {
 				"anyOf": [
 					{
-						"$ref": "#/components/schemas/ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array_"
+						"$ref": "#/components/schemas/ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array_"
 					},
 					{
 						"$ref": "#/components/schemas/ResultError_string_"
@@ -2736,7 +2736,7 @@
 						},
 						"type": "object"
 					},
-					"cost_usd": {
+					"cost": {
 						"$ref": "#/components/schemas/SortDirection"
 					}
 				},
@@ -11312,7 +11312,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array.string_"
+									"$ref": "#/components/schemas/Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array.string_"
 								}
 							}
 						}

--- a/examples/export/typescript/README.md
+++ b/examples/export/typescript/README.md
@@ -99,7 +99,7 @@ Tabular format with the following columns:
 - prompt_tokens
 - completion_tokens
 - latency
-- cost_usd
+- cost
 
 ## Rate Limiting
 

--- a/examples/export/typescript/index.ts
+++ b/examples/export/typescript/index.ts
@@ -97,7 +97,7 @@ function convertToCSVRow(item: RequestResponse): string {
     "prompt_tokens",
     "completion_tokens",
     "latency",
-    "cost_usd",
+    "cost",
   ];
 
   return fields
@@ -127,7 +127,7 @@ function writeCSVHeader(outputStream: fs.WriteStream): void {
     "prompt_tokens",
     "completion_tokens",
     "latency",
-    "cost_usd",
+    "cost",
   ].join(",");
   outputStream.write(header + "\n");
 }

--- a/valhalla/jawn/src/controllers/public/userController.ts
+++ b/valhalla/jawn/src/controllers/public/userController.ts
@@ -113,7 +113,7 @@ export class UserController extends Controller {
         prompt_tokens: number;
         completion_tokens: number;
         user_id: string;
-        cost_usd: number;
+        cost: number;
       }[],
       string
     >
@@ -163,7 +163,7 @@ export class UserController extends Controller {
       prompt_tokens: number;
       completion_tokens: number;
       user_id: string;
-      cost_usd: number;
+      cost: number;
     }>(
       `
     SELECT 
@@ -171,7 +171,7 @@ export class UserController extends Controller {
       sum(prompt_tokens) as prompt_tokens, 
       sum(completion_tokens) as completion_tokens, 
       user_id,
-      sum(cost) / ${COST_PRECISION_MULTIPLIER} as cost_usd
+      sum(cost) / ${COST_PRECISION_MULTIPLIER} as cost
       from request_response_rmt
     WHERE (
       ${filter.filter}

--- a/valhalla/jawn/src/index.ts
+++ b/valhalla/jawn/src/index.ts
@@ -223,7 +223,7 @@ function errorHandler(
     console.warn(`Caught Validation Error for ${req.path}:`, err.fields);
     return res.status(422).json({
       message: "Validation Failed",
-      details: err?.fields,
+      details: err.fields,
     });
   }
   if (err instanceof Error) {

--- a/valhalla/jawn/src/lib/shared/sorts/requests/sorts.ts
+++ b/valhalla/jawn/src/lib/shared/sorts/requests/sorts.ts
@@ -24,7 +24,7 @@ export interface SortLeafRequest {
   values?: {
     [key: string]: SortDirection;
   };
-  cost_usd?: SortDirection;
+  cost?: SortDirection;
 }
 
 function assertValidSortDirection(direction: SortDirection) {
@@ -95,9 +95,9 @@ export function buildRequestSort(sort: SortLeafRequest) {
       return `(request.properties ->> '${key}')::text ${sort.properties[key]}`;
     }
   }
-  if (sort.cost_usd) {
-    assertValidSortDirection(sort.cost_usd);
-    return `cost_usd ${sort.cost_usd}`;
+  if (sort.cost) {
+    assertValidSortDirection(sort.cost);
+    return `cost ${sort.cost}`;
   }
   if (sort.values) {
     for (const key in sort.values) {
@@ -155,9 +155,9 @@ export function buildRequestSortClickhouse(sort: SortLeafRequest): string {
     assertValidSortDirection(sort.response_text);
     return `JSONExtractString(request_response_rmt.response_body, 'choices', 0, 'text') ${sort.response_text}`;
   }
-  if (sort.cost_usd) {
-    assertValidSortDirection(sort.cost_usd);
-    return `cost_usd ${sort.cost_usd}`;
+  if (sort.cost) {
+    assertValidSortDirection(sort.cost);
+    return `cost ${sort.cost}`;
   }
   if (sort.properties) {
     for (const key in sort.properties) {

--- a/valhalla/jawn/src/tsoa-build/private/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/private/routes.ts
@@ -944,7 +944,7 @@ const models: TsoaRoute.Models = {
             "response_text": {"ref":"SortDirection"},
             "properties": {"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"SortDirection"}},
             "values": {"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"SortDirection"}},
-            "cost_usd": {"ref":"SortDirection"},
+            "cost": {"ref":"SortDirection"},
         },
         "additionalProperties": false,
     },

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -3400,7 +3400,7 @@
 						},
 						"type": "object"
 					},
-					"cost_usd": {
+					"cost": {
 						"$ref": "#/components/schemas/SortDirection"
 					}
 				},

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -352,18 +352,18 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array_": {
+    "ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array_": {
         "dataType": "refObject",
         "properties": {
-            "data": {"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"cost_usd":{"dataType":"double","required":true},"user_id":{"dataType":"string","required":true},"completion_tokens":{"dataType":"double","required":true},"prompt_tokens":{"dataType":"double","required":true},"count":{"dataType":"double","required":true}}},"required":true},
+            "data": {"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"cost":{"dataType":"double","required":true},"user_id":{"dataType":"string","required":true},"completion_tokens":{"dataType":"double","required":true},"prompt_tokens":{"dataType":"double","required":true},"count":{"dataType":"double","required":true}}},"required":true},
             "error": {"dataType":"enum","enums":[null],"required":true},
         },
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array.string_": {
+    "Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array.string_": {
         "dataType": "refAlias",
-        "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array_"},{"ref":"ResultError_string_"}],"validators":{}},
+        "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array_"},{"ref":"ResultError_string_"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "UserQueryParams": {
@@ -881,7 +881,7 @@ const models: TsoaRoute.Models = {
             "response_text": {"ref":"SortDirection"},
             "properties": {"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"SortDirection"}},
             "values": {"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"SortDirection"}},
-            "cost_usd": {"ref":"SortDirection"},
+            "cost": {"ref":"SortDirection"},
         },
         "additionalProperties": false,
     },

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -942,12 +942,12 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array_": {
+			"ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array_": {
 				"properties": {
 					"data": {
 						"items": {
 							"properties": {
-								"cost_usd": {
+								"cost": {
 									"type": "number",
 									"format": "double"
 								},
@@ -968,7 +968,7 @@
 								}
 							},
 							"required": [
-								"cost_usd",
+								"cost",
 								"user_id",
 								"completion_tokens",
 								"prompt_tokens",
@@ -993,10 +993,10 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array.string_": {
+			"Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array.string_": {
 				"anyOf": [
 					{
-						"$ref": "#/components/schemas/ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array_"
+						"$ref": "#/components/schemas/ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array_"
 					},
 					{
 						"$ref": "#/components/schemas/ResultError_string_"
@@ -2736,7 +2736,7 @@
 						},
 						"type": "object"
 					},
-					"cost_usd": {
+					"cost": {
 						"$ref": "#/components/schemas/SortDirection"
 					}
 				},
@@ -11312,7 +11312,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array.string_"
+									"$ref": "#/components/schemas/Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array.string_"
 								}
 							}
 						}

--- a/web/components/templates/gateway/initialColumns.tsx
+++ b/web/components/templates/gateway/initialColumns.tsx
@@ -201,7 +201,7 @@ export const getInitialColumns = (): ColumnDef<MappedLLMRequest>[] => [
       return <span>${formatNumber(num)}</span>;
     },
     meta: {
-      sortKey: "cost_usd",
+      sortKey: "cost",
     },
     size: 175,
   },

--- a/web/components/templates/requests/initialColumns.tsx
+++ b/web/components/templates/requests/initialColumns.tsx
@@ -224,7 +224,7 @@ export const getInitialColumns = (): ColumnDef<MappedLLMRequest>[] => [
       return <span>${formatNumber(num)}</span>;
     },
     meta: {
-      sortKey: "cost_usd",
+      sortKey: "cost",
     },
     size: 175,
   },

--- a/web/components/templates/sessions/sessionId/SessionContent.tsx
+++ b/web/components/templates/sessions/sessionId/SessionContent.tsx
@@ -158,7 +158,7 @@ export const SessionContent: React.FC<SessionContentProps> = ({
       { label: "End Time", value: endTime ? get24HourFromDate(endTime) : "-" },
       {
         label: "Cost",
-        value: `$${(session.session_cost_usd ?? 0).toFixed(4)}`,
+        value: `$${(session.session_cost ?? 0).toFixed(4)}`,
       },
       { label: "Avg Latency", value: `${avgLatency.toFixed(0)}ms` },
       { label: "Requests", value: session.traces.length.toString() },
@@ -167,7 +167,7 @@ export const SessionContent: React.FC<SessionContentProps> = ({
   }, [
     startTime,
     endTime,
-    session.session_cost_usd,
+    session.session_cost,
     avgLatency,
     session.traces.length,
     totalTokens,

--- a/web/lib/clients/jawnTypes/private.ts
+++ b/web/lib/clients/jawnTypes/private.ts
@@ -1372,7 +1372,7 @@ Json: JsonObject;
       values?: {
         [key: string]: components["schemas"]["SortDirection"];
       };
-      cost_usd?: components["schemas"]["SortDirection"];
+      cost?: components["schemas"]["SortDirection"];
     };
     RequestQueryParams: {
       filter: components["schemas"]["RequestFilterNode"];

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -910,10 +910,10 @@ export interface components {
       timeZoneDifferenceMinutes?: number;
       sort?: components["schemas"]["SortLeafUsers"];
     };
-    "ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array_": {
+    "ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array_": {
       data: {
           /** Format: double */
-          cost_usd: number;
+          cost: number;
           user_id: string;
           /** Format: double */
           completion_tokens: number;
@@ -925,7 +925,7 @@ export interface components {
       /** @enum {number|null} */
       error: null;
     };
-    "Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array.string_": components["schemas"]["ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array_"] | components["schemas"]["ResultError_string_"];
+    "Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array.string_": components["schemas"]["ResultSuccess__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array_"] | components["schemas"]["ResultError_string_"];
     UserQueryParams: {
       userIds?: string[];
       timeFilter?: {
@@ -1374,7 +1374,7 @@ export interface components {
       values?: {
         [key: string]: components["schemas"]["SortDirection"];
       };
-      cost_usd?: components["schemas"]["SortDirection"];
+      cost?: components["schemas"]["SortDirection"];
     };
     RequestQueryParams: {
       filter: components["schemas"]["RequestFilterNode"];
@@ -3717,7 +3717,7 @@ export interface operations {
       /** @description Ok */
       200: {
         content: {
-          "application/json": components["schemas"]["Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost_usd-number_-Array.string_"];
+          "application/json": components["schemas"]["Result__count-number--prompt_tokens-number--completion_tokens-number--user_id-string--cost-number_-Array.string_"];
         };
       };
     };

--- a/web/lib/sessions/sessionTypes.ts
+++ b/web/lib/sessions/sessionTypes.ts
@@ -14,7 +14,7 @@ export interface Session {
   end_time_unix_timestamp_ms: number;
   session_id: string;
   session_tags: string[];
-  session_cost_usd: number;
+  session_cost: number;
   traces: Trace[];
 }
 

--- a/web/lib/sessions/sessionsFromHeliconeTequests.ts
+++ b/web/lib/sessions/sessionsFromHeliconeTequests.ts
@@ -12,7 +12,7 @@ export function sessionFromHeliconeRequests(
       end_time_unix_timestamp_ms: 0,
       session_id: "0",
       session_tags: [],
-      session_cost_usd: 0,
+      session_cost: 0,
       traces: [],
     };
   }
@@ -43,7 +43,7 @@ export function sessionFromHeliconeRequests(
       "Helicone-Session-Id"
     ] as string,
     session_tags: [],
-    session_cost_usd: sortedRequests // Use sortedRequests here
+    session_cost: sortedRequests // Use sortedRequests here
       .map((r) =>
         modelCost({
           model: r.model_override ?? r.request_model ?? r.response_model ?? "",

--- a/web/services/hooks/requests.tsx
+++ b/web/services/hooks/requests.tsx
@@ -244,6 +244,7 @@ const useGetRequests = (
   isCached: boolean = false,
   isLive: boolean = false,
 ) => {
+  console.log("Sort Leaf", sortLeaf);
   return {
     requests: useGetRequestsWithBodies(
       currentPage,

--- a/web/services/hooks/requests.tsx
+++ b/web/services/hooks/requests.tsx
@@ -244,7 +244,6 @@ const useGetRequests = (
   isCached: boolean = false,
   isLive: boolean = false,
 ) => {
-  console.log("Sort Leaf", sortLeaf);
   return {
     requests: useGetRequestsWithBodies(
       currentPage,

--- a/web/services/lib/sorts/requests/sorts.ts
+++ b/web/services/lib/sorts/requests/sorts.ts
@@ -22,6 +22,7 @@ export interface SortLeafRequest {
   values?: {
     [key: string]: SortDirection;
   };
+  cost?: SortDirection;
 }
 
 function assertValidSortDirection(direction: SortDirection) {


### PR DESCRIPTION
Sorting by cost wouldn't work since cost_usd no longer exists as a synthetic column anymore. Now cost is a real column in `request_response_rmt` and can be filtered/sorted as such.

Replaces `cost_usd` with `cost`.