### PR TITLE
misc: remove loading bar for hql

### DIFF
--- a/web/components/templates/hql/QueryResult.tsx
+++ b/web/components/templates/hql/QueryResult.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useMemo } from "react";
-import LoadingAnimation from "@/components/shared/loadingAnimation";
 import ThemedTable from "@/components/shared/themed/table/themedTable";
 import ThemedModal from "@/components/shared/themed/themedModal";
 import { MAX_EXPORT_CSV } from "@/lib/constants";

--- a/web/components/templates/hql/QueryResult.tsx
+++ b/web/components/templates/hql/QueryResult.tsx
@@ -77,42 +77,36 @@ function QueryResult({
         sql={sql}
         queryLoading={loading}
       />
-      {loading ? (
-        <div className="p-4 text-center text-muted-foreground">
-          <LoadingAnimation />
-        </div>
-      ) : (
-        <ThemedTable
-          id="hql-result"
-          defaultData={result}
-          defaultColumns={[
-            {
-              header: "#",
-              accessorKey: "__rowNum",
-              cell: (info) => info.row.index + 1,
+      <ThemedTable
+        id="hql-result"
+        defaultData={result}
+        defaultColumns={[
+          {
+            header: "#",
+            accessorKey: "__rowNum",
+            cell: (info) => info.row.index + 1,
+          },
+          ...columns.map((col) => ({
+            header: col,
+            accessorKey: col,
+            cell: (info: CellContext<Record<string, any>, unknown>) => {
+              const value = info.getValue();
+              if (typeof value === "object" && value !== null) {
+                return JSON.stringify(value);
+              }
+              return value;
             },
-            ...columns.map((col) => ({
-              header: col,
-              accessorKey: col,
-              cell: (info: CellContext<Record<string, any>, unknown>) => {
-                const value = info.getValue();
-                if (typeof value === "object" && value !== null) {
-                  return JSON.stringify(value);
-                }
-                return value;
-              },
-            })),
-          ]}
-          skeletonLoading={false}
-          dataLoading={false}
-          checkboxMode="never"
-          onRowSelect={() => {}}
-          onSelectAll={() => {}}
-          selectedIds={[]}
-          activeColumns={[]}
-          setActiveColumns={() => {}}
-        />
-      )}
+          })),
+        ]}
+        skeletonLoading={false}
+        dataLoading={false}
+        checkboxMode="never"
+        onRowSelect={() => {}}
+        onSelectAll={() => {}}
+        selectedIds={[]}
+        activeColumns={[]}
+        setActiveColumns={() => {}}
+      />
     </div>
   );
 }


### PR DESCRIPTION
This pull request makes a small change to the `QueryResult` component in `web/components/templates/hql/QueryResult.tsx`. The loading animation that was previously shown while a query was running has been removed, so the results table now renders immediately without displaying a loading indicator. [[1]](diffhunk://#diff-f685bd6421ee729c98e7379886ba3f57b6bc70fb6efecd46cbfed6ea5e712f65L80-L84) [[2]](diffhunk://#diff-f685bd6421ee729c98e7379886ba3f57b6bc70fb6efecd46cbfed6ea5e712f65L115)