### PR TITLE
misc: removed ai gateway dead link

### DIFF
--- a/web/components/templates/quickstart/quickstartPage.tsx
+++ b/web/components/templates/quickstart/quickstartPage.tsx
@@ -143,8 +143,8 @@ const QuickstartPage = () => {
     },
     {
       title: "Integrate",
-      description: "Gateway dashboard",
-      link: "/settings/ai-gateway",
+      description: "",  // TODO Add back once gateway route is fixed
+      link: "",
     },
   ];
 


### PR DESCRIPTION
The change temporarily removes the description and link for the "Integrate" step, pending a fix to the gateway route.