### PR TITLE
fix: [ENG-2849] Fix improper bundling of helicone-package in helpers sdk

### DIFF
--- a/sdk/typescript/helpers/package-lock.json
+++ b/sdk/typescript/helpers/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helicone/helpers",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helicone/helpers",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.21.4",

--- a/sdk/typescript/helpers/package.json
+++ b/sdk/typescript/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helicone/helpers",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "description": "A Node.js wrapper for some of Helicone's common functionalities",

--- a/sdk/typescript/helpers/tsconfig.json
+++ b/sdk/typescript/helpers/tsconfig.json
@@ -22,8 +22,11 @@
     "moduleResolution": "Node",
     "noImplicitAny": true,
     "outDir": "dist",
-    "rootDir": ".",
-    "typeRoots": ["node_modules/@types"]
+    "rootDir": "../../../",
+    "typeRoots": ["node_modules/@types"],
+    "paths": {
+      "@helicone-package/*": ["../../../packages/*"]
+    }
   },
   "exclude": ["dist", "node_modules", "tests/UsageExample.ts"],
   "include": ["*.ts", "tests/**/*.ts"]

--- a/sdk/typescript/helpers/tsup.config.ts
+++ b/sdk/typescript/helpers/tsup.config.ts
@@ -3,8 +3,11 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['index.ts'],
   format: ['cjs', 'esm'],
-  dts: true,
+  dts: {
+    resolve: true,
+  },
   clean: true,
   external: ['openai'],
   bundle: true,
+  noExternal: [/@helicone-package/],
 }) 


### PR DESCRIPTION
Helpers SDK build was not bundling the @helicone-package types correctly - so functionality was preserved (by tsup bundling) but `HeliconePromptManager` shows as `any`.