### PR TITLE
feat: bulk delete hql queries

### DIFF
--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -437,6 +437,9 @@ export interface paths {
     get: operations["GetSavedQuery"];
     delete: operations["DeleteSavedQuery"];
   };
+  "/v1/helicone-sql/saved-queries/bulk-delete": {
+    post: operations["BulkDeleteSavedQueries"];
+  };
   "/v1/helicone-sql/saved-query": {
     put: operations["UpdateSavedQuery"];
     post: operations["CreateSavedQuery"];
@@ -2894,6 +2897,9 @@ Json: JsonObject;
       error: null;
     };
     "Result_void.string_": components["schemas"]["ResultSuccess_void_"] | components["schemas"]["ResultError_string_"];
+    BulkDeleteSavedQueriesRequest: {
+      ids: string[];
+    };
     "ResultSuccess_HqlSavedQuery-Array_": {
       data: components["schemas"]["HqlSavedQuery"][];
       /** @enum {number|null} */
@@ -6256,6 +6262,21 @@ export interface operations {
     parameters: {
       path: {
         queryId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_void.string_"];
+        };
+      };
+    };
+  };
+  BulkDeleteSavedQueries: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["BulkDeleteSavedQueriesRequest"];
       };
     };
     responses: {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -8134,6 +8134,21 @@
 					}
 				]
 			},
