### PR TITLE
fix: estimate cost before request is sent for rl

### DIFF
--- a/worker/src/lib/HeliconeProxyRequest/ProxyForwarder.ts
+++ b/worker/src/lib/HeliconeProxyRequest/ProxyForwarder.ts
@@ -146,7 +146,7 @@ export async function proxyForwarder(
               rateLimiterDO: env.RATE_LIMITER_SQL,
               rateLimitOptions: finalRateLimitOptions,
               userId: proxyRequest.userId,
-              cost: 0,
+              cost: 1,
             });
             responseBuilder.addRateLimitHeaders(
               rateLimitCheckResult,


### PR DESCRIPTION
this commit fixes an issue with our cost based rate limiting. since llm token usage is not knowable before the request is sent, an estimate must be made for the amount of tokens used. the issue fixed in this PR is to change that to a non-zero value, using a naive estimate of 1 cent. the rate limit counter will not be updated with this fake estimate, instead it will only be updated after the response is received

