### PR TITLE
separate saved filters button from filters dropdown

### DIFF
--- a/web/filterAST/FilterASTButton.tsx
+++ b/web/filterAST/FilterASTButton.tsx
@@ -37,7 +37,7 @@ export const FilterASTButton: React.FC<FilterASTButtonProps> = ({ }) => {
   const numFilters = store.getFilterNodeCount();
 
   return (
-    <Row className="space-x-2">
+    <Row className="space-x-2 mr-4">
       <Popover onOpenChange={setIsOpen} open={isOpen}>
         <PopoverTrigger asChild>
           <Button variant="outline" className="gap-2" size="sm">

--- a/web/filterAST/FilterASTButton.tsx
+++ b/web/filterAST/FilterASTButton.tsx
@@ -10,10 +10,11 @@ import { FilterASTEditor } from "./FilterASTEditor";
 import { useFilterAST } from "./context/filterContext";
 import { Badge } from "@/components/ui/badge";
 import { Row } from "@/components/layout/common";
+import SavedFiltersDropdown from "./components/SavedFiltersDropdown";
 
-interface FilterASTButtonProps {}
+interface FilterASTButtonProps { }
 
-export const FilterASTButton: React.FC<FilterASTButtonProps> = ({}) => {
+export const FilterASTButton: React.FC<FilterASTButtonProps> = ({ }) => {
   const { store } = useFilterAST();
   const [isHydrated, setIsHydrated] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
@@ -36,10 +37,10 @@ export const FilterASTButton: React.FC<FilterASTButtonProps> = ({}) => {
   const numFilters = store.getFilterNodeCount();
 
   return (
-    <Row>
+    <Row className="space-x-2">
       <Popover onOpenChange={setIsOpen} open={isOpen}>
         <PopoverTrigger asChild>
-          <Button variant="outline" size="sm" className="gap-2">
+          <Button variant="outline" className="gap-2" size="sm">
             <Filter className="h-4 w-4" />
             Filter
             {!isOpen && store.activeFilterId && (
@@ -60,11 +61,11 @@ export const FilterASTButton: React.FC<FilterASTButtonProps> = ({}) => {
           <FilterASTEditor />
         </PopoverContent>
       </Popover>
+      <SavedFiltersDropdown />
       {store.getFilterNodeCount() > 0 && (
         <Button
           variant="glass"
           size="sm"
-          className="gap-2 ml-2"
           onClick={() => {
             store.clearActiveFilter();
           }}

--- a/web/filterAST/FilterASTEditor.tsx
+++ b/web/filterAST/FilterASTEditor.tsx
@@ -13,9 +13,9 @@ import {
   OrExpression,
 } from "@helicone-package/filters/types";
 
-interface FilterASTEditorProps {}
+interface FilterASTEditorProps { }
 
-export const FilterASTEditor: React.FC<FilterASTEditorProps> = ({}) => {
+export const FilterASTEditor: React.FC<FilterASTEditorProps> = ({ }) => {
   const { store: filterStore, helpers } = useFilterAST();
 
   return (
@@ -53,7 +53,6 @@ export const FilterASTEditor: React.FC<FilterASTEditorProps> = ({}) => {
               </Button>
             )}
           </Row>
-          <SavedFiltersDropdown />
         </div>
       </div>
 

--- a/web/filterAST/FilterASTEditor.tsx
+++ b/web/filterAST/FilterASTEditor.tsx
@@ -5,7 +5,6 @@ import { Input } from "@/components/ui/input";
 import { Plus } from "lucide-react";
 import React from "react";
 import FilterGroupNode from "./components/FilterGroupNode";
-import SavedFiltersDropdown from "./components/SavedFiltersDropdown";
 import { useFilterAST } from "./context/filterContext";
 import {
   AndExpression,

--- a/web/filterAST/components/SavedFiltersDropdown.tsx
+++ b/web/filterAST/components/SavedFiltersDropdown.tsx
@@ -12,11 +12,11 @@ import { useFilterAST } from "@/filterAST/context/filterContext";
 import { Check, ChevronDown, Trash2 } from "lucide-react";
 import React, { useState } from "react";
 
-interface SavedFiltersDropdownProps {}
+interface SavedFiltersDropdownProps { }
 
 export const SavedFiltersDropdown: React.FC<
   SavedFiltersDropdownProps
-> = ({}) => {
+> = ({ }) => {
   const [open, setOpen] = useState(false);
   const { crud, helpers, store } = useFilterAST();
 
@@ -36,7 +36,7 @@ export const SavedFiltersDropdown: React.FC<
         <Button
           variant="glass"
           size="sm"
-          className="flex items-center gap-2 text-xs"
+          className="flex shadow-sm items-center gap-2 text-xs"
         >
           <span>Saved Filters</span>
           {crud.savedFilters.length > 0 && (


### PR DESCRIPTION
## Ticket
no ticket

## Summary
remove the saved filters button from the filters popover and put them side by side. 1 less click needed

## Context
this change was requested by a customer:
[customer's slack message](https://helicone.slack.com/archives/C08TU3RV8CF/p1748932194174729)

## Screenshots
| **Before**   |  **After**  |
|-------------|------------|
|<img width="428" height="106" alt="Screenshot 2025-09-06 at 11 37 18 AM" src="https://github.com/user-attachments/assets/9fe174c5-43c2-429c-8055-a1ebba3c8dcb" /><img width="575" height="64" alt="Screenshot 2025-09-06 at 11 38 51 AM" src="https://github.com/user-attachments/assets/1ddf3e29-ce40-49f5-8991-16453c8d7fb9" />|<img width="542" height="108" alt="Screenshot 2025-09-06 at 11 29 34 AM" src="https://github.com/user-attachments/assets/f93498af-327d-4cde-8fb5-d8b229b69f47" /><img width="1042" height="59" alt="Screenshot 2025-09-06 at 11 38 39 AM" src="https://github.com/user-attachments/assets/75731527-42b1-46a7-a2f1-5181770fc96b" />|