### PR TITLE
fix: resolve Docker build and migration issues

### DIFF
--- a/docker/dockerfiles/dockerfile_web
+++ b/docker/dockerfiles/dockerfile_web
@@ -7,6 +7,7 @@ COPY packages/cost/package.json ./packages/cost/
 COPY packages/filters/package.json ./packages/filters/
 COPY packages/llm-mapper/package.json ./packages/llm-mapper/
 COPY packages/prompts/package.json ./packages/prompts/
+COPY packages/secrets/package.json ./packages/secrets/
 COPY web/package.json ./web/
 COPY valhalla/jawn/package.json ./valhalla/jawn/
 COPY bifrost/package.json ./bifrost/

--- a/supabase/migrations/20250731212201_provider_secret_key.sql
+++ b/supabase/migrations/20250731212201_provider_secret_key.sql
@@ -37,6 +37,10 @@ DROP FUNCTION IF EXISTS provider_keys_encrypt_secret_provider_key();
 -- BEFORE INSERT OR UPDATE ON provider_keys
 -- FOR EACH ROW EXECUTE FUNCTION provider_keys_encrypt_secret_provider_key();
 
+-- Add missing columns that should have been added earlier
+ALTER TABLE provider_keys ADD COLUMN IF NOT EXISTS key_id UUID DEFAULT NULL;
+ALTER TABLE provider_keys ADD COLUMN IF NOT EXISTS nonce BYTEA DEFAULT NULL;
+
 create view public.decrypted_provider_keys_v2 as
  SELECT provider_keys.id,
     provider_keys.org_id,


### PR DESCRIPTION
## Docker Build Fix
- Add missing COPY packages/secrets/package.json to dockerfile_web
- Fixes yarn install error: 'Couldn't find package @helicone-package/secrets@*'
- Resolves Docker compose build failure where web container couldn't build

## Migration Fix  
- Add missing key_id and nonce columns to migration 20250731212201
- Fixes 'column provider_keys.key_id does not exist' migration failure
- Ensures decrypted_provider_keys_v2 view can be created successfully