### PR TITLE
fix: resolve broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Helicone is comprised of five services:
 We ❤️ our contributors! We warmly welcome contributions for documentation, integrations, costs, and feature requests.
 
 - If you have an idea for how Helicone can be better, create a [GitHub issue](https://github.com/Helicone/helicone/issues) or vote on the [roadmap](https://github.com/Helicone/helicone/labels/roadmap)
-- Update costs instructions in [costs/README.md](https://github.com/Helicone/helicone/blob/main/packages/README.md)
+- Update costs instructions in [costs/README.md](https://github.com/Helicone/helicone/blob/main/packages/cost/README.md)
 - Join [discord](https://discord.gg/zsSTcH2qhG) to ask questions
 
 ## License

--- a/docs/getting-started/platform-overview.mdx
+++ b/docs/getting-started/platform-overview.mdx
@@ -99,7 +99,7 @@ When production breaks and everyone's panicking, we're rock solid. Built for whe
 
 <Card
   title="Session Tracking" 
-  href="/observability/sessions"
+  href="/features/sessions"
   icon="code-branch"
 >
   Debug complex AI agents or AI workflows
@@ -116,7 +116,7 @@ When production breaks and everyone's panicking, we're rock solid. Built for whe
 
 <Card
   title="Cost Tracking" 
-  href="/observability/cost-tracking"
+  href="/guides/cookbooks/cost-tracking"
   icon="dollar-sign"
 >
   Track cost and understand the unit economics of your LLM applications

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -13,7 +13,7 @@ We are a team of passionate developers who are committed to making best in class
 ### Getting Started
 
 <CardGroup cols={1}>
-  <Card title="Get Started" icon="code" href="/getting-started">
+  <Card title="Get Started" icon="code" href="/getting-started/quick-start">
     Quickly integrate Helicone into your application and get started.
   </Card>
 </CardGroup>
@@ -68,7 +68,7 @@ The optimal method to integrate with Helicone is through our Gateway.
   </Card>
   <Card
     title="Rate Limiting"
-    href="/features/advanced-usage/custowm-rate-limits"
+    href="/features/advanced-usage/custom-rate-limits"
   >
     Easily rate-limit power users
   </Card>
@@ -78,7 +78,7 @@ The optimal method to integrate with Helicone is through our Gateway.
   <Card title="Fine Tuning" href="/features/advanced-usage/fine-tuning">
     Fine-tune a model on your logs
   </Card>
-  <Card title="Customer Portal" href="/features/customer_portal/intro">
+  <Card title="Customer Portal" href="/features/customer-portal">
     Fine-tune a model on your logs
   </Card>
   <Card title="Key Vault" href="/features/advanced-usage/key-vault">

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -13,7 +13,7 @@ iconType: "solid"
 <CardGroup cols={4}>
   <Card
     title="OpenAI"
-    href="/getting-started/providers/openai"
+    href="/getting-started/integration-method/openai"
     icon={
       <svg
         class="w-[1.60625rem] m:w-[1.375rem] h-auto"
@@ -31,7 +31,7 @@ iconType: "solid"
   />
   <Card
     title="OpenAI"
-    href="/getting-started/providers/openai"
+    href="/getting-started/integration-method/openai"
     icon={
       <svg
         class="w-[1.60625rem] m:w-[1.375rem] h-auto"
@@ -49,7 +49,7 @@ iconType: "solid"
   />
   <Card
     title="OpenAI"
-    href="/getting-started/providers/openai"
+    href="/getting-started/integration-method/openai"
     icon={
       <svg
         class="w-[1.60625rem] m:w-[1.375rem] h-auto"
@@ -118,7 +118,7 @@ The optimal method to integrate with Helicone is through our Gateway.
   <Card title="Fine Tuning" href="/features/advanced-usage/fine-tuning">
     Fine-tune a model on your logs
   </Card>
-  <Card title="Customer Portal" href="/features/customer_portal/intro">
+  <Card title="Customer Portal" href="/features/customer-portal">
     Fine-tune a model on your logs
   </Card>
   <Card title="Key Vault" href="/features/advanced-usage/key-vault">


### PR DESCRIPTION
- Fix typo: custowm-rate-limits → custom-rate-limits in docs/introduction.mdx
- Update /getting-started links to point to /getting-started/quick-start  
- Fix provider links from /getting-started/providers/openai to /getting-started/integration-method/openai
- Update observability links to point to correct paths:
  - /observability/sessions → /features/sessions
  - /observability/cost-tracking → /guides/cookbooks/cost-tracking
- Fix customer portal links from /features/customer_portal/intro to /features/customer-portal
- Correct README.md cost documentation link to point to packages/cost/README.md

@chitalian can you pls check