### PR TITLE
feat: [ENG-2692] Helix in Quickstart

### DIFF
--- a/web/components/templates/agent/HeliconeAgentContext.tsx
+++ b/web/components/templates/agent/HeliconeAgentContext.tsx
@@ -2,6 +2,7 @@ import {
   filtersTools,
   playgroundTools,
   promptsTools,
+  quickstartTools,
   universalTools,
   hqlTools,
 } from "@/lib/agent/tools";
@@ -79,6 +80,8 @@ const getToolsForRoute = (pathname: string): HeliconeAgentTool[] => {
     tools.push(...promptsTools);
   } else if (pathname === "/playground") {
     tools.push(...playgroundTools);
+  } else if (pathname === "/quickstart") {
+    tools.push(...quickstartTools);
   }
 
   if (
@@ -219,11 +222,18 @@ export const HeliconeAgentProvider: React.FC<{
       ),
     );
   };
+
+  const getInitialMessage = () => {
+    if (router.pathname === "/quickstart") {
+      return "Hello, I'm Helix! I can provide personalized help for integrating with Helicone, so ask me anything.";
+    }
+    return "Hello! I'm Helix, your Helicone assistant. How can I help you today?";
+  };
+
   const [messages, setMessages] = useState<Message[]>([
     {
       role: "assistant",
-      content:
-        "Hello! I'm Helix, your Helicone assistant. How can I help you today?",
+      content: getInitialMessage(),
     },
   ]);
 
