### PR TITLE
tests(worker): alerts

### DIFF
--- a/worker/test/alerts/alertManager.spec.ts
+++ b/worker/test/alerts/alertManager.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/lib/safePut", () => ({
+  safePut: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+import { AlertManager } from "../../src/lib/managers/AlertManager";
+
+// Build a minimal Env and KV mocks
+const buildEnv = () => ({
+  UTILITY_KV: {
+    storage: new Map<string, string>(),
+    async get(key: string) {
+      return this.storage.get(key) ?? null;
+    },
+    async put(key: string, value: string) {
+      this.storage.set(key, value);
+    },
+    async delete(key: string) {
+      this.storage.delete(key);
+    },
+  },
+  RESEND_API_KEY: "test_resend",
+});
+
+// Fake AlertStore
+class FakeAlertStore {
+  constructor(public alerts: any[] = []) {}
+  async getAlerts() {
+    return { data: this.alerts, error: null };
+  }
+  async updateAlertStatuses() {
+    return { data: null, error: null };
+  }
+  async updateAlertHistoryStatuses() {
+    return { data: null, error: null };
+  }
+  async insertAlertHistory() {
+    return { data: null, error: null };
+  }
+  async getErrorRate() {
+    return { data: { totalCount: 100, errorCount: 10, requestCount: 100 }, error: null };
+  }
+  async getCost() {
+    return { data: { totalCount: 200, requestCount: 50 }, error: null };
+  }
+}
+
+const baseAlert = {
+  id: "a1",
+  name: "Error Rate Alert",
+  metric: "response.status",
+  threshold: 5,
+  time_window: 300000,
+  minimum_request_count: 10,
+  status: "resolved",
+  org_id: "org",
+  emails: ["x@example.com"],
+  slack_channels: ["C123"],
+  organization: { integrations: [{ id: "i1", integration_name: "slack", settings: { access_token: "x" }, active: true }] },
+};
+
+describe("AlertManager", () => {
+  let env: any;
+
+  beforeEach(() => {
+    env = buildEnv();
+    vi.restoreAllMocks();
+    // Mock fetch for emails and slack
+    global.fetch = vi.fn(async (url: string) => {
+      if (url.includes("resend.com")) {
+        return new Response(null, { status: 200 });
+      }
+      if (url.includes("slack.com")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(null, { status: 200 });
+    }) as any;
+  });
+
+  it("triggers alerts when threshold breached and updates history", async () => {
+    const alertStore = new FakeAlertStore([{ ...baseAlert, status: "resolved" }]);
+    const manager = new AlertManager(alertStore as any, env);
+
+    // getErrorRate returns totalCount=100, errorCount=10 => 10%
+    const res = await manager.checkAlerts();
+    expect(res.error).toBeNull();
+  });
+
+  it("resolves alerts when rate below threshold after cooldown", async () => {
+    const triggeredAlert = { ...baseAlert, status: "triggered" };
+    const alertStore = new FakeAlertStore([triggeredAlert]);
+    const manager = new AlertManager(alertStore as any, env);
+
+    // Put cooldown start in the past beyond COOLDOWN
+    const key = `alert:${triggeredAlert.id}:cooldown_start_timestamp`;
+    const past = Date.now() - (5 * 60 * 1000 + 1000);
+    await env.UTILITY_KV.put(key, `${past}`);
+
+    // Force below threshold by mocking getErrorRate()
+    vi.spyOn(alertStore, "getErrorRate").mockResolvedValue({
+      data: { totalCount: 100, errorCount: 0, requestCount: 100 },
+      error: null,
+    });
+
+    const res = await manager.checkAlerts();
+    expect(res.error).toBeNull();
+  });
+});
+
+

--- a/worker/test/alerts/alertStore.spec.ts
+++ b/worker/test/alerts/alertStore.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AlertStore } from "../../src/lib/db/AlertStore";
+
+// Minimal Clickhouse wrapper mock
+class MockClickhouse {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async dbQuery<T>(query: string, params: (number | string)[]) {
+    return { data: [] as unknown as T[], error: null };
+  }
+}
+
+describe("AlertStore", () => {
+  let supabase: any;
+  let clickhouse: any;
+  let store: AlertStore;
+  let fromMock: any;
+
+  beforeEach(() => {
+    supabase = {
+      from: vi.fn(),
+    } as any;
+    clickhouse = new MockClickhouse();
+    store = new AlertStore(supabase as any, clickhouse);
+
+    fromMock = (supabase as any).from;
+    vi.restoreAllMocks();
+  });
+
+  it("getAlerts returns alerts list", async () => {
+    const selectChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ data: [{ id: "a1" }], error: null }),
+    };
+    (fromMock as any).mockReturnValue(selectChain);
+
+    const res = await store.getAlerts();
+    expect(res.error).toBeNull();
+    expect(res.data).toEqual([{ id: "a1" }]);
+    expect(selectChain.select).toHaveBeenCalled();
+    expect(selectChain.eq).toHaveBeenCalledWith("soft_delete", false);
+  });
+
+  it("updateAlertStatuses updates by ids", async () => {
+    const updateChain = {
+      update: vi.fn().mockReturnThis(),
+      in: vi.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    (fromMock as any).mockReturnValue(updateChain);
+
+    const res = await store.updateAlertStatuses("triggered", ["a1", "a2"]);
+    expect(res.error).toBeNull();
+    expect(updateChain.update).toHaveBeenCalled();
+    expect(updateChain.in).toHaveBeenCalledWith("id", ["a1", "a2"]);
+  });
+
+  it("updateAlertHistoryStatuses updates active entries for alert ids", async () => {
+    const updateChain = {
+      update: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    (fromMock as any).mockReturnValue(updateChain);
+
+    const now = new Date().toISOString();
+    const res = await store.updateAlertHistoryStatuses(
+      "resolved",
+      ["a1"],
+      now
+    );
+    expect(res.error).toBeNull();
+    expect(updateChain.update).toHaveBeenCalled();
+    expect(updateChain.in).toHaveBeenCalledWith("alert_id", ["a1"]);
+    expect(updateChain.eq).toHaveBeenCalledWith("status", "triggered");
+  });
+
+  it("insertAlertHistory inserts rows", async () => {
+    const insertChain = {
+      insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    (fromMock as any).mockReturnValue(insertChain);
+
+    const res = await store.insertAlertHistory([
+      {
+        alert_id: "a1",
+        alert_metric: "response.status",
+        alert_name: "name",
+        alert_start_time: new Date().toISOString(),
+        org_id: "org",
+        status: "triggered",
+        triggered_value: "10",
+      } as any,
+    ]);
+    expect(res.error).toBeNull();
+    expect(insertChain.insert).toHaveBeenCalled();
+  });
+
+  it("getErrorRate queries clickhouse and maps data", async () => {
+    const mock = vi
+      .spyOn(clickhouse, "dbQuery")
+      .mockResolvedValue({
+        data: [
+          { totalCount: 100, errorCount: 10, requestCount: 100 },
+        ],
+        error: null,
+      });
+
+    const res = await store.getErrorRate("org", 60000);
+    expect(res.error).toBeNull();
+    expect(res.data).toEqual({ totalCount: 100, errorCount: 10, requestCount: 100 });
+    expect(mock).toHaveBeenCalled();
+  });
+
+  it("getCost queries clickhouse and maps data", async () => {
+    const mock = vi
+      .spyOn(clickhouse, "dbQuery")
+      .mockResolvedValue({
+        data: [
+          { totalCount: 5.5, requestCount: 42 },
+        ],
+        error: null,
+      });
+
+    const res = await store.getCost("org", 60000);
+    expect(res.error).toBeNull();
+    expect(res.data).toEqual({ totalCount: 5.5, requestCount: 42 });
+    expect(mock).toHaveBeenCalled();
+  });
+});
+
+

--- a/worker/test/alerts/slackAlertManager.spec.ts
+++ b/worker/test/alerts/slackAlertManager.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SlackAlertManager } from "../../src/lib/managers/SlackAlertManager";
+
+describe("SlackAlertManager", () => {
+  let env: any;
+
+  beforeEach(() => {
+    env = {
+      SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/T000/B000/XXXX",
+    } as any;
+    global.fetch = vi.fn(async () => new Response(null, { status: 200 })) as any;
+  });
+
+  it("sends message via webhook", async () => {
+    const mgr = new SlackAlertManager(env);
+    const res = await mgr.sendSlackMessageToChannel("C123", "Test alert");
+    expect(res.error).toBeNull();
+    expect(global.fetch).toHaveBeenCalled();
+  });
+
+  it("returns error when webhook not configured", async () => {
+    const mgr = new SlackAlertManager({} as any);
+    const res = await mgr.sendSlackMessageToChannel("C123", "Test");
+    expect(res.error).toBe("Slack webhook URL not configured");
+  });
+});
+
+

