### PR TITLE
fix: [ENG-2945] update region instead of location on vertex key updates

### DIFF
--- a/web/components/providers/ProviderCard.tsx
+++ b/web/components/providers/ProviderCard.tsx
@@ -123,7 +123,7 @@ const ProviderInstance: React.FC<ProviderInstanceProps> = ({
       };
     } else if (provider.id === "vertex") {
       initialConfig = {
-        location: "",
+        region: "",
         projectId: "",
       };
     }
@@ -321,7 +321,7 @@ const ProviderInstance: React.FC<ProviderInstanceProps> = ({
       ];
     } else if (provider.id === "vertex") {
       configFields = [
-        { label: "Location", key: "location", placeholder: "us-east5" },
+        { label: "Region", key: "region", placeholder: "us-east5" },
         {
           label: "Project ID",
           key: "projectId",


### PR DESCRIPTION
on ai-gateway, when pulling keys, it checks `config.region` but the `ProviderCard` updates `location`. this pr is a fix