### PR TITLE
feat: [ENG-2776] Clear live time filter visuals

### DIFF
--- a/web/components/shared/LivePill.tsx
+++ b/web/components/shared/LivePill.tsx
@@ -40,7 +40,9 @@ export default function LivePill(props: LivePillProps) {
       >
         <ArrowPathIcon
           className={clsx(
-            isDataLoading || isRefetching ? "animate-spin duration-500 ease-in-out" : "",
+            isDataLoading || isRefetching
+              ? "animate-spin duration-500 ease-in-out"
+              : "",
             isLive ? "animate-spin duration-1000" : "",
             "inline h-4 w-4",
           )}

--- a/web/components/shared/LivePill.tsx
+++ b/web/components/shared/LivePill.tsx
@@ -40,8 +40,9 @@ export default function LivePill(props: LivePillProps) {
       >
         <ArrowPathIcon
           className={clsx(
-            isDataLoading || isRefetching ? "animate-spin" : "",
-            "inline h-4 w-4 duration-500 ease-in-out",
+            isDataLoading || isRefetching ? "animate-spin duration-500 ease-in-out" : "",
+            isLive ? "animate-spin duration-1000" : "",
+            "inline h-4 w-4",
           )}
         />
       </Button>

--- a/web/components/shared/themed/themedHeader.tsx
+++ b/web/components/shared/themed/themedHeader.tsx
@@ -54,6 +54,9 @@ interface ThemedHeaderProps {
     customTimeFilter: boolean;
     onTimeSelectHandler: (key: TimeInterval, value: string) => void;
     defaultTimeFilter: TimeInterval;
+    isLive?: boolean;
+    hasCustomTimeFilter?: boolean;
+    onClearTimeFilter?: () => void;
   };
   savedFilters?: {
     filters?: OrganizationFilter[];
@@ -96,6 +99,9 @@ export default function ThemedHeader({
                 defaultValue={timeFilter.defaultTimeFilter ?? "all"}
                 currentTimeFilter={timeFilter.currentTimeFilter}
                 custom={timeFilter.customTimeFilter}
+                isLive={timeFilter.isLive}
+                hasCustomTimeFilter={timeFilter.hasCustomTimeFilter}
+                onClearTimeFilter={timeFilter.onClearTimeFilter}
               />
             )}
           </div>

--- a/web/components/shared/themed/themedTimeFilter.tsx
+++ b/web/components/shared/themed/themedTimeFilter.tsx
@@ -13,6 +13,9 @@ interface ThemedTimeFilterProps {
   defaultValue: string;
   currentTimeFilter: TimeFilter;
   custom?: boolean;
+  isLive?: boolean;
+  hasCustomTimeFilter?: boolean;
+  onClearTimeFilter?: () => void;
 }
 
 function formatDateToInputString(date: Date): string {
@@ -36,6 +39,9 @@ const ThemedTimeFilter = (props: ThemedTimeFilterProps) => {
     isFetching,
     currentTimeFilter,
     custom = false,
+    isLive = false,
+    hasCustomTimeFilter = false,
+    onClearTimeFilter,
   } = props;
   const searchParams = useSearchParams();
   const [active, setActive] = useState<string>(defaultValue);
@@ -103,6 +109,9 @@ const ThemedTimeFilter = (props: ThemedTimeFilterProps) => {
             from: currentTimeFilter?.start,
             to: currentTimeFilter?.end,
           }}
+          isLive={isLive}
+          hasCustomTimeFilter={hasCustomTimeFilter}
+          onClearTimeFilter={onClearTimeFilter}
         />
       )}
 

--- a/web/components/shared/themed/themedTimeFilterShadCN.tsx
+++ b/web/components/shared/themed/themedTimeFilterShadCN.tsx
@@ -152,7 +152,7 @@ export function ThemedTimeFilterShadCN({
         return `${format(from, "LLL d, yyyy HH:mm")} - Now`;
       }
     }
-    
+
     if (from.toDateString() === to.toDateString()) {
       // Same day
       return `${format(from, "LLL d, yyyy")} ${format(
@@ -244,7 +244,6 @@ export function ThemedTimeFilterShadCN({
           className="flex w-auto flex-col gap-2 p-4"
           align="start"
         >
-          
           {/* Predefined ranges */}
           <span className="pt-4 text-sm font-semibold">Quick Select:</span>
           <div className="grid grid-cols-6 gap-2">

--- a/web/components/shared/themed/themedTimeFilterShadCN.tsx
+++ b/web/components/shared/themed/themedTimeFilterShadCN.tsx
@@ -29,6 +29,9 @@ interface ThemedTimeFilterShadCNProps
   extends React.HTMLAttributes<HTMLDivElement> {
   onDateChange: (date: DateRange | undefined) => void;
   initialDateRange?: DateRange;
+  isLive?: boolean;
+  hasCustomTimeFilter?: boolean;
+  onClearTimeFilter?: () => void;
 }
 
 function isValidDate(date: Date | undefined) {
@@ -42,6 +45,9 @@ export function ThemedTimeFilterShadCN({
   className,
   onDateChange,
   initialDateRange,
+  isLive = false,
+  hasCustomTimeFilter = false,
+  onClearTimeFilter,
 }: ThemedTimeFilterShadCNProps) {
   const [date, setDate] = useState<DateRange | undefined>(undefined);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -49,15 +55,12 @@ export function ThemedTimeFilterShadCN({
   const { hasAccess } = useProFeature("time_filter");
 
   useEffect(() => {
-    // Set the initial date range after the component mounts
-    if (!date) {
-      setDate(
-        initialDateRange || {
-          from: new Date(),
-          to: new Date(),
-        },
-      );
-    }
+    setDate(
+      initialDateRange || {
+        from: new Date(),
+        to: new Date(),
+      },
+    );
   }, [initialDateRange]);
 
   const predefinedRanges = [
@@ -142,6 +145,14 @@ export function ThemedTimeFilterShadCN({
   };
 
   const formatDateDisplay = (from: Date, to: Date) => {
+    if (isLive && !hasCustomTimeFilter) {
+      if (from.toDateString() === to.toDateString()) {
+        return `${format(from, "LLL d, yyyy")} ${format(from, "HH:mm")} - Now`;
+      } else {
+        return `${format(from, "LLL d, yyyy HH:mm")} - Now`;
+      }
+    }
+    
     if (from.toDateString() === to.toDateString()) {
       // Same day
       return `${format(from, "LLL d, yyyy")} ${format(
@@ -233,6 +244,7 @@ export function ThemedTimeFilterShadCN({
           className="flex w-auto flex-col gap-2 p-4"
           align="start"
         >
+          
           {/* Predefined ranges */}
           <span className="pt-4 text-sm font-semibold">Quick Select:</span>
           <div className="grid grid-cols-6 gap-2">
@@ -397,6 +409,17 @@ export function ThemedTimeFilterShadCN({
               </div>
             </div>
           </div>
+
+          {hasCustomTimeFilter && onClearTimeFilter && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onClearTimeFilter}
+              className="ml-auto"
+            >
+              Clear
+            </Button>
+          )}
 
           {/* Warning moved to bottom to avoid content shifting */}
           {isInvertedRange && (

--- a/web/components/templates/dashboard/dashboardPage.tsx
+++ b/web/components/templates/dashboard/dashboardPage.tsx
@@ -363,7 +363,8 @@ const DashboardPage = (props: DashboardPageProps) => {
                         }
                       },
                       isLive: isLive,
-                      hasCustomTimeFilter: searchParams.get("t")?.startsWith("custom_") || false,
+                      hasCustomTimeFilter:
+                        searchParams.get("t")?.startsWith("custom_") || false,
                       onClearTimeFilter: () => {
                         searchParams.delete("t");
                         setInterval("24h");

--- a/web/components/templates/dashboard/dashboardPage.tsx
+++ b/web/components/templates/dashboard/dashboardPage.tsx
@@ -310,7 +310,7 @@ const DashboardPage = (props: DashboardPageProps) => {
               >
                 <ArrowPathIcon
                   className={clsx(
-                    isAnyLoading ? "animate-spin" : "",
+                    isAnyLoading || isLive ? "animate-spin" : "",
                     "inline h-5 w-5",
                   )}
                 />
@@ -362,6 +362,16 @@ const DashboardPage = (props: DashboardPageProps) => {
                           });
                         }
                       },
+                      isLive: isLive,
+                      hasCustomTimeFilter: searchParams.get("t")?.startsWith("custom_") || false,
+                      onClearTimeFilter: () => {
+                        searchParams.delete("t");
+                        setInterval("24h");
+                        setTimeFilter({
+                          start: getTimeIntervalAgo("24h"),
+                          end: new Date(),
+                        });
+                      },
                     }
               }
               savedFilters={undefined}
@@ -383,7 +393,7 @@ const DashboardPage = (props: DashboardPageProps) => {
                 cols={gridCols}
                 rowHeight={96}
               >
-                {metricsData.map((m, i) => (
+                {metricsData.map((m) => (
                   <div key={m.id}>
                     <MetricsPanel metric={m} />
                   </div>

--- a/web/components/templates/requests/RequestsPage.tsx
+++ b/web/components/templates/requests/RequestsPage.tsx
@@ -325,13 +325,6 @@ export default function RequestsPage(props: RequestsPageV2Props) {
         message: "Filter saved successfully",
       };
     });
-    // setToolHandler("set-filters", async (args: { filters: FilterNode[] }) => {
-    //   setAdvancedFilters(args.filters);
-    //   return {
-    //     success: true,
-    //     message: "Filters set successfully",
-    //   };
-    // });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allowedFilterDefinitions]);
 
@@ -706,6 +699,12 @@ export default function RequestsPage(props: RequestsPageV2Props) {
                 isFetching={false}
                 defaultValue={getDefaultValue()}
                 custom={true}
+                isLive={isLive}
+                hasCustomTimeFilter={searchParams.get("t")?.startsWith("custom_") || false}
+                onClearTimeFilter={() => {
+                  searchParams.delete("t");
+                  setTimeFilter(defaultFilter);
+                }}
               />
 
               {/* Filter AST Button */}

--- a/web/components/templates/requests/RequestsPage.tsx
+++ b/web/components/templates/requests/RequestsPage.tsx
@@ -700,7 +700,9 @@ export default function RequestsPage(props: RequestsPageV2Props) {
                 defaultValue={getDefaultValue()}
                 custom={true}
                 isLive={isLive}
-                hasCustomTimeFilter={searchParams.get("t")?.startsWith("custom_") || false}
+                hasCustomTimeFilter={
+                  searchParams.get("t")?.startsWith("custom_") || false
+                }
                 onClearTimeFilter={() => {
                   searchParams.delete("t");
                   setTimeFilter(defaultFilter);


### PR DESCRIPTION
Indicate more strongly in UI that the Live mode is on. Primarily, by making the little widdle spinning logo go fast
and by making time filter show 'Now'
<img width="654" height="127" alt="Screenshot 2025-08-22 at 3 11 56 PM" src="https://github.com/user-attachments/assets/f438ed56-b61a-41c4-b48f-b4678a9a3d0f" />