--- a/worker/test/alerts/vitest.config.mts
+++ b/worker/test/alerts/vitest.config.mts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: [],
+  },
+  resolve: {
+    alias: {
+      "@worker": new URL("../../src", import.meta.url).pathname,
+      "@helicone-package/cost": new URL(
+        "../../../packages/cost",
+        import.meta.url
+      ).pathname,
+    },
+  },
+});
+
+

--- a/worker/vitest.config.mts
+++ b/worker/vitest.config.mts
@@ -7,6 +7,7 @@ export default defineConfig({
       "./test/openai/vitest.config.mts",
       "./test/ai-gateway/vitest.config.mts",
       "./test/cache/vitest.config.mts",
+      "./test/alerts/vitest.config.mts",
     ],
   },
 });


### PR DESCRIPTION
* Added `AlertManager` unit tests to verify alert triggering, resolution logic, and integration with mocked dependencies.
* Added `AlertStore` unit tests to validate alert retrieval, status updates, history insertion, and Clickhouse query mapping.
* Added `SlackAlertManager` unit tests to check Slack message sending and error handling for missing webhook configuration.

**Test configuration improvements:**

* Created a dedicated Vitest config file for alerts tests in `worker/test/alerts/vitest.config.mts`, including module aliasing for easier imports.
* Registered the alerts test configuration in the main Vitest config `worker/vitest.config.mts` to ensure alerts tests are run with the overall test suite.