### PR TITLE
fix: hql loading flicker

### DIFF
--- a/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
@@ -121,7 +121,7 @@ export class ClickhouseClientWrapper {
           wait_end_of_query: 1,
           max_execution_time: 30,
           max_memory_usage: "1000000000",
-          max_rows_to_read: `${100_000_000}`,
+          max_rows_to_read: "10000000",
           max_result_rows: "10000",
           SQL_helicone_organization_id: organizationId,
           readonly: "1",
@@ -307,6 +307,7 @@ export interface RequestResponseRMT {
   gateway_deployment_target?: string;
   prompt_id?: string;
   prompt_version?: string;
+  request_referrer?: string;
 }
 
 export interface Prompt2025Input {

--- a/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
@@ -121,7 +121,7 @@ export class ClickhouseClientWrapper {
           wait_end_of_query: 1,
           max_execution_time: 30,
           max_memory_usage: "1000000000",
-          max_rows_to_read: "10000000",
+          max_rows_to_read: `${100_000_000}`,
           max_result_rows: "10000",
           SQL_helicone_organization_id: organizationId,
           readonly: "1",
@@ -307,7 +307,6 @@ export interface RequestResponseRMT {
   gateway_deployment_target?: string;
   prompt_id?: string;
   prompt_version?: string;
-  request_referrer?: string;
 }
 
 export interface Prompt2025Input {

--- a/web/components/templates/hql/hqlPage.tsx
+++ b/web/components/templates/hql/hqlPage.tsx
@@ -29,7 +29,7 @@ import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 
 function HQLPage() {
   const organization = useOrg();
-  const { data: hasAccessToHQL } = useFeatureFlag(
+  const { data: hasAccessToHQL, isLoading: isLoadingFeatureFlag } = useFeatureFlag(
     "hql",
     organization?.currentOrg?.id ?? "",
   );
@@ -207,16 +207,16 @@ function HQLPage() {
     latestQueryRef.current = currentQuery;
   }, [currentQuery]);
 
-  if (!hasAccessToHQL) {
-    return <div>You do not have access to HQL</div>;
-  }
-
-  if (savedQueryDetailsLoading) {
+  if (isLoadingFeatureFlag || savedQueryDetailsLoading) {
     return (
       <div className="flex h-screen w-full items-center justify-center">
         <div className="text-lg">Loading...</div>
       </div>
     );
+  }
+
+  if (!hasAccessToHQL) {
+    return <div>You do not have access to HQL</div>;
   }
 
   return (


### PR DESCRIPTION
* Added the `isLoading` state from the `useFeatureFlag` hook to track when the HQL feature flag is being fetched. (`web/components/templates/hql/hqlPage.tsx`)
* Updated the conditional rendering logic so that the loading indicator is shown while either the feature flag or saved query details are loading, and the "no access" message is only shown once loading is complete and access is denied. (`web/components/templates/hql/hqlPage.tsx`)