### PR TITLE
Fix Vercel AI SDK docs

### DIFF
--- a/docs/getting-started/integration-method/vercelai.mdx
+++ b/docs/getting-started/integration-method/vercelai.mdx
@@ -76,6 +76,8 @@ import { strings } from "/snippets/strings.mdx";
     });
 
     console.log(response);
+    ```
+
 
     ```javascript Google Gemini
     import { createGoogleGenerativeAI } from "@ai-sdk/google";


### PR DESCRIPTION
Backticks were missing causing the docs to not render the Gemini part.