+			"BulkDeleteSavedQueriesRequest": {
+				"properties": {
+					"ids": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"ids"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
 			"ResultSuccess_HqlSavedQuery-Array_": {
 				"properties": {
 					"data": {
@@ -17711,6 +17726,38 @@
 						}
 					}
 				]
+			}
+		},
+		"/v1/helicone-sql/saved-queries/bulk-delete": {
+			"post": {
+				"operationId": "BulkDeleteSavedQueries",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result_void.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"HeliconeSql"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/BulkDeleteSavedQueriesRequest"
+							}
+						}
+					}
+				}
 			}
 		},
 		"/v1/helicone-sql/saved-query": {

--- a/valhalla/jawn/src/controllers/public/heliconeSqlController.ts
+++ b/valhalla/jawn/src/controllers/public/heliconeSqlController.ts
@@ -48,6 +48,10 @@ export interface UpdateSavedQueryRequest extends CreateSavedQueryRequest {
   id: string;
 }
 
+export interface BulkDeleteSavedQueriesRequest {
+  ids: string[];
+}
+
 export interface HqlSavedQuery {
   id: string;
   organization_id: string;
@@ -155,6 +159,21 @@ export class HeliconeSqlController extends Controller {
   ): Promise<Result<void, string>> {
     const heliconeSqlManager = new HqlQueryManager(request.authParams);
     const result = await heliconeSqlManager.deleteSavedQuery(queryId);
+    if (result.error) {
+      this.setStatus(500);
+      return err(result.error);
+    }
+    this.setStatus(200);
+    return ok(undefined);
+  }
+
+  @Post("saved-queries/bulk-delete")
+  public async bulkDeleteSavedQueries(
+    @Body() requestBody: BulkDeleteSavedQueriesRequest,
+    @Request() request: JawnAuthenticatedRequest
+  ): Promise<Result<void, string>> {
+    const heliconeSqlManager = new HqlQueryManager(request.authParams);
+    const result = await heliconeSqlManager.bulkDeleteSavedQueries(requestBody.ids);
     if (result.error) {
       this.setStatus(500);
       return err(result.error);

--- a/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
@@ -307,7 +307,6 @@ export interface RequestResponseRMT {
   gateway_deployment_target?: string;
   prompt_id?: string;
   prompt_version?: string;
-  request_referrer?: string;
 }
 
 export interface Prompt2025Input {

--- a/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
@@ -121,7 +121,7 @@ export class ClickhouseClientWrapper {
           wait_end_of_query: 1,
           max_execution_time: 30,
           max_memory_usage: "1000000000",
-          max_rows_to_read: `${100_000_000}`,
+          max_rows_to_read: "10000000",
           max_result_rows: "10000",
           SQL_helicone_organization_id: organizationId,
           readonly: "1",
@@ -307,6 +307,7 @@ export interface RequestResponseRMT {
   gateway_deployment_target?: string;
   prompt_id?: string;
   prompt_version?: string;
+  request_referrer?: string;
 }
 
 export interface Prompt2025Input {

--- a/valhalla/jawn/src/managers/HqlQueryManager.ts
+++ b/valhalla/jawn/src/managers/HqlQueryManager.ts
@@ -100,4 +100,28 @@ export class HqlQueryManager {
       return err(String(e));
     }
   }
+
+  async bulkDeleteSavedQueries(ids: string[]): Promise<Result<void, string>> {
+    try {
+      if (ids.length === 0) {
+        return ok(undefined);
+      }
+
+      // Create placeholders for the query ($1, $2, $3, etc.)
+      const placeholders = ids.map((_, index) => `$${index + 2}`).join(", ");
+      
+      const result = await dbExecute<void>(
+        `DELETE FROM saved_queries WHERE organization_id = $1 AND id IN (${placeholders})`,
+        [this.authParams.organizationId, ...ids]
+      );
+      
+      if (result.error) {
+        return err(result.error);
+      }
+
+      return ok(undefined);
+    } catch (e) {
+      return err(String(e));
+    }
+  }
 }

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -2638,6 +2638,14 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_void_"},{"ref":"ResultError_string_"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "BulkDeleteSavedQueriesRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "ids": {"dataType":"array","array":{"dataType":"string"},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ResultSuccess_HqlSavedQuery-Array_": {
         "dataType": "refObject",
         "properties": {
@@ -8656,6 +8664,37 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'deleteSavedQuery',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsHeliconeSqlController_bulkDeleteSavedQueries: Record<string, TsoaRoute.ParameterSchema> = {
+                requestBody: {"in":"body","name":"requestBody","required":true,"ref":"BulkDeleteSavedQueriesRequest"},
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+        };
+        app.post('/v1/helicone-sql/saved-queries/bulk-delete',
+            ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController)),
+            ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController.prototype.bulkDeleteSavedQueries)),
+
+            async function HeliconeSqlController_bulkDeleteSavedQueries(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsHeliconeSqlController_bulkDeleteSavedQueries, request, response });
+
+                const controller = new HeliconeSqlController();
+
+              await templateService.apiHandler({
+                methodName: 'bulkDeleteSavedQueries',
                 controller,
                 response,
                 next,

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -8134,6 +8134,21 @@
 					}
 				]
 			},
+			"BulkDeleteSavedQueriesRequest": {
+				"properties": {
+					"ids": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"ids"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
 			"ResultSuccess_HqlSavedQuery-Array_": {
 				"properties": {
 					"data": {
@@ -17711,6 +17726,38 @@
 						}
 					}
 				]
+			}
+		},
+		"/v1/helicone-sql/saved-queries/bulk-delete": {
+			"post": {
+				"operationId": "BulkDeleteSavedQueries",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result_void.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"HeliconeSql"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/BulkDeleteSavedQueriesRequest"
+							}
+						}
+					}
+				}
 			}
 		},
 		"/v1/helicone-sql/saved-query": {

--- a/web/components/templates/hql/constants.ts
+++ b/web/components/templates/hql/constants.ts
@@ -236,3 +236,35 @@ export const useDeleteQueryMutation = (
     },
   };
 };
+
+// Bulk delete queries mutation
+export const useBulkDeleteQueryMutation = (
+  setNotification: (_message: string, _type: "success" | "error") => void,
+) => {
+  const queryClient = useQueryClient();
+  return {
+    mutationFn: async (queryIds: string[]) => {
+      const response = await $JAWN_API.POST(
+        "/v1/helicone-sql/saved-queries/bulk-delete",
+        {
+          body: { ids: queryIds },
+        },
+      );
+      return response;
+    },
+    onSuccess: (_data: any, queryIds: string[]) => {
+      const count = queryIds.length;
+      setNotification(
+        `${count} ${count === 1 ? 'query' : 'queries'} deleted successfully`,
+        "success"
+      );
+      // Invalidate the queries cache to refresh the list
+      queryClient.invalidateQueries({
+        queryKey: ["get", "/v1/helicone-sql/saved-queries"],
+      });
+    },
+    onError: (error: Error) => {
+      setNotification(error.message, "error");
+    },
+  };
+};

