### PR TITLE
feat: hql prevent body select

### DIFF
--- a/valhalla/jawn/src/controllers/public/heliconeSqlController.ts
+++ b/valhalla/jawn/src/controllers/public/heliconeSqlController.ts
@@ -75,6 +75,7 @@ export type ExecuteSqlResponse = {
 };
 
 // Helper function to convert HqlError to string for API responses
+// TODO: move this to the error library, and with better error handling
 function formatHqlError(error: HqlError): string {
   // Include error code in the response for frontend parsing
   const codePrefix = error.code ? `[${error.code}] ` : '';

--- a/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
@@ -23,13 +23,13 @@ export class ClickhouseClientWrapper {
 
   constructor(env: ClickhouseEnv) {
     this.clickHouseClient = createClient({
-      host: env.CLICKHOUSE_HOST,
+      url: env.CLICKHOUSE_HOST,
       username: env.CLICKHOUSE_USER,
       password: env.CLICKHOUSE_PASSWORD,
     });
 
     this.clickHouseHqlClient = createClient({
-      host: env.CLICKHOUSE_HOST,
+      url: env.CLICKHOUSE_HOST,
       username: env.CLICKHOUSE_HQL_USER,
       password: env.CLICKHOUSE_HQL_PASSWORD,
     });

--- a/valhalla/jawn/src/lib/db/test/TestClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/test/TestClickhouseWrapper.ts
@@ -20,13 +20,13 @@ export class TestClickhouseClientWrapper {
 
   constructor(env: ClickhouseEnv) {
     this.clickHouseClient = createClient({
-      host: env.CLICKHOUSE_HOST,
+      url: env.CLICKHOUSE_HOST,
       username: env.CLICKHOUSE_USER,
       password: env.CLICKHOUSE_PASSWORD,
     });
 
     this.clickHouseHqlClient = createClient({
-      host: env.CLICKHOUSE_HOST,
+      url: env.CLICKHOUSE_HOST,
       username: env.CLICKHOUSE_HQL_USER,
       password: env.CLICKHOUSE_HQL_PASSWORD,
     });

--- a/valhalla/jawn/src/lib/errors/HqlErrors.ts
+++ b/valhalla/jawn/src/lib/errors/HqlErrors.ts
@@ -12,6 +12,7 @@ export enum HqlErrorCode {
   INVALID_TABLE = "HQL_INVALID_TABLE",
   SYNTAX_ERROR = "HQL_SYNTAX_ERROR",
   SQL_INJECTION_ATTEMPT = "HQL_SQL_INJECTION_ATTEMPT",
+  FORBIDDEN_SELECT_COLUMN = "HQL_FORBIDDEN_SELECT_COLUMN",
   
   // Query Execution Errors
   QUERY_TIMEOUT = "HQL_QUERY_TIMEOUT",
@@ -58,6 +59,7 @@ export const HqlErrorMessages: Record<HqlErrorCode, string> = {
   [HqlErrorCode.INVALID_TABLE]: "Table is not allowed for querying",
   [HqlErrorCode.SYNTAX_ERROR]: "SQL syntax error",
   [HqlErrorCode.SQL_INJECTION_ATTEMPT]: "Query contains forbidden keywords",
+  [HqlErrorCode.FORBIDDEN_SELECT_COLUMN]: "Selecting request_body or response_body in SELECT is not allowed",
   
   [HqlErrorCode.QUERY_TIMEOUT]: "Query execution timeout (30 seconds). Please optimize your query.",
   [HqlErrorCode.MEMORY_LIMIT_EXCEEDED]: "Query exceeded memory limit. Please reduce the data scope.",
@@ -90,6 +92,7 @@ export const StatusCodeMap: Partial<Record<HqlErrorCode, number>> = {
   [HqlErrorCode.INVALID_TABLE]: 400,
   [HqlErrorCode.SYNTAX_ERROR]: 400,
   [HqlErrorCode.SQL_INJECTION_ATTEMPT]: 400,
+  [HqlErrorCode.FORBIDDEN_SELECT_COLUMN]: 400,
   [HqlErrorCode.MISSING_QUERY_ID]: 400,
   [HqlErrorCode.MISSING_QUERY_NAME]: 400,
   [HqlErrorCode.MISSING_QUERY_SQL]: 400,


### PR DESCRIPTION
Prevent users from selecting  `request_body` and `response_body` in SELECT queries.