### PR TITLE
fix: Update clickhouse wrapper memory usage

### DIFF
--- a/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
@@ -121,7 +121,7 @@ export class ClickhouseClientWrapper {
         clickhouse_settings: {
           wait_end_of_query: 1,
           max_execution_time: 30,
-          max_memory_usage: "1000000000",
+          max_memory_usage: "4000000000",
           max_rows_to_read: "10000000",
           max_result_rows: "10000",
           SQL_helicone_organization_id: organizationId,


### PR DESCRIPTION
This pull request increases the maximum memory usage allowed for Clickhouse queries, which should help prevent out-of-memory errors for larger queries.

* Database configuration:
  * Increased the `max_memory_usage` setting in `ClickhouseClientWrapper` from `1000000000` to `4000000000` to allow queries to use more memory.