### PR TITLE
fix: Override status for errors in anthropic streams

### DIFF
--- a/valhalla/jawn/src/lib/handlers/ResponseBodyHandler.ts
+++ b/valhalla/jawn/src/lib/handlers/ResponseBodyHandler.ts
@@ -74,6 +74,10 @@ export class ResponseBodyHandler extends AbstractLogHandler {
 
     try {
       const processedResponseBody = await this.processBody(context);
+      if (processedResponseBody.data?.statusOverride) {
+        context.message.log.response.status =
+          processedResponseBody.data.statusOverride;
+      }
       context.processedLog.response.model = getModelFromResponse(
         processedResponseBody.data?.processedBody
       );

--- a/valhalla/jawn/src/lib/shared/bodyProcessors/IBodyProcessor.ts
+++ b/valhalla/jawn/src/lib/shared/bodyProcessors/IBodyProcessor.ts
@@ -11,6 +11,12 @@ export interface ParseInput {
 export type ParseOutput = {
   processedBody: any;
   usage?: Usage;
+  // Enables us to override successful status codes if an error
+  // occurs mid stream. Eg, Anthropic will always return a 200 for streams,
+  // but may send an error in the `data` event stream, in which case we want
+  // to override this so that the logs show up as an "error" in our Helicone
+  // dashboard.
+  statusOverride?: number;
 };
 
 export interface IBodyProcessor {

--- a/valhalla/jawn/src/lib/shared/bodyProcessors/anthropicStreamBodyProcessor.ts
+++ b/valhalla/jawn/src/lib/shared/bodyProcessors/anthropicStreamBodyProcessor.ts
@@ -47,6 +47,12 @@ export class AnthropicStreamBodyProcessor implements IBodyProcessor {
 
       try {
         const data = JSON.parse(line.replace("data:", "").trim());
+        if ("error" in data) {
+          return ok({
+            processedBody: data,
+            statusOverride: 500,
+          });
+        }
 
         // Handle input_json_delta for tool_use
         if (


### PR DESCRIPTION
unfortunately, the anthropic streaming api will always return a 200 status code even when the actual response body is an error. in those cases, the response body looks like this, for example:

```
{
  "streamed_data": "event: error\ndata: {\"type\":\"error\",\"error\":{\"details\":null,\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}              }\n\n"
}
```

to fix this, we are allowing the stream body parsers to override the status code. open to other/better places to do this, but the stream parsers felt like a natural fit since they have access to actual JSON objects, rather than `any`, `string` or `string[]`