@@ -303,7 +313,7 @@ export const HeliconeAgentProvider: React.FC<{
           const newChatMessages = [
             {
               role: "assistant",
-              content: "Hello, how can I help you today?",
+              content: getInitialMessage(),
             },
             ...(startingMessages ?? []),
           ];

--- a/web/components/templates/agent/MessageRenderer.tsx
+++ b/web/components/templates/agent/MessageRenderer.tsx
@@ -3,6 +3,8 @@ import dynamic from "next/dynamic";
 import { markdownComponents } from "@/components/shared/prompts/ResponsePanel";
 import { useState } from "react";
 import { ImageModal } from "../requests/components/chatComponent/single/images/ImageModal";
+import { Button } from "@/components/ui/button";
+import { useRouter } from "next/router";
 
 const markdownStyling =
   "w-full text-[13px] prose-p:my-2 prose-h1:mt-2 prose-h1:font-bold prose-h2:mt-2 prose-h3:mt-2 prose-h3:mb-1 prose-a:text-brand prose-a:underline";
@@ -15,9 +17,16 @@ type Message = NonNullable<OpenAIChatRequest["messages"]>[0];
 
 interface MessageRendererProps {
   message: Message;
+  messageIndex?: number;
+  onQuickstartHelp?: () => void;
 }
 
-const MessageRenderer = ({ message }: MessageRendererProps) => {
+const MessageRenderer = ({
+  message,
+  messageIndex,
+  onQuickstartHelp,
+}: MessageRendererProps) => {
+  const router = useRouter();
   const [selectedImage, setSelectedImage] = useState<{
     src: string;
     alt: string;
@@ -111,6 +120,11 @@ const MessageRenderer = ({ message }: MessageRendererProps) => {
   }
 
   if (message.role === "assistant") {
+    const isFirstMessage = messageIndex === 0;
+    const isQuickstartPage = router.pathname === "/quickstart";
+    const showQuickstartButton =
+      isFirstMessage && isQuickstartPage && onQuickstartHelp;
+
     return (
       <div className="w-full">
         <div className="w-full text-sm text-foreground">
@@ -121,6 +135,18 @@ const MessageRenderer = ({ message }: MessageRendererProps) => {
             >
               {message.content}
             </ReactMarkdown>
+          )}
+          {showQuickstartButton && (
+            <div className="mt-3">
+              <Button
+                onClick={onQuickstartHelp}
+                variant="outline"
+                size="sm"
+                className="text-sm"
+              >
+                Help me integrate
+              </Button>
+            </div>
           )}
           {message.tool_calls && (
             <div className="mt-2 space-y-2">

--- a/web/components/templates/agent/MessageRenderer.tsx
+++ b/web/components/templates/agent/MessageRenderer.tsx
@@ -38,18 +38,26 @@ const MessageRenderer = ({ message }: MessageRendererProps) => {
     return (
       <>
         <div className="w-full">
-          {/* <div className="w-full rounded-lg border border-blue-100 bg-sidebar-background px-2.5 py-1 text-foreground "> */}
           <div className="w-full rounded-lg border border-blue-200 bg-blue-100 px-2.5 py-1 text-foreground dark:border-blue-950 dark:bg-blue-900/20">
             {typeof message.content === "string" ? (
-              <span className="text-[13px]">{message.content}</span>
+              <ReactMarkdown
+                components={markdownComponents}
+                className={markdownStyling}
+              >
+                {message.content}
+              </ReactMarkdown>
             ) : Array.isArray(message.content) ? (
               <div className="space-y-2">
                 {message.content
                   .filter((item: any) => item.type === "text")
                   .map((item: any, index: number) => (
-                    <span key={index} className="text-[13px]">
+                    <ReactMarkdown
+                      key={index}
+                      components={markdownComponents}
+                      className={markdownStyling}
+                    >
                       {item.text}
-                    </span>
+                    </ReactMarkdown>
                   ))}
               </div>
             ) : null}

--- a/web/components/templates/agent/agentChat.tsx
+++ b/web/components/templates/agent/agentChat.tsx
@@ -23,14 +23,6 @@ export interface QueuedMessage {
   timestamp: Date;
 }
 
-interface AgentExecutionState {
-  isProcessing: boolean;
-  pendingToolCalls: ToolCall[];
-  currentAssistantMessage?: Message;
-  needsAssistantResponse: boolean;
-  error?: string;
-}
-
 interface AgentChatProps {
   onClose: () => void;
 }
@@ -44,12 +36,6 @@ const AgentChat = ({ onClose }: AgentChatProps) => {
   );
   const [messageQueue, setMessageQueue] = useState<QueuedMessage[]>([]);
 
-  const [agentState, setAgentState] = useState<AgentExecutionState>({
-    isProcessing: false,
-    pendingToolCalls: [],
-    needsAssistantResponse: false,
-  });
-
   const abortController = useRef<AbortController | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const chatInterfaceRef = useRef<{ focus: () => void }>(null);
@@ -60,9 +46,9 @@ const AgentChat = ({ onClose }: AgentChatProps) => {
     executeTool,
     messages,
     updateCurrentSessionMessages,
-    escalateSession,
-    currentSession,
     createNewSession,
+    agentState,
+    setAgentState,
   } = useHeliconeAgent();
 
   const addErrorMessage = (
@@ -241,7 +227,6 @@ const AgentChat = ({ onClose }: AgentChatProps) => {
           model: selectedModel,
           messages: currentMessages,
           temperature: 0.7,
-          max_tokens: 1000,
           tools: tools.map(({ handler, ...tool }) => tool),
         };
 
@@ -485,7 +470,7 @@ const AgentChat = ({ onClose }: AgentChatProps) => {
         </div>
         <div className="flex items-center gap-2">
           <Button
-            onClick={createNewSession}
+            onClick={() => createNewSession()}
             variant="ghost"
             size="sm"
             className="h-7 w-7 p-0 hover:bg-muted"

--- a/web/components/templates/agent/agentChat.tsx
+++ b/web/components/templates/agent/agentChat.tsx
@@ -36,6 +36,10 @@ const AgentChat = ({ onClose }: AgentChatProps) => {
   );
   const [messageQueue, setMessageQueue] = useState<QueuedMessage[]>([]);
 
+  const handleQuickstartHelp = () => {
+    executeTool("quickstart-open-integration-guide", {});
+  };
+
   const abortController = useRef<AbortController | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const chatInterfaceRef = useRef<{ focus: () => void }>(null);
@@ -496,8 +500,13 @@ const AgentChat = ({ onClose }: AgentChatProps) => {
           </div>
         )}
 
-        {messages.map((message) => (
-          <MessageRenderer key={uuidv4()} message={message} />
+        {messages.map((message, index) => (
+          <MessageRenderer
+            key={uuidv4()}
+            message={message}
+            messageIndex={index}
+            onQuickstartHelp={handleQuickstartHelp}
+          />
         ))}
 
         {isLoading && (

--- a/web/components/templates/quickstart/HelixIntegrationDialog.tsx
+++ b/web/components/templates/quickstart/HelixIntegrationDialog.tsx
@@ -1,0 +1,390 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { ChevronLeft, ChevronRight, Bot, FileText } from "lucide-react";
+import {
+  SiPython,
+  SiTypescript,
+  SiJavascript,
+  SiOpenai,
+  SiAnthropic,
+  SiGooglegemini,
+  SiGoogle,
+  SiVercel,
+} from "react-icons/si";
+import { FaAws } from "react-icons/fa";
+import { VscAzure } from "react-icons/vsc";
+
+interface HelixIntegrationDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (message: string) => void;
+}
+
+type IntegrationMethod =
+  | "ai-gateway"
+  | "openai-sdk"
+  | "anthropic-sdk"
+  | "azure"
+  | "bedrock"
+  | "gemini"
+  | "vertex"
+  | "vercel-ai"
+  | "other";
+
+type Framework = "python" | "typescript" | "javascript" | "other";
+
+interface IntegrationData {
+  method: IntegrationMethod;
+  customMethod: string;
+  framework: Framework;
+  customFramework: string;
+  currentCode: string;
+  additionalInstructions: string;
+}
+
+const integrationMethods = [
+  {
+    value: "ai-gateway",
+    label: "Helicone AI Gateway (Recommended)",
+    icon: Bot,
+  },
+  { value: "openai-sdk", label: "OpenAI SDK", icon: SiOpenai },
+  { value: "anthropic-sdk", label: "Anthropic SDK", icon: SiAnthropic },
+  { value: "azure", label: "Azure", icon: VscAzure },
+  { value: "bedrock", label: "Bedrock", icon: FaAws },
+  { value: "gemini", label: "Gemini", icon: SiGooglegemini },
+  { value: "vertex", label: "Vertex", icon: SiGoogle },
+  { value: "vercel-ai", label: "Vercel AI", icon: SiVercel },
+  { value: "other", label: "Other", icon: FileText },
+];
+
+const languages = [
+  { value: "python", label: "Python", icon: SiPython, color: "text-blue-500" },
+  {
+    value: "typescript",
+    label: "TypeScript",
+    icon: SiTypescript,
+    color: "text-blue-500",
+  },
+  {
+    value: "javascript",
+    label: "JavaScript",
+    icon: SiJavascript,
+    color: "text-yellow-500",
+  },
+  { value: "other", label: "Other", icon: FileText, color: "text-gray-500" },
+];
+
+const HelixIntegrationDialog = ({
+  isOpen,
+  onClose,
+  onSubmit,
+}: HelixIntegrationDialogProps) => {
+  const [step, setStep] = useState(1);
+  const [data, setData] = useState<IntegrationData>({
+    method: "ai-gateway",
+    customMethod: "",
+    framework: "python",
+    customFramework: "",
+    currentCode: "",
+    additionalInstructions: "",
+  });
+
+  const totalSteps = 3;
+
+  const handleNext = () => {
+    if (step < totalSteps) {
+      setStep(step + 1);
+    }
+  };
+
+  const handleBack = () => {
+    if (step > 1) {
+      setStep(step - 1);
+    }
+  };
+
+  const formatMessage = () => {
+    const methodNames = {
+      "ai-gateway": "Helicone AI Gateway",
+      "openai-sdk": "OpenAI SDK",
+      "anthropic-sdk": "Anthropic SDK",
+      azure: "Azure",
+      bedrock: "Bedrock",
+      gemini: "Gemini",
+      vertex: "Vertex",
+      "vercel-ai": "Vercel AI",
+      other: data.customMethod || "Other integration method",
+    };
+
+    const frameworkNames = {
+      python: "Python",
+      typescript: "TypeScript",
+      javascript: "JavaScript",
+      other: data.customFramework || "Other",
+    };
+
+    let message = `I'm setting up Helicone integration and need help. Here are my details:\n\n`;
+    message += `**Integration Method:** ${data.method === "other" ? data.customMethod : methodNames[data.method]}\n\n`;
+    message += `**Framework/Language:** ${data.framework === "other" ? data.customFramework : frameworkNames[data.framework]}\n\n`;
+
+    if (data.currentCode.trim()) {
+      const languageMap: Record<string, string> = {
+        python: "python",
+        typescript: "typescript",
+        javascript: "javascript",
+        other: "text",
+      };
+      const lang = languageMap[data.framework] || "text";
+      message += `**Current Code:**\n\`\`\`${lang}\n${data.currentCode}\n\`\`\`\n\n`;
+    }
+
+    if (data.additionalInstructions.trim()) {
+      message += `**Additional Instructions:**\n${data.additionalInstructions}\n\n`;
+    }
+
+    message += `I am new to Helicone. Can you help me integrate it into my application?`;
+
+    return message;
+  };
+
+  const handleSubmit = () => {
+    const message = formatMessage();
+    onSubmit(message);
+    onClose();
+    setStep(1);
+    setData({
+      method: "ai-gateway",
+      customMethod: "",
+      framework: "python",
+      customFramework: "",
+      currentCode: "",
+      additionalInstructions: "",
+    });
+  };
+
+  const renderStep = () => {
+    switch (step) {
+      case 1:
+        return (
+          <div className="space-y-4">
+            <Label className="text-base font-medium">
+              How would you like to integrate with Helicone?
+            </Label>
+            <div className="max-h-[300px] space-y-2 overflow-y-auto rounded-md border border-border p-2">
+              <RadioGroup
+                value={data.method}
+                onValueChange={(value) =>
+                  setData({ ...data, method: value as IntegrationMethod })
+                }
+              >
+                {integrationMethods.map((method) => {
+                  const Icon = method.icon;
+                  return (
+                    <label
+                      key={method.value}
+                      htmlFor={method.value}
+                      className="flex cursor-pointer items-center gap-3 rounded-lg border border-border p-3 hover:bg-muted/50"
+                    >
+                      <RadioGroupItem value={method.value} id={method.value} />
+                      <Icon className="h-4 w-4" />
+                      <span className="font-medium">{method.label}</span>
+                    </label>
+                  );
+                })}
+              </RadioGroup>
+            </div>
+
+            {data.method === "other" && (
+              <div className="space-y-2">
+                <Label htmlFor="custom-method" className="text-sm">
+                  Please specify your integration method
+                </Label>
+                <Input
+                  id="custom-method"
+                  placeholder="e.g., Custom REST API, AWS Bedrock, etc."
+                  value={data.customMethod}
+                  onChange={(e) =>
+                    setData({ ...data, customMethod: e.target.value })
+                  }
+                />
+              </div>
+            )}
+          </div>
+        );
+
+      case 2:
+        return (
+          <div className="space-y-4">
+            <Label className="text-base font-medium">
+              What framework or language are you using?
+            </Label>
+            <RadioGroup
+              value={data.framework}
+              onValueChange={(value) =>
+                setData({ ...data, framework: value as Framework })
+              }
+            >
+              <div className="grid grid-cols-2 gap-3">
+                {languages.map((lang) => {
+                  const Icon = lang.icon;
+                  return (
+                    <label
+                      key={lang.value}
+                      htmlFor={lang.value}
+                      className="flex cursor-pointer items-center gap-2 rounded-lg border border-border p-3 hover:bg-muted/50"
+                    >
+                      <RadioGroupItem value={lang.value} id={lang.value} />
+                      <Icon className={`h-4 w-4 ${lang.color}`} />
+                      <span>{lang.label}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            </RadioGroup>
+
+            {data.framework === "other" && (
+              <div className="space-y-2">
+                <Label htmlFor="custom-framework" className="text-sm">
+                  Please specify your framework or language
+                </Label>
+                <Input
+                  id="custom-framework"
+                  placeholder="e.g., Java, C#, Ruby, etc."
+                  value={data.customFramework}
+                  onChange={(e) =>
+                    setData({ ...data, customFramework: e.target.value })
+                  }
+                />
+              </div>
+            )}
+          </div>
+        );
+
+      case 3:
+        return (
+          <div className="space-y-4">
+            <div>
+              <Label className="text-base font-medium">
+                What else should I know?
+              </Label>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="current-code" className="text-sm font-medium">
+                Current Code (optional)
+              </Label>
+              <Textarea
+                id="current-code"
+                placeholder="Paste your current LLM code here..."
+                className="font-mono min-h-[150px] text-sm"
+                value={data.currentCode}
+                onChange={(e) =>
+                  setData({ ...data, currentCode: e.target.value })
+                }
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label
+                htmlFor="additional-instructions"
+                className="text-sm font-medium"
+              >
+                Additional Instructions (optional)
+              </Label>
+              <Textarea
+                id="additional-instructions"
+                placeholder="Any specific requirements? (e.g., tracking custom properties, streaming, async logging, etc.)"
+                className="min-h-[100px]"
+                value={data.additionalInstructions}
+                onChange={(e) =>
+                  setData({ ...data, additionalInstructions: e.target.value })
+                }
+              />
+            </div>
+          </div>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Bot className="h-5 w-5" />
+            Integrate with Helix
+          </DialogTitle>
+          <DialogDescription>
+            Answer 3 questions and get personalized integration help!
+          </DialogDescription>
+        </DialogHeader>
+
+        <div>
+          <div className="my-2 flex justify-end text-sm text-muted-foreground">
+            <div className="flex items-center gap-3">
+              <span>
+                Step {step} of {totalSteps}
+              </span>
+              <div className="flex gap-1">
+                {Array.from({ length: totalSteps }).map((_, i) => (
+                  <div
+                    key={i}
+                    className={`h-1.5 w-12 rounded-full transition-colors ${
+                      i < step ? "bg-primary" : "bg-muted"
+                    }`}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {renderStep()}
+        </div>
+
+        <div className="flex justify-between">
+          <Button
+            variant="outline"
+            onClick={handleBack}
+            disabled={step === 1}
+            className="flex items-center gap-1"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Back
+          </Button>
+
+          {step < totalSteps ? (
+            <Button onClick={handleNext} className="flex items-center gap-1">
+              Next
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          ) : (
+            <Button
+              onClick={handleSubmit}
+              className="flex items-center gap-1 bg-primary"
+            >
+              <Bot className="h-4 w-4" />
+              Ask Helix
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default HelixIntegrationDialog;

--- a/web/components/templates/quickstart/HelixIntegrationDialog.tsx
+++ b/web/components/templates/quickstart/HelixIntegrationDialog.tsx
@@ -57,15 +57,14 @@ const integrationMethods = [
   {
     value: "ai-gateway",
     label: "Helicone AI Gateway (Recommended)",
-    icon: Bot,
+    icon: SiOpenai,
   },
-  { value: "openai-sdk", label: "OpenAI SDK", icon: SiOpenai },
   { value: "anthropic-sdk", label: "Anthropic SDK", icon: SiAnthropic },
   { value: "azure", label: "Azure", icon: VscAzure },
-  { value: "bedrock", label: "Bedrock", icon: FaAws },
-  { value: "gemini", label: "Gemini", icon: SiGooglegemini },
   { value: "vertex", label: "Vertex", icon: SiGoogle },
-  { value: "vercel-ai", label: "Vercel AI", icon: SiVercel },
+  { value: "gemini", label: "Gemini", icon: SiGooglegemini },
+  { value: "bedrock", label: "Bedrock", icon: FaAws },
+  { value: "vercel-ai", label: "AI SDK", icon: SiVercel },
   { value: "other", label: "Other", icon: FileText },
 ];
 
@@ -213,7 +212,7 @@ const HelixIntegrationDialog = ({
                 </Label>
                 <Input
                   id="custom-method"
-                  placeholder="e.g., Custom REST API, AWS Bedrock, etc."
+                  placeholder="e.g., xAI, Groq Cloud, etc."
                   value={data.customMethod}
                   onChange={(e) =>
                     setData({ ...data, customMethod: e.target.value })
@@ -261,7 +260,7 @@ const HelixIntegrationDialog = ({
                 </Label>
                 <Input
                   id="custom-framework"
-                  placeholder="e.g., Java, C#, Ruby, etc."
+                  placeholder="e.g., Go, Rust, etc."
                   value={data.customFramework}
                   onChange={(e) =>
                     setData({ ...data, customFramework: e.target.value })

--- a/web/components/templates/quickstart/integrationGuide.tsx
+++ b/web/components/templates/quickstart/integrationGuide.tsx
@@ -12,7 +12,7 @@ const IntegrationGuide = ({ apiKey }: IntegrationGuideProps) => {
       className="w-full rounded-lg bg-background"
       onClick={(e) => e.stopPropagation()}
     >
-      <div className="flex flex-col gap-4 p-4">
+      <div className="flex flex-col gap-4 px-4 py-2">
         <IntegrationCodeTabs apiKey={apiKey} />
 
         <div className="flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50/50 px-3 py-2 dark:border-blue-800 dark:bg-blue-950/20">

--- a/web/components/templates/quickstart/integrationGuide.tsx
+++ b/web/components/templates/quickstart/integrationGuide.tsx
@@ -15,7 +15,7 @@ const IntegrationGuide = ({ apiKey }: IntegrationGuideProps) => {
       <div className="flex flex-col gap-4 px-4 py-2">
         <IntegrationCodeTabs apiKey={apiKey} />
 
-        <div className="flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50/50 px-3 py-2 dark:border-blue-800 dark:bg-blue-950/20">
+        <div className="flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50/50 px-3 py-2 dark:border-blue-800 dark:bg-blue-950/20">
           <BookOpen className="h-4 w-4 flex-shrink-0 text-blue-600 dark:text-blue-400" />
           <span className="text-sm text-blue-900 dark:text-blue-100">
             Check our{" "}

--- a/web/components/templates/quickstart/quickstartPage.tsx
+++ b/web/components/templates/quickstart/quickstartPage.tsx
@@ -20,11 +20,11 @@ import {
   BookOpen,
   MessageSquare,
   Mail,
-  MoveUpRight,
   Copy,
   Loader,
   Check,
   Bot,
+  MoveUpRight,
 } from "lucide-react";
 import Link from "next/link";
 import { useKeys } from "@/components/templates/keys/useKeys";
@@ -58,8 +58,13 @@ const QuickstartPage = () => {
     org?.currentOrg?.id ?? "",
   );
 
-  const { createNewSession, setAgentChatOpen, setAgentState } =
-    useHeliconeAgent();
+  const {
+    setAgentChatOpen,
+    setAgentState,
+    setToolHandler,
+    updateCurrentSessionMessages,
+    messages,
+  } = useHeliconeAgent();
 
   useEffect(() => {
     if (org?.currentOrg?.onboarding_status) {
@@ -75,6 +80,20 @@ const QuickstartPage = () => {
       setQuickstartKey(undefined);
     }
   }, [hasKeys]);
+
+  useEffect(() => {
+    setAgentChatOpen(true);
+  }, []);
+
+  useEffect(() => {
+    setToolHandler("quickstart-open-integration-guide", async () => {
+      setIsHelixDialogOpen(true);
+      return {
+        success: true,
+        message: "Successfully opened the integration guide dialog",
+      };
+    });
+  }, []);
 
   const handleCreateKey = async () => {
     try {
@@ -95,11 +114,11 @@ const QuickstartPage = () => {
   };
 
   const handleHelixSubmit = (message: string) => {
-    const startingMessage = {
+    const helpMessage = {
       role: "user" as const,
       content: message,
     };
-    createNewSession([startingMessage]);
+    updateCurrentSessionMessages([...messages, helpMessage], true);
     setAgentChatOpen(true);
 
     setTimeout(() => {
@@ -205,15 +224,6 @@ const QuickstartPage = () => {
                   <IntegrationGuide apiKey={quickstartKey} />
 
                   <div className="mx-4 mb-2 flex flex-col gap-2">
-                    <Button
-                      onClick={() => setIsHelixDialogOpen(true)}
-                      variant="outline"
-                      className="flex w-full items-center justify-center gap-2"
-                    >
-                      <Bot size={16} />
-                      Integrate with Helix
-                    </Button>
-
                     <div
                       className={`rounded-sm border border-border p-3 ${org?.currentOrg?.has_integrated ? "bg-confirmative/10" : "bg-muted/30"}`}
                     >
@@ -241,9 +251,11 @@ const QuickstartPage = () => {
                     href="https://docs.helicone.ai/getting-started/quick-start"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="w-fit"
                   >
-                    <Button variant="link" className="flex items-center gap-1">
+                    <Button
+                      variant="link"
+                      className="flex w-auto items-center gap-1"
+                    >
                       Using another SDK?
                       <MoveUpRight size={12} />
                     </Button>
@@ -283,6 +295,15 @@ const QuickstartPage = () => {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent>
+              <DropdownMenuItem asChild>
+                <button
+                  onClick={() => setIsHelixDialogOpen(true)}
+                  className="flex w-full items-center"
+                >
+                  <Bot size={16} className="mr-2" />
+                  Ask Helix
+                </button>
+              </DropdownMenuItem>
               <DropdownMenuItem asChild>
                 <Link
                   href="https://docs.helicone.ai"

--- a/web/data/providers.ts
+++ b/web/data/providers.ts
@@ -189,7 +189,7 @@ export const providers: Provider[] = [
     apiKeyLabel: "OpenRouter API Key",
     apiKeyPlaceholder: "...",
     relevanceScore: 35,
-    note: "We don't support OpenRouter in our AI Gateway but you can use it with our Playground.",
+    note: "We don't support OpenRouter in our AI Gateway, but you can use it with our Playground.",
   },
   // {
   //   id: "hyperbolic",

--- a/web/lib/agent/tools.ts
+++ b/web/lib/agent/tools.ts
@@ -59,6 +59,20 @@ export const universalTools = [
   },
 ];
 
+export const quickstartTools = [
+  {
+    type: "function" as const,
+    function: {
+      name: "quickstart-open-integration-guide",
+      description: "Shows the integration guide to the user.",
+      parameters: {
+        type: "object",
+        properties: {},
+      },
+    },
+  },
+];
+
 export const hqlTools = [
   {
     type: "function" as const,


### PR DESCRIPTION
Integrates Helix into the quickstart flow
- created `HeliconeIntegrationDialog` that shows a 3 step process where users provide the language+sdk of choice
- adds button to open dialog in the helix chat
- open helix chat by default in the `/quickstart` page

<img width="720" height="406" alt="image" src="https://github.com/user-attachments/assets/ca1a8d23-128f-4345-a19d-d24ff14d84c9" />
<img width="931" height="729" alt="Screenshot 2025-08-26 at 2 18 30 PM" src="https://github.com/user-attachments/assets/6e1d4902-5592-4f99-97d5-b5f9aa8bb746" />
<img width="910" height="531" alt="Screenshot 2025-08-26 at 2 18 35 PM" src="https://github.com/user-attachments/assets/f1dfed0d-3c51-46fe-980e-1ae9b1959f74" />
<img width="1019" height="768" alt="Screenshot 2025-08-26 at 2 18 41 PM" src="https://github.com/user-attachments/assets/2cca610a-db1d-4553-9c14-2512f95d3fd2" />
