### PR TITLE
feat: [ENG-2905] Optional messages in Helicone Prompts

### DIFF
--- a/docs/features/advanced-usage/prompts.mdx
+++ b/docs/features/advanced-usage/prompts.mdx
@@ -67,6 +67,7 @@ Traditional prompt development involves hardcoded prompts in application code, m
     <CodeGroup>
       ```typescript TypeScript
       import { OpenAI } from "openai";
+      import { HeliconeChatCreateParams } from "@helicone/helpers";
 
       const openai = new OpenAI({
         baseURL: "https://ai-gateway.helicone.ai",
@@ -77,11 +78,45 @@ Traditional prompt development involves hardcoded prompts in application code, m
         model: "gpt-4o-mini",
         prompt_id: "abc123", // Reference your saved prompt
         environment: "production", // Optional: specify environment
+        messages: [
+          {
+            role: "user",
+            content: "Hello there!"
+          }
+        ], // optional: saved prompt also provides messages
         inputs: {
           customer_name: "John Doe",
           product: "AI Gateway"
         }
+      } as HeliconeChatCreateParams);
+      ```
+
+      ```typescript TypeScript (with satisfies)
+      import { OpenAI } from "openai";
+      import { HeliconeChatCreateParams } from "@helicone/helpers";
+
+      const openai = new OpenAI({
+        baseURL: "https://ai-gateway.helicone.ai",
+        apiKey: process.env.HELICONE_API_KEY,
       });
+
+      const body = {
+        model: "gpt-4o-mini",
+        prompt_id: "abc123",
+        environment: "production", // Optional: specify environment
+        messages: [
+          {
+            role: "user",
+            content: "Hello there!"
+          }
+        ], // optional: saved prompt also provides messages
+        inputs: {
+          customer_name: "John Doe",
+          product: "AI Gateway"
+        }
+      } satisfies HeliconeChatCreateParams;
+
+      const response = await openai.chat.completions.create(body);
       ```
 
       ```python Python
@@ -215,6 +250,8 @@ Messages work differently than other parameters. Instead of overriding, runtime 
 - Define consistent system prompts and example conversations in your saved prompt
 - Add dynamic user messages at runtime
 - Build multi-turn conversations that maintain context
+
+Since your saved prompts contain the required messages, the `messages` parameter becomes optional in API calls when using Helicone prompts. However, if your prompt template is empty or lacks messages, you'll need to provide them at runtime.
 
 <Warning>
   Runtime messages are always appended to the end of your saved prompt messages. Make sure your saved prompt structure accounts for this behavior.
@@ -459,6 +496,8 @@ Prompts through the AI Gateway come with several benefits:
     - `environment` - Optional environment to target (e.g., "production", "staging")
     - `version_id` - Optional specific version (defaults to production version)
     - `inputs` - Variable values
+    
+    **Important**: These types make `messages` optional because Helicone prompts are expected to contain the required message structure. If your prompt template is empty or doesn't include messages, you'll need to provide them at runtime.
 
     For direct SDK integration:
     ```typescript
@@ -483,6 +522,8 @@ Prompts through the AI Gateway come with several benefits:
     - `environment` - Optional environment to target (e.g., "production", "staging")
     - `version_id` - Optional specific version (defaults to production version)
     - `inputs` - Variable values for template substitution
