### PR TITLE
feat: HQL datadog dashboard

### DIFF
--- a/docker/terraform/datadog/.terraform.lock.hcl
+++ b/docker/terraform/datadog/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/datadog/datadog" {
+  version     = "3.73.0"
+  constraints = ">= 3.40.0"
+  hashes = [
+    "h1:z97y3WOHeZqWq9oV16SiB5kwYeH1rI41rL/Iz/9KgKY=",
+    "zh:1ed88dcedb4d23eae4e8287a37f719162766abe9d119e134ea6b0a9923326585",
+    "zh:2e2faf2641fc8c9488cc6c295e4fa57603eda7dde4e407f5e8dbbce9c010211c",
+    "zh:35bed314bf8721b6bfbf9b1cd3336bf0c7c22f4cc429f1045a19088a4fbc689c",
+    "zh:3aa2ab657dae52db11dc7e9bf1bcd03dfa60381e4ec0d481f397c6136a802400",
+    "zh:67d5aa7a4ffc7b97326615077f6b8ef1071a0707d7dfbfbe31610423b06ae8dd",
+    "zh:7f899db79c4fe37529bf5c5fde15d3b1488b907992a91bfafe79dceb3a764f28",
+    "zh:8957b1e4bbdcdee16038bf8df3e66e1ed80df86b98e1df348984cdf06cc58d1e",
+    "zh:9e7a72edc2faa36e6f84c58a1a75b7bc93880a44f0d2f63463d8cc460a3ac996",
+    "zh:a82bcc02403721cb39a13f94e191f434cf4ea1f756155b12c7d1e0bc9d763796",
+    "zh:af2015cfc47b22ade64cf3b23f71d61d53b4e756a7219936de1e9c262e6f87f8",
+    "zh:b72d88715e90c6960f66cacb40560eec0ccaf260ad4b6dd4bf3169406bdbdcd2",
+    "zh:b787a06c006aa2dfd46c03f92552c4dddcb36e6e09dbd24c1e2a177c6de8b013",
+    "zh:d97bcf42e43053ef263c9ff388942f166093562949d56a4c06c516fe4399d33e",
+    "zh:fe1dc94a8fbdfc60b12b04d3c3b9c2e262c3526ab5db328df8c49d338d0617af",
+  ]
+}

