### PR TITLE
refactor: move toFilterNode to packages sdk

### DIFF
--- a/packages/filters/toFilterNode.ts
+++ b/packages/filters/toFilterNode.ts
@@ -4,14 +4,14 @@ import {
   FilterNode,
   FilterBranch,
   FilterLeaf,
-} from "@helicone-package/filters/filterDefs";
+} from "./filterDefs";
 import {
   FilterExpression,
   ConditionExpression,
   AndExpression,
   OrExpression,
   FieldSpec,
-} from "@helicone-package/filters/types";
+} from "./types";
 
 /**
  * Maps the new FilterAST operator names to the legacy operator names

--- a/web/components/templates/dashboard/dashboardPage.tsx
+++ b/web/components/templates/dashboard/dashboardPage.tsx
@@ -22,7 +22,7 @@ import { useLocalStorage } from "../../../services/hooks/localStorage";
 import { useOrg } from "../../layout/org/organizationContext";
 
 import { useFilterStore } from "@/filterAST/store/filterStore";
-import { toFilterNode } from "@/filterAST/toFilterNode";
+import { toFilterNode } from "@helicone-package/filters/toFilterNode";
 import AuthHeader from "../../shared/authHeader";
 import { clsx } from "../../shared/clsx";
 import LoadingAnimation from "../../shared/loadingAnimation";

--- a/web/components/templates/dashboard/useDashboardPage.tsx
+++ b/web/components/templates/dashboard/useDashboardPage.tsx
@@ -8,7 +8,7 @@ import { CostOverTime } from "../../../pages/api/metrics/costOverTime";
 import { ErrorOverTime } from "../../../pages/api/metrics/errorOverTime";
 
 import { useFilterStore } from "@/filterAST/store/filterStore";
-import { toFilterNode } from "@/filterAST/toFilterNode";
+import { toFilterNode } from "@helicone-package/filters/toFilterNode";
 import { TokensOverTime } from "@/pages/api/metrics/TokensOverTimeType";
 import { getTokensPerRequest } from "../../../lib/api/metrics/averageTokensPerRequest";
 import { LatencyOverTime } from "../../../lib/api/metrics/getLatencyOverTime";

--- a/web/components/templates/properties/propertyPanel.tsx
+++ b/web/components/templates/properties/propertyPanel.tsx
@@ -17,7 +17,7 @@ import ThemedTableHeader from "../../shared/themed/themedHeader";
 import useSearchParams from "../../shared/utils/useSearchParams";
 import { formatNumber } from "../users/initialColumns";
 import { useFilterStore } from "@/filterAST/store/filterStore";
-import { toFilterNode } from "@/filterAST/toFilterNode";
+import { toFilterNode } from "@helicone-package/filters/toFilterNode";
 
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/web/components/templates/requests/useRequestsPageV2.tsx
+++ b/web/components/templates/requests/useRequestsPageV2.tsx
@@ -16,7 +16,7 @@ import {
 import { filterUITreeToFilterNode } from "@helicone-package/filters/helpers";
 import { SortLeafRequest } from "../../../services/lib/sorts/requests/sorts";
 import { useFilterAST } from "@/filterAST/context/filterContext";
-import { toFilterNode } from "@/filterAST/toFilterNode";
+import { toFilterNode } from "@helicone-package/filters/toFilterNode";
 
 const useRequestsPageV2 = (
   currentPage: number,

--- a/web/pages/sessions/[name]/[session_id].tsx
+++ b/web/pages/sessions/[name]/[session_id].tsx
@@ -13,7 +13,7 @@ import { sessionFromHeliconeRequests } from "../../../lib/sessions/sessionsFromH
 import { useGetRequests } from "../../../services/hooks/requests";
 import { useRouter } from "next/router";
 import { useFilterAST } from "@/filterAST/context/filterContext";
-import { toFilterNode } from "@/filterAST/toFilterNode";
+import { toFilterNode } from "@helicone-package/filters/toFilterNode";
 
 export const SessionDetail = ({
   session_id,

--- a/web/services/hooks/sessions.tsx
+++ b/web/services/hooks/sessions.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useOrg } from "../../components/layout/org/organizationContext";
 import { getJawnClient } from "../../lib/clients/jawn";
 import { useFilterAST } from "@/filterAST/context/filterContext";
-import { toFilterNode } from "@/filterAST/toFilterNode";
+import { toFilterNode } from "@helicone-package/filters/toFilterNode";
 import { FilterExpression } from "@helicone-package/filters/types";
 import { TimeFilter } from "@/types/timeFilter";
 

--- a/web/services/hooks/users.tsx
+++ b/web/services/hooks/users.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useOrg } from "@/components/layout/org/organizationContext";
 import { useFilterAST } from "@/filterAST/context/filterContext";
 import { FilterExpression } from "@helicone-package/filters/types";
-import { toFilterNode } from "@/filterAST/toFilterNode";
+import { toFilterNode } from "@helicone-package/filters/toFilterNode";
 import { getJawnClient } from "@/lib/clients/jawn";
 import { TimeFilter } from "@/types/timeFilter";
 


### PR DESCRIPTION
This pull request refactors the import paths for the `toFilterNode` utility and its dependencies, consolidating them under the `@helicone-package/filters` package. This change improves code organization and modularity by ensuring all references to `toFilterNode` use the shared package location, rather than local paths. Additionally, the internal imports within `toFilterNode` itself are updated to use relative paths, reflecting its new location.

**Refactoring imports to use shared package paths:**

* Updated all occurrences of `import { toFilterNode } from "@/filterAST/toFilterNode"` to `import { toFilterNode } from "@helicone-package/filters/toFilterNode"` across multiple files, including `dashboardPage.tsx`, `useDashboardPage.tsx`, `propertyPanel.tsx`, `useRequestsPageV2.tsx`, `[session_id].tsx`, `sessions.tsx`, and `users.tsx`. [[1]](diffhunk://#diff-3afdc711baf35f5ee3c5142e8541032164431e14ec5bf87e4cbf4791e6ecb56eL25-R25) [[2]](diffhunk://#diff-5c10379e50e7bb5c3a00ebc5bb0f7af3d9ed93056633aa8a7ba8bbb80d7ad6bcL11-R11) [[3]](diffhunk://#diff-3f9a1c4d41c72f244ddd05f331f8bc2c7b350b68396f8b165eee4e5aead943e1L20-R20) [[4]](diffhunk://#diff-44e7c14cb3c2f55f35943cf8142cb49215f4c384c073ab96225e44caea0d04f9L19-R19) [web/pages/sessions/[name]/[session_id].tsxL16-R16](diffhunk://#diff-133072956d8bd739dbd945dc50b0ed4a398042f682add94f6132a9bad0736aa1L16-R16), [[5]](diffhunk://#diff-2b45871a787bb56148b9dd4a8aef8a908080d921513838ab722300f4cdcfdeadL5-R5) [[6]](diffhunk://#diff-5e3b78874be84bef57dfad968f161b72077633e4e31edd4a1231db4646c36387L5-R5)

**Updating internal imports in `toFilterNode`:**

* Changed internal imports in `toFilterNode.ts` (renamed from `web/filterAST/toFilterNode.ts`) to use relative paths for `filterDefs` and `types`, replacing package imports.