### PR TITLE
fix: add hql-store bucket to minio setup

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       /bin/sh -c "
       /usr/bin/mc alias set localminio http://minio:9000 minioadmin minioadmin;
       /usr/bin/mc mb --ignore-existing localminio/request-response-storage;
+      /usr/bin/mc mb --ignore-existing localminio/hql-store;
       exit 0;
       "
 


### PR DESCRIPTION
Created the hql-store bucket in minio to enable downloading CSV's in self hosted mode.
