### PR TITLE
fix: honor dark mode for monaco editor

### DIFF
--- a/web/components/templates/hql/hqlPage.tsx
+++ b/web/components/templates/hql/hqlPage.tsx
@@ -372,7 +372,7 @@ function HQLPage() {
                   // Define and apply transparent background themes
                   // Apply the custom theme immediately
                   monaco.editor.setTheme(
-                    currentTheme === "dark" ? "custom-dark" : "custom-light"
+                    currentTheme === "dark" ? "custom-dark" : "custom-light",
                   );
 
                   // Regex to match forbidden write statements (case-insensitive, at start of line ignoring whitespace)


### PR DESCRIPTION
Synchronize the Monaco editor's theme with the application's current theme (light or dark mode)