### PR TITLE
fix: onboarding taking over every page

### DIFF
--- a/web/components/layout/auth/authLayout.tsx
+++ b/web/components/layout/auth/authLayout.tsx
@@ -88,6 +88,11 @@ const AuthLayout = (props: AuthLayoutProps) => {
   );
   const orgContext = useOrg();
 
+  useEffect(() => {
+    if (orgContext?.currentOrg?.has_onboarded === false) {
+      router.push("/onboarding");
+    }
+  }, [orgContext?.currentOrg?.has_onboarded]);
 
   const banner = useMemo((): BannerType | null => {
     const activeBanner = alertBanners?.data?.find((x) => x.active);


### PR DESCRIPTION
Allow a user to still use other features of the app without having to explicitly onboard.