### PR TITLE
fix: flicker prior to splash page of hql

### DIFF
--- a/valhalla/jawn/src/lib/stores/HqlStore.ts
+++ b/valhalla/jawn/src/lib/stores/HqlStore.ts
@@ -3,7 +3,7 @@ import { err, ok, Result } from "../../packages/common/result";
 import { S3Client } from "../shared/db/s3Client";
 import fs from "fs";
 
-const HQL_STORE_BUCKET = "hql-store";
+const HQL_STORE_BUCKET = process.env.HQL_STORE_BUCKET || "hql-store";
 
 export class HqlStore {
   private s3Client: S3Client;

--- a/web/components/templates/hql/hqlPage.tsx
+++ b/web/components/templates/hql/hqlPage.tsx
@@ -253,7 +253,7 @@ function HQLPage() {
     latestQueryRef.current = currentQuery;
   }, [currentQuery]);
 
-  if (isLoadingFeatureFlag || savedQueryDetailsLoading) {
+  if (!organization?.currentOrg?.id || isLoadingFeatureFlag || savedQueryDetailsLoading) {
     return (
       <div className="flex h-screen w-full items-center justify-center">
         <div className="text-lg">Loading...</div>
@@ -261,7 +261,7 @@ function HQLPage() {
     );
   }
 
-  if (!hasAccessToHQL?.data) {
+  if (hasAccessToHQL?.data === false) {
     return (
       <EmptyStateCard
         feature="hql"

--- a/web/services/hooks/admin.tsx
+++ b/web/services/hooks/admin.tsx
@@ -274,6 +274,9 @@ const useFeatureFlag = (feature: string, orgId: string) => {
         orgId,
       },
     },
+    {
+      enabled: Boolean(orgId),
+    },
   );
   return {
     data,


### PR DESCRIPTION
The `HQLPage` component now checks for the presence of `organization.currentOrg.id` before rendering, ensuring the organization context is loaded before proceeding.