### PR TITLE
feat: test CI and dry tests

### DIFF
--- a/.github/actions/node-test/action.yml
+++ b/.github/actions/node-test/action.yml
@@ -1,0 +1,36 @@
+name: Node Test
+description: Setup Node, install dependencies, and run provided test command
+inputs:
+  node-version:
+    description: Node.js version
+    required: false
+    default: '20'
+  working-directory:
+    description: Optional working directory to run the test command
+    required: false
+    default: '.'
+  test-command:
+    description: Command to run tests
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: yarn
+
+    - name: Install dependencies
+      shell: bash
+      run: yarn install --frozen-lockfile
+
+    - name: Run tests
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: ${{ inputs.test-command }}
+
+

--- a/.github/workflows/packages-tests.yml
+++ b/.github/workflows/packages-tests.yml
@@ -1,0 +1,38 @@
+name: Packages Tests
+
+on:
+  push:
+    paths:
+      - 'packages/**'
+      - 'yarn.lock'
+      - 'package.json'
+      - '.github/workflows/packages-tests.yml'
+  pull_request:
+    paths:
+      - 'packages/**'
+      - 'yarn.lock'
+      - 'package.json'
+      - '.github/workflows/packages-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run Jest for packages
+        run: npx jest --config packages/jest.config.ts --runInBand
+        env:
+          CI: true
+
+

--- a/.github/workflows/packages-tests.yml
+++ b/.github/workflows/packages-tests.yml
@@ -18,21 +18,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Run packages tests
+        uses: ./.github/actions/node-test
         with:
-          node-version: '20'
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Run Jest for packages
-        run: npx jest --config packages/jest.config.ts --runInBand
-        env:
-          CI: true
+          test-command: npx jest --config packages/jest.config.ts --runInBand
 
 

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -1,0 +1,39 @@
+name: Web Tests
+
+on:
+  push:
+    paths:
+      - 'web/**'
+      - 'yarn.lock'
+      - 'package.json'
+      - '.github/workflows/web-tests.yml'
+  pull_request:
+    paths:
+      - 'web/**'
+      - 'yarn.lock'
+      - 'package.json'
+      - '.github/workflows/web-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies (workspaces)
+        run: yarn install --frozen-lockfile
+
+      - name: Run Jest in web (pass when no tests)
+        working-directory: web
+        run: npx jest --passWithNoTests --runInBand
+        env:
+          CI: true
+
+

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -18,22 +18,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Run web tests
+        uses: ./.github/actions/node-test
         with:
-          node-version: '20'
-          cache: 'yarn'
-
-      - name: Install dependencies (workspaces)
-        run: yarn install --frozen-lockfile
-
-      - name: Run Jest in web (pass when no tests)
-        working-directory: web
-        run: npx jest --passWithNoTests --runInBand
-        env:
-          CI: true
+          working-directory: web
+          test-command: npx jest --passWithNoTests --runInBand
 
 

--- a/.github/workflows/worker-tests.yml
+++ b/.github/workflows/worker-tests.yml
@@ -18,21 +18,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Run worker tests
+        uses: ./.github/actions/node-test
         with:
-          node-version: '20'
-          cache: 'yarn'
-
-      - name: Install dependencies (workspaces)
-        run: yarn install --frozen-lockfile
-
-      - name: Run Vitest for worker
-        run: yarn workspace helicone-worker test:run -- --reporter=dot
-        env:
-          CI: true
+          test-command: yarn workspace helicone-worker test:run -- --reporter=dot
 
 

--- a/.github/workflows/worker-tests.yml
+++ b/.github/workflows/worker-tests.yml
@@ -1,0 +1,38 @@
+name: Worker Tests
+
+on:
+  push:
+    paths:
+      - 'worker/**'
+      - 'yarn.lock'
+      - 'package.json'
+      - '.github/workflows/worker-tests.yml'
+  pull_request:
+    paths:
+      - 'worker/**'
+      - 'yarn.lock'
+      - 'package.json'
+      - '.github/workflows/worker-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies (workspaces)
+        run: yarn install --frozen-lockfile
+
+      - name: Run Vitest for worker
+        run: yarn workspace helicone-worker test:run -- --reporter=dot
+        env:
+          CI: true
+
+


### PR DESCRIPTION
This pull request introduces a reusable GitHub Action for running Node.js tests and refactors the test workflows for the `packages`, `web`, and `worker` directories to use this new action. This improves consistency and maintainability across the project's CI setup.

* Updated `.github/workflows/packages-tests.yml` to use the new Node test action for running Jest tests on the `packages` directory.
* Updated `.github/workflows/web-tests.yml` to use the Node test action for running Jest tests in the `web` directory, with support for skipping tests if none are found.
* Updated `.github/workflows/worker-tests.yml` to use the Node test action for running tests in the `worker` workspace using a custom Yarn command.