### PR TITLE
refactor: Use empty JSON instead of "all" string for filter consistency

### DIFF
--- a/bifrost/app/pi/first_page/useTestApiKey.tsx
+++ b/bifrost/app/pi/first_page/useTestApiKey.tsx
@@ -12,7 +12,7 @@ export const testAPIKey = async (apiKey: string) => {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      filter: "all",
+      filter: {},
       isCached: false,
       limit: 10,
       offset: 0,

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -14219,7 +14219,7 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"filter": "all",
+											"filter": {},
 											"isCached": false,
 											"limit": 10,
 											"offset": 0,
@@ -14270,7 +14270,7 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"filter": "all",
+											"filter": {},
 											"isCached": false,
 											"limit": 10,
 											"offset": 0,

--- a/examples/export/typescript/index.ts
+++ b/examples/export/typescript/index.ts
@@ -138,7 +138,7 @@ async function makeRequest(
   options: QueryOptions
 ): Promise<RequestResponse[]> {
   const requestBody = {
-    filter: "all",
+    filter: {},
     isCached: false,
     limit,
     offset,

--- a/packages/__tests__/filters/toFilterNode.test.js
+++ b/packages/__tests__/filters/toFilterNode.test.js
@@ -3,19 +3,19 @@ const { FilterAST } = require("../../filters/filterExpressions");
 
 describe("toFilterNode", () => {
   describe("null and undefined inputs", () => {
-    it("should return 'all' for null input", () => {
+    it("should return empty JSON for null input", () => {
       const result = toFilterNode(null);
-      expect(result).toBe("all");
+      expect(result).toEqual({});
     });
 
-    it("should return 'all' for undefined input", () => {
+    it("should return empty JSON for undefined input", () => {
       const result = toFilterNode(undefined);
-      expect(result).toBe("all");
+      expect(result).toEqual({});
     });
 
-    it("should return 'all' for empty string", () => {
+    it("should return empty JSON for empty string", () => {
       const result = toFilterNode("");
-      expect(result).toBe("all");
+      expect(result).toEqual({});
     });
   });
 
@@ -58,10 +58,10 @@ describe("toFilterNode", () => {
   });
 
   describe("'all' expressions", () => {
-    it("should return 'all' for all expression", () => {
+    it("should return empty JSON for all expression", () => {
       const filter = FilterAST.all();
       const result = toFilterNode(filter);
-      expect(result).toBe("all");
+      expect(result).toEqual({});
     });
   });
 
@@ -275,14 +275,14 @@ describe("toFilterNode", () => {
   });
 
   describe("AND expressions", () => {
-    it("should return 'all' for empty AND expression", () => {
+    it("should return empty JSON for empty AND expression", () => {
       const filter = {
         type: "and",
         expressions: [],
       };
 
       const result = toFilterNode(filter);
-      expect(result).toBe("all");
+      expect(result).toEqual({});
     });
 
     it("should return the single expression for AND with one expression", () => {
@@ -345,14 +345,14 @@ describe("toFilterNode", () => {
   });
 
   describe("OR expressions", () => {
-    it("should return 'all' for empty OR expression", () => {
+    it("should return empty JSON for empty OR expression", () => {
       const filter = {
         type: "or",
         expressions: [],
       };
 
       const result = toFilterNode(filter);
-      expect(result).toBe("all");
+      expect(result).toEqual({});
     });
 
     it("should return the single expression for OR with one expression", () => {

--- a/packages/filters/filterDefs.ts
+++ b/packages/filters/filterDefs.ts
@@ -387,7 +387,7 @@ export type TablesAndViews = {
 };
 export type FilterLeaf = SingleKey<TablesAndViews>;
 
-export type FilterNode = FilterLeaf | FilterBranch | "all";
+export type FilterNode = FilterLeaf | FilterBranch | {};
 
 export interface FilterBranch {
   left: FilterNode;

--- a/packages/filters/toFilterNode.ts
+++ b/packages/filters/toFilterNode.ts
@@ -81,7 +81,7 @@ export function toFilterNode(
 ): FilterNode {
   // Handle null or undefined filter
   if (!filter) {
-    return "all";
+    return {} as FilterLeaf;
   }
 
   // Handle string input (JSON string)
@@ -106,7 +106,7 @@ export function toFilterNode(
 
   // Handle "all" expression
   if (filter.type === "all") {
-    return "all";
+    return {} as FilterLeaf;
   }
 
   // Handle condition expression
@@ -213,7 +213,7 @@ export function toFilterNode(
 
     // If there are no expressions, return "all"
     if (andExpr.expressions.length === 0) {
-      return "all";
+      return {} as FilterLeaf;
     }
 
     // If there's only one expression, convert it directly
@@ -252,9 +252,8 @@ export function toFilterNode(
       );
     }
 
-    // If there are no expressions, return "all"
     if (orExpr.expressions.length === 0) {
-      return "all";
+      return {} as FilterLeaf;
     }
 
     // If there's only one expression, convert it directly

--- a/valhalla/jawn/src/controllers/public/promptController.ts
+++ b/valhalla/jawn/src/controllers/public/promptController.ts
@@ -158,7 +158,7 @@ export class PromptController extends Controller {
     const promptManager = new PromptManager(request.authParams);
 
     const result = await promptManager.getPrompts({
-      filter: "all"
+      filter: {}
     });
     
     if (result.error) {
@@ -464,7 +464,7 @@ export class PromptController extends Controller {
     const promptManager = new PromptManager(request.authParams);
     const result = await promptManager.getPromptVersions(
       {
-        left: requestBody.filter ?? "all",
+        left: requestBody.filter ?? {},
         operator: "and",
         right: {
           prompt_v2: {
@@ -534,7 +534,7 @@ export class PromptController extends Controller {
     const promptManager = new PromptManager(request.authParams);
     const result = await promptManager.getCompiledPromptVersions(
       {
-        left: requestBody.filter ?? "all",
+        left: requestBody.filter ?? {},
         operator: "and",
         right: {
           prompt_v2: {
@@ -565,7 +565,7 @@ export class PromptController extends Controller {
     const promptManager = new PromptManager(request.authParams);
     const result = await promptManager.getPormptVersionsTemplates(
       {
-        left: requestBody.filter ?? "all",
+        left: requestBody.filter ?? {},
         operator: "and",
         right: {
           prompt_v2: {

--- a/valhalla/jawn/src/controllers/public/propertyController.ts
+++ b/valhalla/jawn/src/controllers/public/propertyController.ts
@@ -42,7 +42,7 @@ export class PropertyController extends Controller {
     const builtFilter = await buildFilterWithAuthClickHouseOrganizationProperties({
       org_id: request.authParams.organizationId,
       argsAcc: [],
-      filter: "all",
+      filter: {},
     });
 
     const query = `

--- a/valhalla/jawn/src/controllers/public/requestController.ts
+++ b/valhalla/jawn/src/controllers/public/requestController.ts
@@ -85,7 +85,7 @@ export class RequestController extends Controller {
 
   @Post("query")
   @Example<RequestQueryParams>({
-    filter: "all",
+    filter: {},
     isCached: false,
     limit: 10,
     offset: 0,
@@ -112,7 +112,7 @@ export class RequestController extends Controller {
 
   @Post("query-clickhouse")
   @Example<RequestQueryParams>({
-    filter: "all",
+    filter: {},
     isCached: false,
     limit: 10,
     offset: 0,

--- a/valhalla/jawn/src/controllers/public/sessionController.ts
+++ b/valhalla/jawn/src/controllers/public/sessionController.ts
@@ -77,7 +77,7 @@ export class SessionController extends Controller {
       async () => {
         const sessionManager = new SessionManager(request.authParams);
         const result = await sessionManager.getSessions({
-          filter: "all",
+          filter: {},
           search: "",
           timeFilter: {
             startTimeUnixMs: new Date().getTime() - 1000 * 60 * 60 * 30,

--- a/valhalla/jawn/src/managers/eval/EvalManager.ts
+++ b/valhalla/jawn/src/managers/eval/EvalManager.ts
@@ -125,7 +125,7 @@ export class EvalManager extends BaseManager {
     const builtFilter = await buildFilterWithAuthClickHouse({
       org_id: this.authParams.organizationId,
       argsAcc: [],
-      filter: "all",
+      filter: {},
     });
 
     const query = `

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -50438,7 +50438,7 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"filter": "all",
+											"filter": {},
 											"isCached": false,
 											"limit": 10,
 											"offset": 0,
@@ -50489,7 +50489,7 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"filter": "all",
+											"filter": {},
 											"isCached": false,
 											"limit": 10,
 											"offset": 0,

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -14219,7 +14219,7 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"filter": "all",
+											"filter": {},
 											"isCached": false,
 											"limit": 10,
 											"offset": 0,
@@ -14270,7 +14270,7 @@
 								"examples": {
 									"Example 1": {
 										"value": {
-											"filter": "all",
+											"filter": {},
 											"isCached": false,
 											"limit": 10,
 											"offset": 0,

--- a/web/components/layout/onboardingContext.tsx
+++ b/web/components/layout/onboardingContext.tsx
@@ -440,7 +440,7 @@ export const OnboardingProvider = ({
     const setReady = async () => {
       const countResponse = await $JAWN_API.POST("/v1/request/count/query", {
         body: {
-          filter: "all",
+          filter: {},
         },
       });
 

--- a/web/components/templates/dashboard/dashboardPage.tsx
+++ b/web/components/templates/dashboard/dashboardPage.tsx
@@ -68,7 +68,9 @@ const DashboardPage = (props: DashboardPageProps) => {
   const searchParams = useSearchParams();
   const orgContext = useOrg();
   const filterStore = useFilterStore();
-  const filters = filterStore.filter ? toFilterNode(filterStore.filter) : ({} as FilterLeaf);
+  const filters = filterStore.filter
+    ? toFilterNode(filterStore.filter)
+    : ({} as FilterLeaf);
 
   const shouldShowMockData = orgContext?.currentOrg?.has_onboarded === false;
 

--- a/web/components/templates/dashboard/dashboardPage.tsx
+++ b/web/components/templates/dashboard/dashboardPage.tsx
@@ -23,6 +23,7 @@ import { useOrg } from "../../layout/org/organizationContext";
 
 import { useFilterStore } from "@/filterAST/store/filterStore";
 import { toFilterNode } from "@helicone-package/filters/toFilterNode";
+import { FilterLeaf } from "@helicone-package/filters/filterDefs";
 import AuthHeader from "../../shared/authHeader";
 import { clsx } from "../../shared/clsx";
 import LoadingAnimation from "../../shared/loadingAnimation";
@@ -67,7 +68,7 @@ const DashboardPage = (props: DashboardPageProps) => {
   const searchParams = useSearchParams();
   const orgContext = useOrg();
   const filterStore = useFilterStore();
-  const filters = filterStore.filter ? toFilterNode(filterStore.filter) : "all";
+  const filters = filterStore.filter ? toFilterNode(filterStore.filter) : ({} as FilterLeaf);
 
   const shouldShowMockData = orgContext?.currentOrg?.has_onboarded === false;
 

--- a/web/components/templates/dashboard/useDashboardPage.tsx
+++ b/web/components/templates/dashboard/useDashboardPage.tsx
@@ -70,7 +70,7 @@ export const useDashboardPage = ({
 }: DashboardPageData) => {
   const properties = useGetPropertiesV2(getPropertyFiltersV2);
   const filterStore = useFilterStore();
-  const filter = filterStore.filter ? toFilterNode(filterStore.filter) : "all";
+  const filter = filterStore.filter ? toFilterNode(filterStore.filter) : ({} as FilterLeaf);
 
   const { isLoading: isModelsLoading, models } = useModels(
     timeFilter,

--- a/web/components/templates/dashboard/useDashboardPage.tsx
+++ b/web/components/templates/dashboard/useDashboardPage.tsx
@@ -70,7 +70,9 @@ export const useDashboardPage = ({
 }: DashboardPageData) => {
   const properties = useGetPropertiesV2(getPropertyFiltersV2);
   const filterStore = useFilterStore();
-  const filter = filterStore.filter ? toFilterNode(filterStore.filter) : ({} as FilterLeaf);
+  const filter = filterStore.filter
+    ? toFilterNode(filterStore.filter)
+    : ({} as FilterLeaf);
 
   const { isLoading: isModelsLoading, models } = useModels(
     timeFilter,

--- a/web/components/templates/evals/CreateNewEvaluator/components/TestEvaluator.new.tsx
+++ b/web/components/templates/evals/CreateNewEvaluator/components/TestEvaluator.new.tsx
@@ -41,7 +41,7 @@ export function TestEvaluator() {
       if (!requestId) {
         const requests = await jawn.POST("/v1/request/query-clickhouse", {
           body: {
-            filter: "all",
+            filter: {},
             limit: 1,
             sort: {
               created_at: "desc",

--- a/web/components/templates/evals/CreateNewEvaluator/components/TestEvaluator.tsx
+++ b/web/components/templates/evals/CreateNewEvaluator/components/TestEvaluator.tsx
@@ -41,7 +41,7 @@ export function TestEvaluator() {
       if (!requestId) {
         const requests = await jawn.POST("/v1/request/query-clickhouse", {
           body: {
-            filter: "all",
+            filter: {},
             limit: 1,
             sort: {
               created_at: "desc",

--- a/web/components/templates/evals/details/TestDrawer.tsx
+++ b/web/components/templates/evals/details/TestDrawer.tsx
@@ -42,7 +42,7 @@ export function TestDrawer({ evaluatorId, isOpen, onClose }: TestDrawerProps) {
       try {
         const requests = await jawn.POST("/v1/request/query-clickhouse", {
           body: {
-            filter: "all",
+            filter: {},
             limit: 1,
             sort: {
               created_at: "desc",

--- a/web/components/templates/models/modelPage.tsx
+++ b/web/components/templates/models/modelPage.tsx
@@ -47,7 +47,7 @@ const ModelPage = (props: ModelPageProps) => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          filter: "all",
+          filter: {},
           offset: 0,
           limit: 100,
           timeFilter,

--- a/web/components/templates/requests/useRequestsPageV2.tsx
+++ b/web/components/templates/requests/useRequestsPageV2.tsx
@@ -76,7 +76,7 @@ const useRequestsPageV2 = (
     (filter: any) => filter.label?.trim() === "Helicone-Rate-Limit-Status",
   );
 
-  let rateLimitFilterNode: FilterNode = ({} as FilterLeaf);
+  let rateLimitFilterNode: FilterNode = {} as FilterLeaf;
   if (rateLimited && rateLimitFilterMapIndex !== -1) {
     rateLimitFilterNode = filterUITreeToFilterNode(filterMap, {
       filterMapIdx: rateLimitFilterMapIndex,

--- a/web/components/templates/requests/useRequestsPageV2.tsx
+++ b/web/components/templates/requests/useRequestsPageV2.tsx
@@ -6,7 +6,7 @@ import { getTimeIntervalAgo } from "../../../lib/timeCalculations/time";
 import { useModels } from "../../../services/hooks/models";
 import { useGetPropertiesV2 } from "../../../services/hooks/propertiesV2";
 import { useGetRequests } from "../../../services/hooks/requests";
-import { FilterNode } from "@helicone-package/filters/filterDefs";
+import { FilterLeaf, FilterNode } from "@helicone-package/filters/filterDefs";
 import {
   getPropertyFiltersV2,
   REQUEST_TABLE_FILTERS,
@@ -76,7 +76,7 @@ const useRequestsPageV2 = (
     (filter: any) => filter.label?.trim() === "Helicone-Rate-Limit-Status",
   );
 
-  let rateLimitFilterNode: FilterNode = "all";
+  let rateLimitFilterNode: FilterNode = ({} as FilterLeaf);
   if (rateLimited && rateLimitFilterMapIndex !== -1) {
     rateLimitFilterNode = filterUITreeToFilterNode(filterMap, {
       filterMapIdx: rateLimitFilterMapIndex,
@@ -93,7 +93,7 @@ const useRequestsPageV2 = (
       left: filterUITreeToFilterNode(filterMap, uiFilterIdxs),
       right: filterStore.store.filter
         ? toFilterNode(filterStore.store.filter)
-        : "all",
+        : ({} as FilterLeaf),
       operator: "and",
     },
     // Combine with only the conditional Rate Limit Filter

--- a/web/lib/api/cache/stats.ts
+++ b/web/lib/api/cache/stats.ts
@@ -31,7 +31,7 @@ export async function getCacheCountClickhouse(
 ): Promise<Result<number, string>> {
   const builtFilter = await buildFilterWithAuthClickHouseCacheMetrics({
     org_id: orgId,
-    filter: "all",
+    filter: {},
     argsAcc: [],
   });
 

--- a/web/lib/api/properties/properties.ts
+++ b/web/lib/api/properties/properties.ts
@@ -12,7 +12,7 @@ export async function getProperties(
   const builtFilter = await buildFilterWithAuthClickHouseProperties({
     org_id,
     argsAcc: [],
-    filter: "all",
+    filter: {},
   });
   const query = `
   select distinct key as property

--- a/web/pages/api/has_converted.ts
+++ b/web/pages/api/has_converted.ts
@@ -9,7 +9,7 @@ async function handler(option: HandlerWrapperOptions<Result<boolean, string>>) {
     res,
     userData: { orgId },
   } = option;
-  const requests = await getRequests(orgId, "all", 0, 1, {
+  const requests = await getRequests(orgId, {} as any, 0, 1, {
     created_at: "desc",
   });
 

--- a/web/pages/api/user/checkOnboarded.ts
+++ b/web/pages/api/user/checkOnboarded.ts
@@ -8,7 +8,7 @@ import { getRequestCountClickhouse } from "../../../lib/api/request/request";
 import { Result } from "@/packages/common/result";
 
 async function checkAndUpdateOrgs(orgId: string): Promise<boolean> {
-  const count = (await getRequestCountClickhouse(orgId, "all")).data ?? 0;
+  const count = (await getRequestCountClickhouse(orgId, {} as any)).data ?? 0;
   if (count > 0) {
     const { error } = await dbExecute(
       `UPDATE organization SET has_onboarded = true WHERE id = $1`,

--- a/web/services/hooks/country.tsx
+++ b/web/services/hooks/country.tsx
@@ -23,7 +23,7 @@ const useCountries = (
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          filter: userFilters ?? "all",
+          filter: userFilters ?? {},
           offset: 0,
           limit,
           timeFilter,

--- a/web/services/hooks/models.tsx
+++ b/web/services/hooks/models.tsx
@@ -18,7 +18,7 @@ const useModels = (
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          filter: userFilters ?? "all",
+          filter: userFilters ?? {},
           offset: 0,
           limit,
           timeFilter,

--- a/web/services/hooks/prompts/prompts.tsx
+++ b/web/services/hooks/prompts/prompts.tsx
@@ -64,7 +64,7 @@ export const usePrompts = (promptId?: string) => {
       const promptId = query.queryKey[2] as string;
       const jawn = getJawnClient(orgId);
 
-      let filterNode: any = "all";
+      let filterNode: any = {};
 
       if (promptId) {
         filterNode = {
@@ -181,7 +181,7 @@ export const useCreatePrompt = () => {
         (
           await jawn.POST("/v1/prompt/query", {
             body: {
-              filter: "all",
+              filter: {},
             },
           })
         )?.data?.data || [];

--- a/web/services/hooks/sessions.tsx
+++ b/web/services/hooks/sessions.tsx
@@ -4,6 +4,7 @@ import { getJawnClient } from "../../lib/clients/jawn";
 import { useFilterAST } from "@/filterAST/context/filterContext";
 import { toFilterNode } from "@helicone-package/filters/toFilterNode";
 import { FilterExpression } from "@helicone-package/filters/types";
+import { FilterLeaf } from "@helicone-package/filters/filterDefs";
 import { TimeFilter } from "@/types/timeFilter";
 
 const useSessions = ({
@@ -45,7 +46,7 @@ const useSessions = ({
           },
           nameEquals: nameEquals ?? "",
           timezoneDifference: 0,
-          filter: filter ? (toFilterNode(filter) as any) : "all",
+          filter: filter ? (toFilterNode(filter) as any) : ({} as FilterLeaf),
         },
       });
       if (result.error || result.data.error) {
@@ -106,7 +107,7 @@ const useSessionNames = (
                 startTimeUnixMs: timeFilter.start.getTime(),
               }
             : undefined,
-          filter: filter ? (toFilterNode(filter) as any) : "all",
+          filter: filter ? (toFilterNode(filter) as any) : ({} as FilterLeaf),
         },
       });
       if (result.error || result.data.error) {
@@ -172,7 +173,7 @@ const useSessionMetrics = (
             endTimeUnixMs: timeFilter.end.getTime(),
             startTimeUnixMs: timeFilter.start.getTime(),
           },
-          filter: filter ? (toFilterNode(filter) as any) : "all",
+          filter: filter ? (toFilterNode(filter) as any) : ({} as FilterLeaf),
         },
       });
       if (result.error || result.data.error) {

--- a/web/services/hooks/users.tsx
+++ b/web/services/hooks/users.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useOrg } from "@/components/layout/org/organizationContext";
 import { useFilterAST } from "@/filterAST/context/filterContext";
 import { FilterExpression } from "@helicone-package/filters/types";
+import { FilterLeaf } from "@helicone-package/filters/filterDefs";
 import { toFilterNode } from "@helicone-package/filters/toFilterNode";
 import { getJawnClient } from "@/lib/clients/jawn";
 import { TimeFilter } from "@/types/timeFilter";
@@ -154,7 +155,7 @@ const useUsers = (
       const timeFilter = query.queryKey[6] as TimeFilter;
 
       const jawn = getJawnClient(orgId);
-      const filterNode = filter ? toFilterNode(filter) : "all";
+      const filterNode = filter ? toFilterNode(filter) : ({} as FilterLeaf);
 
       const result = await jawn.POST("/v1/user/metrics/query", {
         body: {


### PR DESCRIPTION
This pull request standardizes the representation of an "all" filter across the codebase, replacing the string `"all"` with an empty filter object `{}` (typed as `FilterLeaf` where appropriate). This change affects backend controllers, frontend components, filter conversion logic, and documentation, ensuring consistency in how the absence of filter criteria is handled and passed throughout the system.

**Filter Representation Standardization**

* Updated all usages of `"all"` as a filter value to `{}` in backend controllers (`PromptController`, `PropertyController`, `RequestController`, `SessionController`, `EvalManager`) to ensure consistent filter handling in API requests. [[1]](diffhunk://#diff-8efde93d9cdbb350648e9b56a756d4a3be550cbe354704c47c7af977263b3ae0L161-R161) [[2]](diffhunk://#diff-8efde93d9cdbb350648e9b56a756d4a3be550cbe354704c47c7af977263b3ae0L467-R467) [[3]](diffhunk://#diff-8efde93d9cdbb350648e9b56a756d4a3be550cbe354704c47c7af977263b3ae0L537-R537) [[4]](diffhunk://#diff-8efde93d9cdbb350648e9b56a756d4a3be550cbe354704c47c7af977263b3ae0L568-R568) [[5]](diffhunk://#diff-1ebacf08380cc0895a3539b5678761fd89647f35c2c21f21e7833629235edd09L45-R45) [[6]](diffhunk://#diff-0dbafa70c12d3f3b4d1f730ecc2a1ef2de46b1a7285438f808b97beccbffb91dL88-R88) [[7]](diffhunk://#diff-0dbafa70c12d3f3b4d1f730ecc2a1ef2de46b1a7285438f808b97beccbffb91dL115-R115) [[8]](diffhunk://#diff-e86e808bacd2ea5cb7467053abb609a66c561372542a45259f0c56a213381154L80-R80) [[9]](diffhunk://#diff-9c35f46d833ee3c621cc895e2154b5fae71ce81e7107fba78007a2b3e6079d42L128-R128)
* Updated frontend components and hooks to use `{}` (typed as `FilterLeaf` where needed) instead of `"all"` when no filter is present, including in dashboard, requests, models, onboarding, and evals-related pages. [[1]](diffhunk://#diff-3afdc711baf35f5ee3c5142e8541032164431e14ec5bf87e4cbf4791e6ecb56eL70-R73) [[2]](diffhunk://#diff-5c10379e50e7bb5c3a00ebc5bb0f7af3d9ed93056633aa8a7ba8bbb80d7ad6bcL73-R75) [[3]](diffhunk://#diff-54eba1acd6f0c819285215121e181a65aed3347a291f59bbc73f0bfe4215e49aL44-R44) [[4]](diffhunk://#diff-552d54e283d1df67807207a588a59e92cf93bf90ae51e381b85fba16b5ba00baL44-R44) [[5]](diffhunk://#diff-ef1e2352d3e3c5676c3d1b8d314f57f8508d1c442ba5c656721092d3a4b3877aL45-R45) [[6]](diffhunk://#diff-e78810ca35964372777a9fc55a0d47a832f1f73982fa519ebdf48229112dddd3L50-R50) [[7]](diffhunk://#diff-f652cf182e17bf4da36e3d5444cc661e1523d7bcf87b221d17213ec263696f68L443-R443) [[8]](diffhunk://#diff-44e7c14cb3c2f55f35943cf8142cb49215f4c384c073ab96225e44caea0d04f9L79-R79) [[9]](diffhunk://#diff-44e7c14cb3c2f55f35943cf8142cb49215f4c384c073ab96225e44caea0d04f9L96-R96)

**Filter Conversion Logic**

* Modified the `toFilterNode` function and related tests to return `{}` instead of `"all"` for null, undefined, empty string, and empty filter expressions, ensuring that filter conversion always yields a valid filter object. [[1]](diffhunk://#diff-be93cb182e5175f0bd392ba0f86542cc993432a7a41279f10377057ce851f026L84-R84) [[2]](diffhunk://#diff-be93cb182e5175f0bd392ba0f86542cc993432a7a41279f10377057ce851f026L109-R109) [[3]](diffhunk://#diff-be93cb182e5175f0bd392ba0f86542cc993432a7a41279f10377057ce851f026L216-R216) [[4]](diffhunk://#diff-be93cb182e5175f0bd392ba0f86542cc993432a7a41279f10377057ce851f026L255-R256) [[5]](diffhunk://#diff-1242049d3b14d2f0ed0380e27017083c635931a726d4f4676e7a8c07c31ba33bL6-R18) [[6]](diffhunk://#diff-1242049d3b14d2f0ed0380e27017083c635931a726d4f4676e7a8c07c31ba33bL61-R64) [[7]](diffhunk://#diff-1242049d3b14d2f0ed0380e27017083c635931a726d4f4676e7a8c07c31ba33bL278-R285) [[8]](diffhunk://#diff-1242049d3b14d2f0ed0380e27017083c635931a726d4f4676e7a8c07c31ba33bL348-R355)

**Documentation and Example Updates**

* Updated API documentation and example payloads in Swagger JSON files to use `{}` for the filter field instead of `"all"`, reflecting the new standard in public and private API docs. [[1]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L14222-R14222) [[2]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L14273-R14273) [[3]](diffhunk://#diff-442bdac6e8b0e9bcd796237e7adb29da7966b68a9927df23435231cfcda603bfL50441-R50441) [[4]](diffhunk://#diff-442bdac6e8b0e9bcd796237e7adb29da7966b68a9927df23435231cfcda603bfL50492-R50492)

**Type and Import Adjustments**

* Added or updated imports for `FilterLeaf` where needed in frontend code to support the new filter representation and maintain type safety. [[1]](diffhunk://#diff-3afdc711baf35f5ee3c5142e8541032164431e14ec5bf87e4cbf4791e6ecb56eR26) [[2]](diffhunk://#diff-44e7c14cb3c2f55f35943cf8142cb49215f4c384c073ab96225e44caea0d04f9L9-R9)

**API Usage Consistency**

* Updated all API request bodies and example usages to send `{}` for the filter parameter, ensuring requests are handled consistently across the stack. [[1]](diffhunk://#diff-af5ceae55a66c17c8e75d304b8fdbfd25a314115be8c0a0101b08ad96dac6a88L15-R15) [[2]](diffhunk://#diff-f62d14586b0a68b39cfbd32309a1b3ff1a3534f2e763696d2b67499461406244L141-R141)

Let me know if you have questions about how this impacts filter handling or integration points!