### PR TITLE
fix: hql clickhouse query count

### DIFF
--- a/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
@@ -121,7 +121,7 @@ export class ClickhouseClientWrapper {
           wait_end_of_query: 1,
           max_execution_time: 30,
           max_memory_usage: "1000000000",
-          max_rows_to_read: `${100_000_000}`,
+          max_rows_to_read: "10000000",
           max_result_rows: "10000",
           SQL_helicone_organization_id: organizationId,
           readonly: "1",
@@ -307,6 +307,7 @@ export interface RequestResponseRMT {
   gateway_deployment_target?: string;
   prompt_id?: string;
   prompt_version?: string;
+  request_referrer?: string;
 }
 
 export interface Prompt2025Input {

--- a/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
@@ -121,7 +121,7 @@ export class ClickhouseClientWrapper {
           wait_end_of_query: 1,
           max_execution_time: 30,
           max_memory_usage: "1000000000",
-          max_rows_to_read: "10000000",
+          max_rows_to_read: `${100_000_000}`,
           max_result_rows: "10000",
           SQL_helicone_organization_id: organizationId,
           readonly: "1",

--- a/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
@@ -121,7 +121,7 @@ export class ClickhouseClientWrapper {
           wait_end_of_query: 1,
           max_execution_time: 30,
           max_memory_usage: "1000000000",
-          max_rows_to_read: "10000000",
+          max_rows_to_read: `${100_000_000}`,
           max_result_rows: "10000",
           SQL_helicone_organization_id: organizationId,
           readonly: "1",
@@ -307,7 +307,6 @@ export interface RequestResponseRMT {
   gateway_deployment_target?: string;
   prompt_id?: string;
   prompt_version?: string;
-  request_referrer?: string;
 }
 
 export interface Prompt2025Input {


### PR DESCRIPTION
This pull request increases the maximum number of rows that can be read in a Clickhouse query from 10 million to 100 million. This change allows for larger queries to be executed, which may be necessary for processing bigger datasets.