### PR TITLE
misc: avoid hardcoding bucket for hql

### DIFF
--- a/valhalla/jawn/src/lib/stores/HqlStore.ts
+++ b/valhalla/jawn/src/lib/stores/HqlStore.ts
@@ -3,7 +3,7 @@ import { err, ok, Result } from "../../packages/common/result";
 import { S3Client } from "../shared/db/s3Client";
 import fs from "fs";
 
-const HQL_STORE_BUCKET = "hql-store";
+const HQL_STORE_BUCKET = process.env.HQL_STORE_BUCKET || "hql-store";
 
 export class HqlStore {
   private s3Client: S3Client;


### PR DESCRIPTION
Made the `HQL_STORE_BUCKET` variable in `HqlStore.ts` configurable through the `HQL_STORE_BUCKET` environment variable, defaulting to `"helicone-minio"`