--- a/web/components/templates/hql/directory.tsx
+++ b/web/components/templates/hql/directory.tsx
@@ -5,6 +5,7 @@ import { components } from "@/lib/clients/jawnTypes/public";
 import { Dispatch, SetStateAction, useMemo, useState } from "react";
 import { clsx } from "clsx";
 import { ChevronDown, ChevronRight, Trash2 } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -23,6 +24,7 @@ import {
 } from "@/components/ui/tooltip";
 import { $JAWN_API } from "@/lib/clients/jawn";
 import { CommandLineIcon } from "@heroicons/react/24/outline";
+import { useBulkDeleteQueryMutation } from "./constants";
 
 interface DirectoryProps {
   tables: {
@@ -253,14 +255,47 @@ function QueryList({
   >;
 }) {
   const { setNotification } = useNotification();
+  const [selectedQueries, setSelectedQueries] = useState<Set<string>>(new Set());
 
   const deleteQueryMutation = useMutation(
     useDeleteQueryMutation(setNotification),
   );
 
+  const bulkDeleteMutation = useMutation(
+    useBulkDeleteQueryMutation(setNotification),
+  );
+
   const handleDeleteQuery = (queryId: string, queryName: string) => {
     if (confirm(`Are you sure you want to delete "${queryName}"?`)) {
       deleteQueryMutation.mutate(queryId);
+    }
+  };
+
+  const handleBulkDelete = () => {
+    const count = selectedQueries.size;
+    if (confirm(`Are you sure you want to delete ${count} selected ${count === 1 ? 'query' : 'queries'}?`)) {
+      bulkDeleteMutation.mutate(Array.from(selectedQueries));
+      setSelectedQueries(new Set());
+    }
+  };
+
+  const toggleQuerySelection = (queryId: string) => {
+    setSelectedQueries(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(queryId)) {
+        newSet.delete(queryId);
+      } else {
+        newSet.add(queryId);
+      }
+      return newSet;
+    });
+  };
+
+  const toggleSelectAll = () => {
+    if (selectedQueries.size === queries.length) {
+      setSelectedQueries(new Set());
+    } else {
+      setSelectedQueries(new Set(queries.map(q => q.id)));
     }
   };
 
@@ -284,9 +319,29 @@ function QueryList({
       )}
 
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-sm font-medium text-muted-foreground">
-          Queries ({queries.length})
-        </h3>
+        <div className="flex items-center gap-2">
+          {queries.length > 0 && (
+            <Checkbox
+              checked={selectedQueries.size === queries.length && queries.length > 0}
+              onCheckedChange={toggleSelectAll}
+              aria-label="Select all queries"
+            />
+          )}
+          <h3 className="text-sm font-medium text-muted-foreground">
+            Queries ({queries.length})
+          </h3>
+        </div>
+        {selectedQueries.size > 0 && (
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={handleBulkDelete}
+            disabled={bulkDeleteMutation.isPending}
+          >
+            <Trash2 className="mr-1 h-3 w-3" />
+            Delete ({selectedQueries.size})
+          </Button>
+        )}
       </div>
       {isLoading ? (
         <div className="text-sm text-muted-foreground">Loading...</div>
@@ -297,19 +352,28 @@ function QueryList({
               <ContextMenuTrigger>
                 <div
                   className="group flex cursor-pointer items-center justify-between rounded-md px-2 py-2 hover:bg-muted/50"
-                  onClick={() => {
-                    setCurrentQuery({
-                      id: query.id,
-                      name: query.name,
-                      sql: query.sql,
-                    });
-                  }}
                 >
-                  <span className="flex items-center gap-2 truncate pr-2 text-sm">
-                    <CommandLineIcon className="h-4 w-4" />
-
-                    {query.name}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      checked={selectedQueries.has(query.id)}
+                      onCheckedChange={() => toggleQuerySelection(query.id)}
+                      onClick={(e) => e.stopPropagation()}
+                      aria-label={`Select ${query.name}`}
+                    />
+                    <span 
+                      className="flex items-center gap-2 truncate pr-2 text-sm"
+                      onClick={() => {
+                        setCurrentQuery({
+                          id: query.id,
+                          name: query.name,
+                          sql: query.sql,
+                        });
+                      }}
+                    >
+                      <CommandLineIcon className="h-4 w-4" />
+                      {query.name}
+                    </span>
+                  </div>
                 </div>
               </ContextMenuTrigger>
               <ContextMenuContent>

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -437,6 +437,9 @@ export interface paths {
     get: operations["GetSavedQuery"];
     delete: operations["DeleteSavedQuery"];
   };
+  "/v1/helicone-sql/saved-queries/bulk-delete": {
+    post: operations["BulkDeleteSavedQueries"];
+  };
   "/v1/helicone-sql/saved-query": {
     put: operations["UpdateSavedQuery"];
     post: operations["CreateSavedQuery"];
@@ -629,6 +632,25 @@ export interface paths {
   "/v1/public/alert-banner": {
     get: operations["GetAlertBanners"];
     patch: operations["UpdateAlertBannerActive"];
+  };
+  "/v1/agent/generate": {
+    post: operations["Generate"];
+  };
+  "/v1/agent/thread/{sessionId}/message": {
+    post: operations["UpsertThreadMessage"];
+  };
+  "/v1/agent/thread/{sessionId}": {
+    get: operations["GetThread"];
+    delete: operations["DeleteThread"];
+  };
+  "/v1/agent/thread/{sessionId}/escalate": {
+    post: operations["EscalateThread"];
+  };
+  "/v1/agent/threads": {
+    get: operations["GetAllThreads"];
+  };
+  "/v1/agent/mcp/search": {
+    post: operations["SearchDocs"];
   };
 }
 
@@ -2875,6 +2897,9 @@ Json: JsonObject;
       error: null;
     };
     "Result_void.string_": components["schemas"]["ResultSuccess_void_"] | components["schemas"]["ResultError_string_"];
+    BulkDeleteSavedQueriesRequest: {
+      ids: string[];
+    };
     "ResultSuccess_HqlSavedQuery-Array_": {
       data: components["schemas"]["HqlSavedQuery"][];
       /** @enum {number|null} */
@@ -3534,6 +3559,273 @@ Json: JsonObject;
       error: null;
     };
     "Result__id-number--active-boolean--title-string--message-string--created_at-string--updated_at-string_-Array.string_": components["schemas"]["ResultSuccess__id-number--active-boolean--title-string--message-string--created_at-string--updated_at-string_-Array_"] | components["schemas"]["ResultError_string_"];
+    InAppThread: {
+      id: string;
+      chat: unknown;
+      user_id: string;
+      org_id: string;
+      /** Format: date-time */
+      created_at: string;
+      escalated: boolean;
+      metadata: unknown;
+      /** Format: date-time */
+      updated_at: string;
+      soft_delete: boolean;
+    };
+    ResultSuccess_InAppThread_: {
+      data: components["schemas"]["InAppThread"];
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result_InAppThread.string_": components["schemas"]["ResultSuccess_InAppThread_"] | components["schemas"]["ResultError_string_"];
+    /**
+     * @description Learn about
+     * [text inputs](https://platform.openai.com/docs/guides/text-generation).
+     */
+    ChatCompletionContentPartText: {
+      /** @description The text content. */
+      text: string;
+      /**
+       * @description The type of the content part.
+       * @enum {string}
+       */
+      type: "text";
+    };
+    /**
+     * @description Developer-provided instructions that the model should follow, regardless of
+     * messages sent by the user. With o1 models and newer, `developer` messages
+     * replace the previous `system` messages.
+     */
+    ChatCompletionDeveloperMessageParam: {
+      /** @description The contents of the developer message. */
+      content: string | components["schemas"]["ChatCompletionContentPartText"][];
+      /**
+       * @description The role of the messages author, in this case `developer`.
+       * @enum {string}
+       */
+      role: "developer";
+      /**
+       * @description An optional name for the participant. Provides the model information to
+       * differentiate between participants of the same role.
+       */
+      name?: string;
+    };
+    /**
+     * @description Developer-provided instructions that the model should follow, regardless of
+     * messages sent by the user. With o1 models and newer, use `developer` messages
+     * for this purpose instead.
+     */
+    ChatCompletionSystemMessageParam: {
+      /** @description The contents of the system message. */
+      content: string | components["schemas"]["ChatCompletionContentPartText"][];
+      /**
+       * @description The role of the messages author, in this case `system`.
+       * @enum {string}
+       */
+      role: "system";
+      /**
+       * @description An optional name for the participant. Provides the model information to
+       * differentiate between participants of the same role.
+       */
+      name?: string;
+    };
+    "ChatCompletionContentPartImage.ImageURL": {
+      /** @description Either a URL of the image or the base64 encoded image data. */
+      url: string;
+      /**
+       * @description Specifies the detail level of the image. Learn more in the
+       * [Vision guide](https://platform.openai.com/docs/guides/vision#low-or-high-fidelity-image-understanding).
+       * @enum {string}
+       */
+      detail?: "auto" | "low" | "high";
+    };
+    /** @description Learn about [image inputs](https://platform.openai.com/docs/guides/vision). */
+    ChatCompletionContentPartImage: {
+      image_url: components["schemas"]["ChatCompletionContentPartImage.ImageURL"];
+      /**
+       * @description The type of the content part.
+       * @enum {string}
+       */
+      type: "image_url";
+    };
+    "ChatCompletionContentPartInputAudio.InputAudio": {
+      /** @description Base64 encoded audio data. */
+      data: string;
+      /**
+       * @description The format of the encoded audio data. Currently supports "wav" and "mp3".
+       * @enum {string}
+       */
+      format: "wav" | "mp3";
+    };
+    /** @description Learn about [audio inputs](https://platform.openai.com/docs/guides/audio). */
+    ChatCompletionContentPartInputAudio: {
+      input_audio: components["schemas"]["ChatCompletionContentPartInputAudio.InputAudio"];
+      /**
+       * @description The type of the content part. Always `input_audio`.
+       * @enum {string}
+       */
+      type: "input_audio";
+    };
+    "ChatCompletionContentPart.File.File": {
+      /**
+       * @description The base64 encoded file data, used when passing the file to the model as a
+       * string.
+       */
+      file_data?: string;
+      /** @description The ID of an uploaded file to use as input. */
+      file_id?: string;
+      /** @description The name of the file, used when passing the file to the model as a string. */
+      filename?: string;
+    };
+    /**
+     * @description Learn about [file inputs](https://platform.openai.com/docs/guides/text) for text
+     * generation.
+     */
+    "ChatCompletionContentPart.File": {
+      file: components["schemas"]["ChatCompletionContentPart.File.File"];
+      /**
+       * @description The type of the content part. Always `file`.
+       * @enum {string}
+       */
+      type: "file";
+    };
+    /**
+     * @description Learn about
+     * [text inputs](https://platform.openai.com/docs/guides/text-generation).
+     */
+    ChatCompletionContentPart: components["schemas"]["ChatCompletionContentPartText"] | components["schemas"]["ChatCompletionContentPartImage"] | components["schemas"]["ChatCompletionContentPartInputAudio"] | components["schemas"]["ChatCompletionContentPart.File"];
+    /**
+     * @description Messages sent by an end user, containing prompts or additional context
+     * information.
+     */
+    ChatCompletionUserMessageParam: {
+      /** @description The contents of the user message. */
+      content: string | components["schemas"]["ChatCompletionContentPart"][];
+      /**
+       * @description The role of the messages author, in this case `user`.
+       * @enum {string}
+       */
+      role: "user";
+      /**
+       * @description An optional name for the participant. Provides the model information to
+       * differentiate between participants of the same role.
+       */
+      name?: string;
+    };
+    /**
+     * @description Data about a previous audio response from the model.
+     * [Learn more](https://platform.openai.com/docs/guides/audio).
+     */
+    "ChatCompletionAssistantMessageParam.Audio": {
+      /** @description Unique identifier for a previous audio response from the model. */
+      id: string;
+    };
+    ChatCompletionContentPartRefusal: {
+      /** @description The refusal message generated by the model. */
+      refusal: string;
+      /**
+       * @description The type of the content part.
+       * @enum {string}
+       */
+      type: "refusal";
+    };
+    /** @deprecated */
+    "ChatCompletionAssistantMessageParam.FunctionCall": {
+      /**
+       * @description The arguments to call the function with, as generated by the model in JSON
+       * format. Note that the model does not always generate valid JSON, and may
+       * hallucinate parameters not defined by your function schema. Validate the
+       * arguments in your code before calling your function.
+       */
+      arguments: string;
+      /** @description The name of the function to call. */
+      name: string;
+    };
+    /** @description Messages sent by the model in response to user messages. */
+    ChatCompletionAssistantMessageParam: {
+      /**
+       * @description The role of the messages author, in this case `assistant`.
+       * @enum {string}
+       */
+      role: "assistant";
+      /**
+       * @description Data about a previous audio response from the model.
+       * [Learn more](https://platform.openai.com/docs/guides/audio).
+       */
+      audio?: components["schemas"]["ChatCompletionAssistantMessageParam.Audio"] | null;
+      /**
+       * @description The contents of the assistant message. Required unless `tool_calls` or
+       * `function_call` is specified.
+       */
+      content?: (string | ((components["schemas"]["ChatCompletionContentPartText"] | components["schemas"]["ChatCompletionContentPartRefusal"])[])) | null;
+      /** @deprecated */
+      function_call?: components["schemas"]["ChatCompletionAssistantMessageParam.FunctionCall"] | null;
+      /**
+       * @description An optional name for the participant. Provides the model information to
+       * differentiate between participants of the same role.
+       */
+      name?: string;
+      /** @description The refusal message by the assistant. */
+      refusal?: string | null;
+      /** @description The tool calls generated by the model, such as function calls. */
+      tool_calls?: components["schemas"]["ChatCompletionMessageToolCall"][];
+    };
+    ChatCompletionToolMessageParam: {
+      /** @description The contents of the tool message. */
+      content: string | components["schemas"]["ChatCompletionContentPartText"][];
+      /**
+       * @description The role of the messages author, in this case `tool`.
+       * @enum {string}
+       */
+      role: "tool";
+      /** @description Tool call that this message is responding to. */
+      tool_call_id: string;
+    };
+    /** @deprecated */
+    ChatCompletionFunctionMessageParam: {
+      /** @description The contents of the function message. */
+      content: string | null;
+      /** @description The name of the function to call. */
+      name: string;
+      /**
+       * @description The role of the messages author, in this case `function`.
+       * @enum {string}
+       */
+      role: "function";
+    };
+    /**
+     * @description Developer-provided instructions that the model should follow, regardless of
+     * messages sent by the user. With o1 models and newer, `developer` messages
+     * replace the previous `system` messages.
+     */
+    ChatCompletionMessageParam: components["schemas"]["ChatCompletionDeveloperMessageParam"] | components["schemas"]["ChatCompletionSystemMessageParam"] | components["schemas"]["ChatCompletionUserMessageParam"] | components["schemas"]["ChatCompletionAssistantMessageParam"] | components["schemas"]["ChatCompletionToolMessageParam"] | components["schemas"]["ChatCompletionFunctionMessageParam"];
+    "ResultSuccess__success-boolean__": {
+      data: {
+        success: boolean;
+      };
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result__success-boolean_.string_": components["schemas"]["ResultSuccess__success-boolean__"] | components["schemas"]["ResultError_string_"];
+    ThreadSummary: {
+      id: string;
+      /** Format: date-time */
+      created_at: string;
+      /** Format: date-time */
+      updated_at: string;
+      escalated: boolean;
+      /** Format: double */
+      message_count: number;
+      first_message?: string;
+      last_message?: string;
+      soft_delete?: boolean;
+    };
+    "ResultSuccess_ThreadSummary-Array_": {
+      data: components["schemas"]["ThreadSummary"][];
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result_ThreadSummary-Array.string_": components["schemas"]["ResultSuccess_ThreadSummary-Array_"] | components["schemas"]["ResultError_string_"];
   };
   responses: {
   };
@@ -5639,6 +5931,9 @@ export interface operations {
     requestBody: {
       content: {
         "application/json": components["schemas"]["OpenAIChatRequest"] & {
+          inputs?: unknown;
+          environment?: string;
+          prompt_id?: string;
           logRequest?: boolean;
           useAIGateway?: boolean;
         };
@@ -5967,6 +6262,21 @@ export interface operations {
     parameters: {
       path: {
         queryId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_void.string_"];
+        };
+      };
+    };
+  };
+  BulkDeleteSavedQueries: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["BulkDeleteSavedQueriesRequest"];
       };
     };
     responses: {
@@ -7206,6 +7516,104 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["Result_void.string_"];
+        };
+      };
+    };
+  };
+  UpsertThreadMessage: {
+    parameters: {
+      path: {
+        sessionId: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          metadata: {
+            posthogSession?: string;
+            [key: string]: unknown;
+          };
+          messages: components["schemas"]["ChatCompletionMessageParam"][];
+        };
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_InAppThread.string_"];
+        };
+      };
+    };
+  };
+  GetThread: {
+    parameters: {
+      path: {
+        sessionId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_InAppThread.string_"];
+        };
+      };
+    };
+  };
+  DeleteThread: {
+    parameters: {
+      path: {
+        sessionId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result__success-boolean_.string_"];
+        };
+      };
+    };
+  };
+  EscalateThread: {
+    parameters: {
+      path: {
+        sessionId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_InAppThread.string_"];
+        };
+      };
+    };
+  };
+  GetAllThreads: {
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_ThreadSummary-Array.string_"];
+        };
+      };
+    };
+  };
+  SearchDocs: {
+    requestBody: {
+      content: {
+        "application/json": {
+          query: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_string.string_"];
         };
       };
     };


### PR DESCRIPTION
This pull request introduces a bulk delete feature for saved queries in the Helicone SQL module, allowing users to select and delete multiple queries at once via the API and frontend. The implementation includes backend API changes, updates to data models and types, and UI enhancements for multi-selection and bulk actions.

**Bulk delete feature for saved queries**

_Backend API and data model changes:_
* Added a new API endpoint `POST /v1/helicone-sql/saved-queries/bulk-delete` to support bulk deletion of saved queries, including OpenAPI and TSOA route definitions. [[1]](diffhunk://#diff-632a235f3c0ee76c5f6128d0affffff19c359a96f16fa402cd00f6d11e0ffec8R440-R442) [[2]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R17731-R17762) [[3]](diffhunk://#diff-381d211b9a18fe59eb4f5bb7734a540ed9605458415c866c5ac5b81cdbf88279R8678-R8708)
* Defined the `BulkDeleteSavedQueriesRequest` type, allowing an array of query IDs to be passed for deletion. [[1]](diffhunk://#diff-632a235f3c0ee76c5f6128d0affffff19c359a96f16fa402cd00f6d11e0ffec8R2900-R2902) [[2]](diffhunk://#diff-b600ba3180ce49d908ccac0834b59d7b768f0239547877aa8f04a983ea02787bR51-R54) [[3]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R8137-R8151) [[4]](diffhunk://#diff-381d211b9a18fe59eb4f5bb7734a540ed9605458415c866c5ac5b81cdbf88279R2641-R2648)
* Implemented the `bulkDeleteSavedQueries` method in `HqlQueryManager` to execute the deletion in the database, and exposed it in the controller. [[1]](diffhunk://#diff-5610e9f4cf6c02bcd31d82da3900fdfa61041676f7a69ee2a9978e6803cc4046R103-R126) [[2]](diffhunk://#diff-b600ba3180ce49d908ccac0834b59d7b768f0239547877aa8f04a983ea02787bR170-R184)

_Frontend UI and mutation changes:_
* Added `useBulkDeleteQueryMutation` for calling the bulk delete API, handling notifications and cache invalidation.
* Updated the queries directory UI to support multi-selection with checkboxes, "select all" functionality, and a bulk delete button. [[1]](diffhunk://#diff-b088bc7f4a43aa934b7c705787ef73af8ca915ff2192e8c67786f360cf1eae50R258-R301) [[2]](diffhunk://#diff-b088bc7f4a43aa934b7c705787ef73af8ca915ff2192e8c67786f360cf1eae50R322-R345) [[3]](diffhunk://#diff-b088bc7f4a43aa934b7c705787ef73af8ca915ff2192e8c67786f360cf1eae50R355-R364) [[4]](diffhunk://#diff-b088bc7f4a43aa934b7c705787ef73af8ca915ff2192e8c67786f360cf1eae50L308-R377) [[5]](diffhunk://#diff-b088bc7f4a43aa934b7c705787ef73af8ca915ff2192e8c67786f360cf1eae50R8) [[6]](diffhunk://#diff-b088bc7f4a43aa934b7c705787ef73af8ca915ff2192e8c67786f360cf1eae50R27)

_Other improvements:_
* Reduced the `max_rows_to_read` limit in `ClickhouseClientWrapper` for safer database reads.