### PR TITLE
fix: resolve response parsing error caused by compressed responses

### DIFF
--- a/worker/src/lib/clients/ProviderClient.ts
+++ b/worker/src/lib/clients/ProviderClient.ts
@@ -103,12 +103,9 @@ export async function callProvider(props: CallProps): Promise<Response> {
     headersWithExtra = joinHeaders(removedHeaders, props.extraHeaders);
   }
 
-  if (
-    originalUrl.host.includes("localhost") ||
-    originalUrl.host.includes("127.0.0.1")
-  ) {
-    headersWithExtra.set("Accept-Encoding", "Identity");
-  }
+  // Always set Accept-Encoding to identity to prevent compressed responses
+  // that would cause parsing errors in ReadableInterceptor
+  headersWithExtra.set("Accept-Encoding", "identity");
 
   const baseInit = { method, headers: headersWithExtra };
   const init = method === "GET" ? { ...baseInit } : { ...baseInit, body };

--- a/worker/src/lib/clients/TokenCounterClient.ts
+++ b/worker/src/lib/clients/TokenCounterClient.ts
@@ -17,6 +17,7 @@ export async function getTokenCount(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "Accept-Encoding": "identity",
         authorization: "Bearer " + process.env.TOKEN_KEY,
       },
       body: JSON.stringify({ content: inputText }),
@@ -30,6 +31,7 @@ export async function getTokenCount(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "Accept-Encoding": "identity",
         authorization: "Bearer " + process.env.TOKEN_KEY,
       },
       body: JSON.stringify({ content: inputText }),

--- a/worker/src/routers/openaiProxyRouter.ts
+++ b/worker/src/routers/openaiProxyRouter.ts
@@ -40,9 +40,11 @@ export const getOpenAIProxyRouter = (router: BaseRouter) => {
         const new_url = new URL(
           `https://api.openai.com${requestWrapper.url.pathname}`
         );
+        const headers = new Headers(requestWrapper.getHeaders());
+        headers.set("Accept-Encoding", "identity");
         return await fetch(new_url.href, {
           method: requestWrapper.getMethod(),
-          headers: requestWrapper.getHeaders(),
+          headers: headers,
           body: requestWrapper.getBody(),
         });
       }


### PR DESCRIPTION
## Problem

ref: #2973 
- Worker proxy was failing to parse OpenAI responses with `SyntaxError: Unexpected token '!'`
- Model fields missing from dashboard despite successful requests
- **Root cause:** OpenAI returned gzipped responses, but `ReadableInterceptor` tried to decode binary gzip data as UTF-8 text

## Solution
- Set `Accept-Encoding: identity` in all external provider requests
- Forces providers to return uncompressed, plain-text responses
- Applied to `ProviderClient`, `openaiProxyRouter`, and `TokenCounterClient`

@connortbot @chitalian can you pls check this