+    
+    **Important**: Similar to TypeScript, `messages` becomes optional when using prompts since your saved prompt template should contain the necessary message structure.
 
     The main class for direct SDK integration:
     ```python

--- a/packages/prompts/HeliconePromptManager.ts
+++ b/packages/prompts/HeliconePromptManager.ts
@@ -148,8 +148,8 @@ export class HeliconePromptManager {
 
     const { prompt_id, version_id, inputs, environment, ...inputOpenaiParams } = params;
     const mergedBody = {
-      ...inputOpenaiParams,
       ...sourcePromptBody,
+      ...inputOpenaiParams,
       messages: substitutedMessages,
       response_format: finalResponseFormat,
       tools: finalTools,

--- a/packages/prompts/HeliconePromptManager.ts
+++ b/packages/prompts/HeliconePromptManager.ts
@@ -94,7 +94,10 @@ export class HeliconePromptManager {
 
     const substitutionValues = params.inputs || {};
 
-    const mergedMessages = [...sourcePromptBody.messages, ...params.messages];
+    const mergedMessages = [
+      ...(sourcePromptBody.messages || []),
+      ...(params.messages || []),
+    ];
 
     const substitutedMessages = mergedMessages.map((message) => {
       if (typeof message.content === "string") {
@@ -145,8 +148,8 @@ export class HeliconePromptManager {
 
     const { prompt_id, version_id, inputs, environment, ...inputOpenaiParams } = params;
     const mergedBody = {
-      ...sourcePromptBody,
       ...inputOpenaiParams,
+      ...sourcePromptBody,
       messages: substitutedMessages,
       response_format: finalResponseFormat,
       tools: finalTools,

--- a/packages/prompts/types.ts
+++ b/packages/prompts/types.ts
@@ -52,6 +52,12 @@ export interface Prompt2025Input {
   inputs: Record<string, any>;
 }
 
+// OpenAI chat completion types where messages is optional
+// this is because we can generally assume that prompts contain messages themselves, and so after merging the params, the messages will be present
+// and OpenAI compatible endpoints will not complain about messages being omitted.
+type ChatCompletionCreateParamsNonStreamingPartialMessages = Omit<ChatCompletionCreateParamsNonStreaming, 'messages'> & Partial<Pick<ChatCompletionCreateParamsNonStreaming, 'messages'>>;
+type ChatCompletionCreateParamsStreamingPartialMessages = Omit<ChatCompletionCreateParamsStreaming, 'messages'> & Partial<Pick<ChatCompletionCreateParamsStreaming, 'messages'>>;
+
 /**
  * Parameters for using Helicone prompt templates.
  *
@@ -91,7 +97,7 @@ export type HeliconePromptParams = {
  * const response = await openai.chat.completions.create({
  *   prompt_id: "XXXXXX",
  *   model: "gpt-4",
- *   messages: [{ role: "user", content: "Hello!" }],
+ *   messages: [{ role: "user", content: "Hello!" }], // optional
  *   inputs: {
  *     name: "John",
  *     age: 20,
@@ -99,7 +105,7 @@ export type HeliconePromptParams = {
  * } as HeliconeChatCreateCompletion);
  * ```
  */
-export type HeliconeChatCreateParams = ChatCompletionCreateParamsNonStreaming &
+export type HeliconeChatCreateParams = ChatCompletionCreateParamsNonStreamingPartialMessages &
   HeliconePromptParams;
 
 /**
@@ -111,7 +117,7 @@ export type HeliconeChatCreateParams = ChatCompletionCreateParamsNonStreaming &
  * const stream = await openai.chat.completions.create({
  *   prompt_id: "XXXXXX",
  *   model: "gpt-4",
- *   messages: [{ role: "user", content: "Hello!" }],
+ *   messages: [{ role: "user", content: "Hello!" }], // optional
  *   stream: true,
  *   inputs: {
  *     name: "John",
@@ -121,4 +127,4 @@ export type HeliconeChatCreateParams = ChatCompletionCreateParamsNonStreaming &
  * ```
  */
 export type HeliconeChatCreateParamsStreaming =
-  ChatCompletionCreateParamsStreaming & HeliconePromptParams;
+  ChatCompletionCreateParamsStreamingPartialMessages & HeliconePromptParams;


### PR DESCRIPTION
- make messages optional in the HeliconeChatCreateParams type
- update documentation to reflect this along with a better type checking example and warnings about how messages is optional but may error if prompt body is empty