### PR TITLE
fix: display full height on onboarding

### DIFF
--- a/web/components/onboarding/OnboardingHeader.tsx
+++ b/web/components/onboarding/OnboardingHeader.tsx
@@ -82,7 +82,7 @@ export const OnboardingHeader = ({ children }: OnboardingHeaderProps) => {
 
   if (isLoading || !org?.currentOrg?.id || org?.currentOrg?.has_onboarded) {
     return (
-      <div className="flex min-h-screen w-full flex-col">
+      <div className="flex min-h-dvh w-full flex-col">
         <div className="flex flex-1 items-center justify-center">
           <LoadingAnimation />
         </div>
@@ -91,7 +91,7 @@ export const OnboardingHeader = ({ children }: OnboardingHeaderProps) => {
   }
 
   return (
-    <div className="flex min-h-screen w-full flex-col bg-[hsl(var(--background))]">
+    <div className="flex min-h-dvh w-full flex-col bg-[hsl(var(--background))]">
       <header className="flex h-14 w-full items-center justify-between border-b border-[hsl(var(--border))] bg-[hsl(var(--background))] px-4 sm:px-6">
         <div className="flex min-w-0 items-center gap-4 overflow-x-auto pr-2 md:pr-0">
           <div className="flex-shrink-0">
@@ -153,7 +153,7 @@ export const OnboardingHeader = ({ children }: OnboardingHeaderProps) => {
           </button>
         </div>
       </header>
-      {children}
+      <main className="flex flex-1">{children}</main>
     </div>
   );
 };

--- a/web/pages/onboarding/index.tsx
+++ b/web/pages/onboarding/index.tsx
@@ -59,7 +59,7 @@ export default function OnboardingPage() {
 
   if (subscription.isLoading || isLoading) {
     return (
-      <div className="flex min-h-screen w-full flex-col items-center">
+      <div className="flex min-h-dvh w-full flex-col items-center">
         <OnboardingHeader />
         <div className="mx-auto mt-12 w-full max-w-md px-4">
           <div className="flex flex-col gap-4">

--- a/web/pages/onboarding/members/index.tsx
+++ b/web/pages/onboarding/members/index.tsx
@@ -110,7 +110,7 @@ export default function OnboardingMembersPage() {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen w-full flex-col items-center">
+      <div className="flex min-h-dvh w-full flex-col items-center">
         <OnboardingHeader />
         <div className="mx-auto mt-12 w-full max-w-2xl px-4">
           <div className="flex flex-col gap-6">

--- a/web/pages/pi/onboarding/index.tsx
+++ b/web/pages/pi/onboarding/index.tsx
@@ -22,7 +22,7 @@ export default function OnboardingPage() {
 
   return (
     <AuthLayout>
-      <div className="container mx-auto flex min-h-screen items-center justify-center p-4">
+      <div className="container mx-auto flex min-h-dvh items-center justify-center p-4">
         <Card className="w-full max-w-md">
           <CardHeader>
             <CardTitle className="text-center text-2xl">Welcome! 👋</CardTitle>


### PR DESCRIPTION
This change ensures that the onboarding pages and headers consistently fill the visible viewport, especially on mobile devices where browser chrome can affect the actual visible area. Additionally, the structure of the main content area in the onboarding header is improved for better layout consistency.