### PR TITLE
update to use internal responses over apiclient

### DIFF
--- a/valhalla/jawn/src/managers/creditsManager.ts
+++ b/valhalla/jawn/src/managers/creditsManager.ts
@@ -60,10 +60,16 @@ export class CreditsManager extends BaseManager {
           method: "GET",
           headers: {
             "Content-Type": "application/json",
-            "Authorization": `Bearer ${process.env.HELICONE_MANUAL_ACCESS_KEY}`,
+            Authorization: `Bearer ${process.env.HELICONE_MANUAL_ACCESS_KEY}`,
           },
         }
       );
+      if (!paymentsResponse.ok) {
+        return err(
+          `Error retrieving credit balance transactions: ${paymentsResponse.statusText}`
+        );
+      }
+
       const payments = await paymentsResponse.json();
 
       return ok({

--- a/worker/src/api/lib/internalResponse.ts
+++ b/worker/src/api/lib/internalResponse.ts
@@ -1,0 +1,29 @@
+export const InternalResponse = {
+  newError(message: string, status: number): Response {
+    console.error(`Response Error: `, message);
+    return new Response(JSON.stringify({ error: message }), { status });
+  },
+  successJSON(data: unknown, enableCors = false): Response {
+    if (enableCors) {
+      return new Response(JSON.stringify(data), {
+        status: 200,
+        headers: {
+          "content-type": "application/json;charset=UTF-8",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "PUT",
+          "Access-Control-Allow-Headers":
+            "Content-Type, helicone-jwt, helicone-org-id",
+        },
+      });
+    }
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: {
+        "content-type": "application/json;charset=UTF-8",
+      },
+    });
+  },
+  unauthorized(): Response {
+    return this.newError("Unauthorized", 401);
+  },
+};


### PR DESCRIPTION
the manual access key is not a proper helicone key, so we are throwing on auth header validation. Even tho we dont validate it. To fix this we can remove the APIClient completely, since we are just using the underlying response helper and pull that out into it's own class