--- a/docker/terraform/datadog/dashboards.json.tf
+++ b/docker/terraform/datadog/dashboards.json.tf
@@ -1,0 +1,131 @@
+resource "datadog_dashboard_json" "hql_overview" {
+  dashboard = <<JSON
+{
+  "title": "HQL Overview",
+  "description": "Overview of Helicone Query Language traces (counts, latency, errors).",
+  "layout_type": "ordered",
+  "template_variables": [
+    { "name": "service", "prefix": "service" },
+    { "name": "env", "prefix": "env" }
+  ],
+  "widgets": [
+    {
+      "definition": {
+        "type": "timeseries",
+        "title": "HQL span count by operation",
+        "show_legend": true,
+        "requests": [
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.executeSql"}, "compute": {"aggregation": "count"}, "group_by": [{"facet": "resource_name"}]}},
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.getClickHouseSchema"}, "compute": {"aggregation": "count"}, "group_by": [{"facet": "resource_name"}]}},
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.downloadCsv"}, "compute": {"aggregation": "count"}, "group_by": [{"facet": "resource_name"}]}}
+        ]
+      }
+    },
+    {
+      "definition": {
+        "type": "timeseries",
+        "title": "executeSql latency (p50/p95/p99)",
+        "show_legend": true,
+        "requests": [
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.executeSql"}, "compute": {"aggregation": "pc50"}, "group_by": [{"facet": "resource_name"}]}},
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.executeSql"}, "compute": {"aggregation": "pc95"}, "group_by": [{"facet": "resource_name"}]}},
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.executeSql"}, "compute": {"aggregation": "pc99"}, "group_by": [{"facet": "resource_name"}]}}
+        ]
+      }
+    },
+    {
+      "definition": {
+        "type": "timeseries",
+        "title": "executeSql hits vs errors",
+        "show_legend": true,
+        "requests": [
+          {"display_type": "line", "style": {"palette": "dog_classic"}, "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.executeSql"}, "compute": {"aggregation": "count"}, "group_by": [{"facet": "resource_name"}]}},
+          {"display_type": "line", "style": {"palette": "warm"}, "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.executeSql status:error"}, "compute": {"aggregation": "count"}, "group_by": [{"facet": "resource_name"}]}}
+        ]
+      }
+    },
+    {
+      "definition": {
+        "type": "toplist",
+        "title": "Top HQL resources by p95 latency - executeSql",
+        "requests": [
+          {"apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.executeSql"}, "compute": {"aggregation": "pc95"}, "group_by": [{"facet": "resource_name"}]}}
+        ]
+      }
+    },
+    {
+      "definition": {
+        "type": "toplist",
+        "title": "Top HQL resources by p95 latency - getClickHouseSchema",
+        "requests": [
+          {"apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.getClickHouseSchema"}, "compute": {"aggregation": "pc95"}, "group_by": [{"facet": "resource_name"}]}}
+        ]
+      }
+    },
+    {
+      "definition": {
+        "type": "toplist",
+        "title": "Top HQL resources by p95 latency - downloadCsv",
+        "requests": [
+          {"apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.downloadCsv"}, "compute": {"aggregation": "pc95"}, "group_by": [{"facet": "resource_name"}]}}
+        ]
+      }
+    }
+  ]
+}
+JSON
+}
+
+resource "datadog_dashboard_json" "hql_controllers" {
+  dashboard = <<JSON
+{
+  "title": "HQL Controllers",
+  "description": "Controller-level HQL traces (counts, latency, errors).",
+  "layout_type": "ordered",
+  "template_variables": [
+    { "name": "service", "prefix": "service" },
+    { "name": "env", "prefix": "env" }
+  ],
+  "widgets": [
+    {
+      "definition": {
+        "type": "timeseries",
+        "title": "Controller span counts",
+        "show_legend": true,
+        "requests": [
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.controller.executeSql"}, "compute": {"aggregation": "count"}, "group_by": [{"facet": "resource_name"}]}},
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.controller.getClickHouseSchema"}, "compute": {"aggregation": "count"}, "group_by": [{"facet": "resource_name"}]}},
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.controller.downloadCsv"}, "compute": {"aggregation": "count"}, "group_by": [{"facet": "resource_name"}]}}
+        ]
+      }
+    },
+    {
+      "definition": {
+        "type": "timeseries",
+        "title": "Controller p95 latency",
+        "show_legend": true,
+        "requests": [
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.controller.executeSql"}, "compute": {"aggregation": "pc95"}, "group_by": [{"facet": "resource_name"}]}},
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.controller.getClickHouseSchema"}, "compute": {"aggregation": "pc95"}, "group_by": [{"facet": "resource_name"}]}},
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.controller.downloadCsv"}, "compute": {"aggregation": "pc95"}, "group_by": [{"facet": "resource_name"}]}}
+        ]
+      }
+    },
+    {
+      "definition": {
+        "type": "timeseries",
+        "title": "Controller errors",
+        "show_legend": true,
+        "requests": [
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.controller.executeSql status:error"}, "compute": {"aggregation": "count"}, "group_by": [{"facet": "resource_name"}]}},
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.controller.getClickHouseSchema status:error"}, "compute": {"aggregation": "count"}, "group_by": [{"facet": "resource_name"}]}},
+          {"display_type": "line", "apm_query": {"index": "trace-search", "search": {"query": "service:$service env:$env name:hql.controller.downloadCsv status:error"}, "compute": {"aggregation": "count"}, "group_by": [{"facet": "resource_name"}]}}
+        ]
+      }
+    }
+  ]
+}
+JSON
+}
+
+

--- a/docker/terraform/datadog/terraform.tfvars.example
+++ b/docker/terraform/datadog/terraform.tfvars.example
@@ -1,0 +1,5 @@
+# Datadog API credentials
+# Get these from your Datadog account: https://app.datadoghq.com/organization-settings/api-keys
+datadog_api_key = "your_datadog_api_key_here"
+datadog_app_key = "your_datadog_app_key_here"
+datadog_api_url = "https://api.us5.datadoghq.com"

--- a/docker/terraform/datadog/variables.tf
+++ b/docker/terraform/datadog/variables.tf
@@ -1,0 +1,12 @@
+variable "datadog_api_key" {
+  type = string
+}
+
+variable "datadog_app_key" {
+  type = string
+}
+
+variable "datadog_api_url" {
+  description = "Datadog API base URL, e.g. https://api.us5.datadoghq.com"
+  type        = string
+}

--- a/docker/terraform/datadog/versions.tf
+++ b/docker/terraform/datadog/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    datadog = {
+      source  = "DataDog/datadog"
+      version = ">= 3.40.0"
+    }
+  }
+  cloud {
+    organization = "helicone"
+    workspaces {
+      name = "helicone-datadog"
+    }
+  }
+}
+
+provider "datadog" {
+  api_key = var.datadog_api_key
+  app_key = var.datadog_app_key
+  api_url = var.datadog_api_url
+}


### PR DESCRIPTION
This pull request introduces initial Terraform configuration for the HQL datadog dashboard and provider settings. The dashboard itself consists of traces set up in https://github.com/Helicone/helicone/pull/4673

`dashboards.json.tf` to defines two Datadog dashboards: one for HQL overview (traces, latency, errors) and another for controller-level metrics.