### PR TITLE
docs: hql api

### DIFF
--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -414,6 +414,10 @@ export interface paths {
     post: operations["GetCostsOverTime"];
   };
   "/v1/public/model-registry/models": {
+    /**
+     * Returns a comprehensive list of all AI models with their configurations, pricing, and capabilities
+     * @description Get all available models from the registry
+     */
     get: operations["GetModelRegistry"];
   };
   "/v1/public/compare/models": {
@@ -443,27 +447,62 @@ export interface paths {
     get: operations["GetSlackChannels"];
   };
   "/v1/helicone-sql/schema": {
-    /** @description Get ClickHouse schema (tables and columns) */
+    /**
+     * Get database schema
+     * @description Get ClickHouse schema (tables and columns)
+     */
     get: operations["GetClickHouseSchema"];
   };
   "/v1/helicone-sql/execute": {
+    /**
+     * Execute SQL query
+     * @description Execute a SQL query against ClickHouse
+     */
     post: operations["ExecuteSql"];
   };
   "/v1/helicone-sql/download": {
+    /**
+     * Download query results as CSV
+     * @description Execute a SQL query and download results as CSV
+     */
     post: operations["DownloadCsv"];
   };
   "/v1/helicone-sql/saved-queries": {
+    /**
+     * List saved queries
+     * @description Get all saved queries for the organization
+     */
     get: operations["GetSavedQueries"];
   };
   "/v1/helicone-sql/saved-query/{queryId}": {
+    /**
+     * Get saved query
+     * @description Get a specific saved query by ID
+     */
     get: operations["GetSavedQuery"];
+    /**
+     * Update saved query
+     * @description Update an existing saved query
+     */
+    put: operations["UpdateSavedQuery"];
+    /**
+     * Delete saved query
+     * @description Delete a saved query by ID
+     */
     delete: operations["DeleteSavedQuery"];
   };
   "/v1/helicone-sql/saved-queries/bulk-delete": {
+    /**
+     * Bulk delete saved queries
+     * @description Delete multiple saved queries at once
+     */
     post: operations["BulkDeleteSavedQueries"];
   };
   "/v1/helicone-sql/saved-query": {
-    put: operations["UpdateSavedQuery"];
+    /**
+     * Create saved query
+     * @description Create a new saved query
+     */
     post: operations["CreateSavedQuery"];
   };
   "/v1/experiment/new-empty": {
@@ -3084,11 +3123,6 @@ Json: JsonObject;
       error: null;
     };
     "Result_HqlSavedQuery.string_": components["schemas"]["ResultSuccess_HqlSavedQuery_"] | components["schemas"]["ResultError_string_"];
-    UpdateSavedQueryRequest: {
-      name: string;
-      sql: string;
-      id: string;
-    };
     "ResultSuccess__tableId-string--experimentId-string__": {
       data: {
         experimentId: string;
@@ -6348,9 +6382,13 @@ export interface operations {
       };
     };
   };
+  /**
+   * Returns a comprehensive list of all AI models with their configurations, pricing, and capabilities
+   * @description Get all available models from the registry
+   */
   GetModelRegistry: {
     responses: {
-      /** @description Ok */
+      /** @description Complete model registry with models and filter options */
       200: {
         content: {
           "application/json": components["schemas"]["Result_ModelRegistryResponse.string_"];
@@ -6496,10 +6534,13 @@ export interface operations {
       };
     };
   };
-  /** @description Get ClickHouse schema (tables and columns) */
+  /**
+   * Get database schema
+   * @description Get ClickHouse schema (tables and columns)
+   */
   GetClickHouseSchema: {
     responses: {
-      /** @description Ok */
+      /** @description Array of table schemas with columns */
       200: {
         content: {
           "application/json": components["schemas"]["Result_ClickHouseTableSchema-Array.string_"];
@@ -6507,14 +6548,19 @@ export interface operations {
       };
     };
   };
+  /**
+   * Execute SQL query
+   * @description Execute a SQL query against ClickHouse
+   */
   ExecuteSql: {
+    /** @description The SQL query to execute */
     requestBody: {
       content: {
         "application/json": components["schemas"]["ExecuteSqlRequest"];
       };
     };
     responses: {
-      /** @description Ok */
+      /** @description Query results with rows and metadata */
       200: {
         content: {
           "application/json": components["schemas"]["Result_ExecuteSqlResponse.string_"];
@@ -6522,14 +6568,19 @@ export interface operations {
       };
     };
   };
+  /**
+   * Download query results as CSV
+   * @description Execute a SQL query and download results as CSV
+   */
   DownloadCsv: {
+    /** @description The SQL query to execute */
     requestBody: {
       content: {
         "application/json": components["schemas"]["ExecuteSqlRequest"];
       };
     };
     responses: {
-      /** @description Ok */
+      /** @description URL to download the CSV file */
       200: {
         content: {
           "application/json": components["schemas"]["Result_string.string_"];
@@ -6537,9 +6588,13 @@ export interface operations {
       };
     };
   };
+  /**
+   * List saved queries
+   * @description Get all saved queries for the organization
+   */
   GetSavedQueries: {
     responses: {
-      /** @description Ok */
+      /** @description Array of saved queries */
       200: {
         content: {
           "application/json": components["schemas"]["Result_Array_HqlSavedQuery_.string_"];
@@ -6547,14 +6602,19 @@ export interface operations {
       };
     };
   };
+  /**
+   * Get saved query
+   * @description Get a specific saved query by ID
+   */
   GetSavedQuery: {
     parameters: {
       path: {
+        /** @description The ID of the saved query */
         queryId: string;
       };
     };
     responses: {
-      /** @description Ok */
+      /** @description The saved query details */
       200: {
         content: {
           "application/json": components["schemas"]["Result_HqlSavedQuery-or-null.string_"];
@@ -6562,9 +6622,40 @@ export interface operations {
       };
     };
   };
+  /**
+   * Update saved query
+   * @description Update an existing saved query
+   */
+  UpdateSavedQuery: {
+    parameters: {
+      path: {
+        /** @description The ID of the saved query to update */
+        queryId: string;
+      };
+    };
+    /** @description The updated query details */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateSavedQueryRequest"];
+      };
+    };
+    responses: {
+      /** @description The updated saved query */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_HqlSavedQuery.string_"];
+        };
+      };
+    };
+  };
+  /**
+   * Delete saved query
+   * @description Delete a saved query by ID
+   */
   DeleteSavedQuery: {
     parameters: {
       path: {
+        /** @description The ID of the saved query to delete */
         queryId: string;
       };
     };
@@ -6577,7 +6668,12 @@ export interface operations {
       };
     };
   };
+  /**
+   * Bulk delete saved queries
+   * @description Delete multiple saved queries at once
+   */
   BulkDeleteSavedQueries: {
+    /** @description Array of query IDs to delete */
     requestBody: {
       content: {
         "application/json": components["schemas"]["BulkDeleteSavedQueriesRequest"];
@@ -6592,29 +6688,19 @@ export interface operations {
       };
     };
   };
-  UpdateSavedQuery: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateSavedQueryRequest"];
-      };
-    };
-    responses: {
-      /** @description Ok */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Result_HqlSavedQuery.string_"];
-        };
-      };
-    };
-  };
+  /**
+   * Create saved query
+   * @description Create a new saved query
+   */
   CreateSavedQuery: {
+    /** @description The saved query details */
     requestBody: {
       content: {
         "application/json": components["schemas"]["CreateSavedQueryRequest"];
       };
     };
     responses: {
-      /** @description Ok */
+      /** @description Array containing the created saved query */
       200: {
         content: {
           "application/json": components["schemas"]["Result_HqlSavedQuery-Array.string_"];

--- a/docs/features/hql.mdx
+++ b/docs/features/hql.mdx
@@ -100,27 +100,12 @@ Saved queries can be revisited and shared within your organization.
 
 ### Via API
 
-HQL endpoints are namespaced under `/v1/helicone-sql` and require an authenticated request scoped to your organization.
+Interactive API documentation is available at: [https://api.helicone.ai/docs/#/HeliconeSql](https://api.helicone.ai/docs/#/HeliconeSql) 
 
-```bash
-curl -X POST "https://api.helicone.ai/v1/helicone-sql/execute" \
-  -H "Authorization: Bearer $HELICONE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "sql": "SELECT request_model, COUNT() AS c FROM request_response_rmt GROUP BY request_model ORDER BY c DESC LIMIT 50"
-  }'
-```
+### API Limits
 
-Download large result sets as CSV:
-
-```bash
-curl -X POST "https://api.helicone.ai/v1/helicone-sql/download" \
-  -H "Authorization: Bearer $HELICONE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "sql": "SELECT * FROM request_response_rmt WHERE request_created_at >= toDateTime64(now(), 3) - INTERVAL 7 DAY"
-  }'
-```
+- **Query limit**: 300,000 rows maximum per query
+- **Rate limits**: 100 queries/min, 10 CSV downloads/min
 
 ## Related
 

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -8906,26 +8906,6 @@
 					}
 				]
 			},
-			"UpdateSavedQueryRequest": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"sql": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"name",
-					"sql",
-					"id"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
 			"ResultSuccess__tableId-string--experimentId-string__": {
 				"properties": {
 					"data": {
@@ -12034,8 +12014,9 @@
 		"securitySchemes": {
 			"api_key": {
 				"type": "apiKey",
-				"name": "authorization",
-				"in": "header"
+				"name": "Authorization",
+				"in": "header",
+				"description": "Bearer token authentication. Format: 'Bearer YOUR_API_KEY'"
 			}
 		}
 	},
@@ -18221,16 +18202,93 @@
 				"operationId": "GetModelRegistry",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "Complete model registry with models and filter options",
 						"content": {
 							"application/json": {
 								"schema": {
 									"$ref": "#/components/schemas/Result_ModelRegistryResponse.string_"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"models": [
+												{
+													"id": "claude-opus-4-1",
+													"name": "Anthropic: Claude Opus 4.1",
+													"author": "anthropic",
+													"contextLength": 200000,
+													"endpoints": [
+														{
+															"provider": "anthropic",
+															"providerSlug": "anthropic",
+															"supportsPtb": true,
+															"pricing": {
+																"prompt": 15,
+																"completion": 75,
+																"cacheRead": 1.5,
+																"cacheWrite": 18.75
+															}
+														}
+													],
+													"maxOutput": 32000,
+													"trainingDate": "2025-08-05",
+													"description": "Most capable Claude model with extended context",
+													"inputModalities": [
+														null
+													],
+													"outputModalities": [
+														null
+													],
+													"supportedParameters": [
+														null,
+														null,
+														null,
+														null,
+														null,
+														null,
+														null
+													]
+												}
+											],
+											"total": 150,
+											"filters": {
+												"providers": [
+													{
+														"name": "anthropic",
+														"displayName": "Anthropic"
+													},
+													{
+														"name": "openai",
+														"displayName": "OpenAI"
+													},
+													{
+														"name": "google",
+														"displayName": "Google"
+													}
+												],
+												"authors": [
+													"anthropic",
+													"openai",
+													"google",
+													"meta"
+												],
+												"capabilities": [
+													"audio",
+													"image",
+													"thinking",
+													"caching",
+													"reasoning"
+												]
+											}
+										}
+									}
 								}
 							}
 						}
 					}
 				},
+				"description": "Get all available models from the registry",
+				"summary": "Returns a comprehensive list of all AI models with their configurations, pricing, and capabilities",
 				"tags": [
 					"Model Registry"
 				],
@@ -18577,7 +18635,7 @@
 				"operationId": "GetClickHouseSchema",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "Array of table schemas with columns",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -18588,10 +18646,15 @@
 					}
 				},
 				"description": "Get ClickHouse schema (tables and columns)",
+				"summary": "Get database schema",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": []
 			}
 		},
@@ -18600,7 +18663,7 @@
 				"operationId": "ExecuteSql",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "Query results with rows and metadata",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -18610,17 +18673,25 @@
 						}
 					}
 				},
+				"description": "Execute a SQL query against ClickHouse",
+				"summary": "Execute SQL query",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": [],
 				"requestBody": {
+					"description": "The SQL query to execute",
 					"required": true,
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/ExecuteSqlRequest"
+								"$ref": "#/components/schemas/ExecuteSqlRequest",
+								"description": "The SQL query to execute"
 							}
 						}
 					}
@@ -18632,7 +18703,7 @@
 				"operationId": "DownloadCsv",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "URL to download the CSV file",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -18642,17 +18713,25 @@
 						}
 					}
 				},
+				"description": "Execute a SQL query and download results as CSV",
+				"summary": "Download query results as CSV",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": [],
 				"requestBody": {
+					"description": "The SQL query to execute",
 					"required": true,
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/ExecuteSqlRequest"
+								"$ref": "#/components/schemas/ExecuteSqlRequest",
+								"description": "The SQL query to execute"
 							}
 						}
 					}
@@ -18664,7 +18743,7 @@
 				"operationId": "GetSavedQueries",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "Array of saved queries",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -18674,10 +18753,16 @@
 						}
 					}
 				},
+				"description": "Get all saved queries for the organization",
+				"summary": "List saved queries",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": []
 			}
 		},
@@ -18686,7 +18771,7 @@
 				"operationId": "GetSavedQuery",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "The saved query details",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -18696,12 +18781,19 @@
 						}
 					}
 				},
+				"description": "Get a specific saved query by ID",
+				"summary": "Get saved query",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": [
 					{
+						"description": "The ID of the saved query",
 						"in": "path",
 						"name": "queryId",
 						"required": true,
@@ -18725,12 +18817,19 @@
 						}
 					}
 				},
+				"description": "Delete a saved query by ID",
+				"summary": "Delete saved query",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": [
 					{
+						"description": "The ID of the saved query to delete",
 						"in": "path",
 						"name": "queryId",
 						"required": true,
@@ -18739,6 +18838,54 @@
 						}
 					}
 				]
+			},
+			"put": {
+				"operationId": "UpdateSavedQuery",
+				"responses": {
+					"200": {
+						"description": "The updated saved query",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result_HqlSavedQuery.string_"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update an existing saved query",
+				"summary": "Update saved query",
+				"tags": [
+					"HeliconeSql"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": [
+					{
+						"description": "The ID of the saved query to update",
+						"in": "path",
+						"name": "queryId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "The updated query details",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateSavedQueryRequest",
+								"description": "The updated query details"
+							}
+						}
+					}
+				}
 			}
 		},
 		"/v1/helicone-sql/saved-queries/bulk-delete": {
@@ -18756,17 +18903,25 @@
 						}
 					}
 				},
+				"description": "Delete multiple saved queries at once",
+				"summary": "Bulk delete saved queries",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": [],
 				"requestBody": {
+					"description": "Array of query IDs to delete",
 					"required": true,
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/BulkDeleteSavedQueriesRequest"
+								"$ref": "#/components/schemas/BulkDeleteSavedQueriesRequest",
+								"description": "Array of query IDs to delete"
 							}
 						}
 					}
@@ -18778,7 +18933,7 @@
 				"operationId": "CreateSavedQuery",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "Array containing the created saved query",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -18788,47 +18943,25 @@
 						}
 					}
 				},
+				"description": "Create a new saved query",
+				"summary": "Create saved query",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": [],
 				"requestBody": {
+					"description": "The saved query details",
 					"required": true,
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/CreateSavedQueryRequest"
-							}
-						}
-					}
-				}
-			},
-			"put": {
-				"operationId": "UpdateSavedQuery",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Result_HqlSavedQuery.string_"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"HeliconeSql"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/UpdateSavedQueryRequest"
+								"$ref": "#/components/schemas/CreateSavedQueryRequest",
+								"description": "The saved query details"
 							}
 						}
 					}

--- a/valhalla/jawn/src/controllers/public/heliconeSqlController.ts
+++ b/valhalla/jawn/src/controllers/public/heliconeSqlController.ts
@@ -9,6 +9,7 @@ import {
   Put,
   Path,
   Delete,
+  Security,
 } from "tsoa";
 import { err, ok, Result, isError } from "../../packages/common/result";
 import { 
@@ -50,10 +51,6 @@ export interface CreateSavedQueryRequest {
   sql: string;
 }
 
-export interface UpdateSavedQueryRequest extends CreateSavedQueryRequest {
-  id: string;
-}
-
 export interface BulkDeleteSavedQueriesRequest {
   ids: string[];
 }
@@ -87,7 +84,10 @@ function formatHqlError(error: HqlError): string {
 export class HeliconeSqlController extends Controller {
   /**
    * Get ClickHouse schema (tables and columns)
+   * @summary Get database schema
+   * @returns {ClickHouseTableSchema[]} Array of table schemas with columns
    */
+  @Security("api_key")
   @Get("schema")
   public async getClickHouseSchema(
     @Request() request: JawnAuthenticatedRequest
@@ -103,6 +103,13 @@ export class HeliconeSqlController extends Controller {
     return ok(result.data);
   }
 
+  /**
+   * Execute a SQL query against ClickHouse
+   * @summary Execute SQL query
+   * @param requestBody The SQL query to execute
+   * @returns {ExecuteSqlResponse} Query results with rows and metadata
+   */
+  @Security("api_key")
   @Post("execute")
   public async executeSql(
     @Body() requestBody: ExecuteSqlRequest,
@@ -138,6 +145,13 @@ export class HeliconeSqlController extends Controller {
     return ok(result.data);
   }
 
+  /**
+   * Execute a SQL query and download results as CSV
+   * @summary Download query results as CSV
+   * @param requestBody The SQL query to execute
+   * @returns {string} URL to download the CSV file
+   */
+  @Security("api_key")
   @Post("download")
   public async downloadCsv(
     @Body() requestBody: ExecuteSqlRequest,
@@ -173,6 +187,12 @@ export class HeliconeSqlController extends Controller {
     return ok(result.data);
   }
 
+  /**
+   * Get all saved queries for the organization
+   * @summary List saved queries
+   * @returns {HqlSavedQuery[]} Array of saved queries
+   */
+  @Security("api_key")
   @Get("saved-queries")
   public async getSavedQueries(
     @Request() request: JawnAuthenticatedRequest
@@ -189,6 +209,13 @@ export class HeliconeSqlController extends Controller {
     return ok(res.data || []);
   }
 
+  /**
+   * Get a specific saved query by ID
+   * @summary Get saved query
+   * @param queryId The ID of the saved query
+   * @returns {HqlSavedQuery} The saved query details
+   */
+  @Security("api_key")
   @Get("saved-query/{queryId}")
   public async getSavedQuery(
     @Path() queryId: string,
@@ -206,6 +233,12 @@ export class HeliconeSqlController extends Controller {
     return ok(result.data);
   }
 
+  /**
+   * Delete a saved query by ID
+   * @summary Delete saved query
+   * @param queryId The ID of the saved query to delete
+   */
+  @Security("api_key")
   @Delete("saved-query/{queryId}")
   public async deleteSavedQuery(
     @Path() queryId: string,
@@ -223,6 +256,12 @@ export class HeliconeSqlController extends Controller {
     return ok(undefined);
   }
 
+  /**
+   * Delete multiple saved queries at once
+   * @summary Bulk delete saved queries
+   * @param requestBody Array of query IDs to delete
+   */
+  @Security("api_key")
   @Post("saved-queries/bulk-delete")
   public async bulkDeleteSavedQueries(
     @Body() requestBody: BulkDeleteSavedQueriesRequest,
@@ -238,6 +277,13 @@ export class HeliconeSqlController extends Controller {
     return ok(undefined);
   }
 
+  /**
+   * Create a new saved query
+   * @summary Create saved query
+   * @param requestBody The saved query details
+   * @returns {HqlSavedQuery[]} Array containing the created saved query
+   */
+  @Security("api_key")
   @Post("saved-query")
   public async createSavedQuery(
     @Body() requestBody: CreateSavedQueryRequest,
@@ -255,13 +301,25 @@ export class HeliconeSqlController extends Controller {
     return ok(result.data);
   }
 
-  @Put("saved-query")
+  /**
+   * Update an existing saved query
+   * @summary Update saved query
+   * @param queryId The ID of the saved query to update
+   * @param requestBody The updated query details
+   * @returns {HqlSavedQuery} The updated saved query
+   */
+  @Security("api_key")
+  @Put("saved-query/{queryId}")
   public async updateSavedQuery(
-    @Body() requestBody: UpdateSavedQueryRequest,
+    @Path() queryId: string,
+    @Body() requestBody: CreateSavedQueryRequest,
     @Request() request: JawnAuthenticatedRequest
   ): Promise<Result<HqlSavedQuery, string>> {
     const hqlQueryManager = new HqlQueryManager(request.authParams);
-    const result = await hqlQueryManager.updateSavedQuery(requestBody);
+    const result = await hqlQueryManager.updateSavedQuery({
+      id: queryId,
+      ...requestBody
+    });
     
     if (isError(result)) {
       this.setStatus(result.error.statusCode || 500);

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -8490,7 +8490,7 @@
 			},
 			"url.URL": {
 				"type": "string",
-				"description": "The **`URL`** interface is used to parse, construct, normalize, and encode URL.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/URL)"
+				"description": "The **`URL`** interface is used to parse, construct, normalize, and encode URL.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/URL)\n`URL` class is a global reference for `import { URL } from 'node:url'`\nhttps://nodejs.org/api/url.html#the-whatwg-url-api"
 			},
 			"stripe.Stripe.Application": {
 				"description": "The Application object.",
@@ -46898,8 +46898,9 @@
 		"securitySchemes": {
 			"api_key": {
 				"type": "apiKey",
-				"name": "authorization",
-				"in": "header"
+				"name": "Authorization",
+				"in": "header",
+				"description": "Bearer token authentication. Format: 'Bearer YOUR_API_KEY'"
 			}
 		}
 	},

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -2872,16 +2872,6 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_HqlSavedQuery_"},{"ref":"ResultError_string_"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UpdateSavedQueryRequest": {
-        "dataType": "refObject",
-        "properties": {
-            "name": {"dataType":"string","required":true},
-            "sql": {"dataType":"string","required":true},
-            "id": {"dataType":"string","required":true},
-        },
-        "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ResultSuccess__tableId-string--experimentId-string__": {
         "dataType": "refObject",
         "properties": {
@@ -8947,6 +8937,7 @@ export function RegisterRoutes(app: Router) {
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
         app.get('/v1/helicone-sql/schema',
+            authenticateMiddleware([{"api_key":[]}]),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController)),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController.prototype.getClickHouseSchema)),
 
@@ -8978,6 +8969,7 @@ export function RegisterRoutes(app: Router) {
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
         app.post('/v1/helicone-sql/execute',
+            authenticateMiddleware([{"api_key":[]}]),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController)),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController.prototype.executeSql)),
 
@@ -9009,6 +9001,7 @@ export function RegisterRoutes(app: Router) {
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
         app.post('/v1/helicone-sql/download',
+            authenticateMiddleware([{"api_key":[]}]),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController)),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController.prototype.downloadCsv)),
 
@@ -9039,6 +9032,7 @@ export function RegisterRoutes(app: Router) {
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
         app.get('/v1/helicone-sql/saved-queries',
+            authenticateMiddleware([{"api_key":[]}]),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController)),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController.prototype.getSavedQueries)),
 
@@ -9070,6 +9064,7 @@ export function RegisterRoutes(app: Router) {
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
         app.get('/v1/helicone-sql/saved-query/:queryId',
+            authenticateMiddleware([{"api_key":[]}]),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController)),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController.prototype.getSavedQuery)),
 
@@ -9101,6 +9096,7 @@ export function RegisterRoutes(app: Router) {
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
         app.delete('/v1/helicone-sql/saved-query/:queryId',
+            authenticateMiddleware([{"api_key":[]}]),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController)),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController.prototype.deleteSavedQuery)),
 
@@ -9132,6 +9128,7 @@ export function RegisterRoutes(app: Router) {
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
         app.post('/v1/helicone-sql/saved-queries/bulk-delete',
+            authenticateMiddleware([{"api_key":[]}]),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController)),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController.prototype.bulkDeleteSavedQueries)),
 
@@ -9163,6 +9160,7 @@ export function RegisterRoutes(app: Router) {
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
         app.post('/v1/helicone-sql/saved-query',
+            authenticateMiddleware([{"api_key":[]}]),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController)),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController.prototype.createSavedQuery)),
 
@@ -9190,10 +9188,12 @@ export function RegisterRoutes(app: Router) {
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsHeliconeSqlController_updateSavedQuery: Record<string, TsoaRoute.ParameterSchema> = {
-                requestBody: {"in":"body","name":"requestBody","required":true,"ref":"UpdateSavedQueryRequest"},
+                queryId: {"in":"path","name":"queryId","required":true,"dataType":"string"},
+                requestBody: {"in":"body","name":"requestBody","required":true,"ref":"CreateSavedQueryRequest"},
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
         };
-        app.put('/v1/helicone-sql/saved-query',
+        app.put('/v1/helicone-sql/saved-query/:queryId',
+            authenticateMiddleware([{"api_key":[]}]),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController)),
             ...(fetchMiddlewares<RequestHandler>(HeliconeSqlController.prototype.updateSavedQuery)),
 

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -8906,26 +8906,6 @@
 					}
 				]
 			},
-			"UpdateSavedQueryRequest": {
-				"properties": {
-					"name": {
-						"type": "string"
-					},
-					"sql": {
-						"type": "string"
-					},
-					"id": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"name",
-					"sql",
-					"id"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
 			"ResultSuccess__tableId-string--experimentId-string__": {
 				"properties": {
 					"data": {
@@ -12034,8 +12014,9 @@
 		"securitySchemes": {
 			"api_key": {
 				"type": "apiKey",
-				"name": "authorization",
-				"in": "header"
+				"name": "Authorization",
+				"in": "header",
+				"description": "Bearer token authentication. Format: 'Bearer YOUR_API_KEY'"
 			}
 		}
 	},
@@ -18221,16 +18202,93 @@
 				"operationId": "GetModelRegistry",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "Complete model registry with models and filter options",
 						"content": {
 							"application/json": {
 								"schema": {
 									"$ref": "#/components/schemas/Result_ModelRegistryResponse.string_"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"models": [
+												{
+													"id": "claude-opus-4-1",
+													"name": "Anthropic: Claude Opus 4.1",
+													"author": "anthropic",
+													"contextLength": 200000,
+													"endpoints": [
+														{
+															"provider": "anthropic",
+															"providerSlug": "anthropic",
+															"supportsPtb": true,
+															"pricing": {
+																"prompt": 15,
+																"completion": 75,
+																"cacheRead": 1.5,
+																"cacheWrite": 18.75
+															}
+														}
+													],
+													"maxOutput": 32000,
+													"trainingDate": "2025-08-05",
+													"description": "Most capable Claude model with extended context",
+													"inputModalities": [
+														null
+													],
+													"outputModalities": [
+														null
+													],
+													"supportedParameters": [
+														null,
+														null,
+														null,
+														null,
+														null,
+														null,
+														null
+													]
+												}
+											],
+											"total": 150,
+											"filters": {
+												"providers": [
+													{
+														"name": "anthropic",
+														"displayName": "Anthropic"
+													},
+													{
+														"name": "openai",
+														"displayName": "OpenAI"
+													},
+													{
+														"name": "google",
+														"displayName": "Google"
+													}
+												],
+												"authors": [
+													"anthropic",
+													"openai",
+													"google",
+													"meta"
+												],
+												"capabilities": [
+													"audio",
+													"image",
+													"thinking",
+													"caching",
+													"reasoning"
+												]
+											}
+										}
+									}
 								}
 							}
 						}
 					}
 				},
+				"description": "Get all available models from the registry",
+				"summary": "Returns a comprehensive list of all AI models with their configurations, pricing, and capabilities",
 				"tags": [
 					"Model Registry"
 				],
@@ -18577,7 +18635,7 @@
 				"operationId": "GetClickHouseSchema",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "Array of table schemas with columns",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -18588,10 +18646,15 @@
 					}
 				},
 				"description": "Get ClickHouse schema (tables and columns)",
+				"summary": "Get database schema",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": []
 			}
 		},
@@ -18600,7 +18663,7 @@
 				"operationId": "ExecuteSql",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "Query results with rows and metadata",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -18610,17 +18673,25 @@
 						}
 					}
 				},
+				"description": "Execute a SQL query against ClickHouse",
+				"summary": "Execute SQL query",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": [],
 				"requestBody": {
+					"description": "The SQL query to execute",
 					"required": true,
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/ExecuteSqlRequest"
+								"$ref": "#/components/schemas/ExecuteSqlRequest",
+								"description": "The SQL query to execute"
 							}
 						}
 					}
@@ -18632,7 +18703,7 @@
 				"operationId": "DownloadCsv",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "URL to download the CSV file",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -18642,17 +18713,25 @@
 						}
 					}
 				},
+				"description": "Execute a SQL query and download results as CSV",
+				"summary": "Download query results as CSV",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": [],
 				"requestBody": {
+					"description": "The SQL query to execute",
 					"required": true,
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/ExecuteSqlRequest"
+								"$ref": "#/components/schemas/ExecuteSqlRequest",
+								"description": "The SQL query to execute"
 							}
 						}
 					}
@@ -18664,7 +18743,7 @@
 				"operationId": "GetSavedQueries",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "Array of saved queries",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -18674,10 +18753,16 @@
 						}
 					}
 				},
+				"description": "Get all saved queries for the organization",
+				"summary": "List saved queries",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": []
 			}
 		},
@@ -18686,7 +18771,7 @@
 				"operationId": "GetSavedQuery",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "The saved query details",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -18696,12 +18781,19 @@
 						}
 					}
 				},
+				"description": "Get a specific saved query by ID",
+				"summary": "Get saved query",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": [
 					{
+						"description": "The ID of the saved query",
 						"in": "path",
 						"name": "queryId",
 						"required": true,
@@ -18725,12 +18817,19 @@
 						}
 					}
 				},
+				"description": "Delete a saved query by ID",
+				"summary": "Delete saved query",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": [
 					{
+						"description": "The ID of the saved query to delete",
 						"in": "path",
 						"name": "queryId",
 						"required": true,
@@ -18739,6 +18838,54 @@
 						}
 					}
 				]
+			},
+			"put": {
+				"operationId": "UpdateSavedQuery",
+				"responses": {
+					"200": {
+						"description": "The updated saved query",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result_HqlSavedQuery.string_"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update an existing saved query",
+				"summary": "Update saved query",
+				"tags": [
+					"HeliconeSql"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": [
+					{
+						"description": "The ID of the saved query to update",
+						"in": "path",
+						"name": "queryId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"description": "The updated query details",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateSavedQueryRequest",
+								"description": "The updated query details"
+							}
+						}
+					}
+				}
 			}
 		},
 		"/v1/helicone-sql/saved-queries/bulk-delete": {
@@ -18756,17 +18903,25 @@
 						}
 					}
 				},
+				"description": "Delete multiple saved queries at once",
+				"summary": "Bulk delete saved queries",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": [],
 				"requestBody": {
+					"description": "Array of query IDs to delete",
 					"required": true,
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/BulkDeleteSavedQueriesRequest"
+								"$ref": "#/components/schemas/BulkDeleteSavedQueriesRequest",
+								"description": "Array of query IDs to delete"
 							}
 						}
 					}
@@ -18778,7 +18933,7 @@
 				"operationId": "CreateSavedQuery",
 				"responses": {
 					"200": {
-						"description": "Ok",
+						"description": "Array containing the created saved query",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -18788,47 +18943,25 @@
 						}
 					}
 				},
+				"description": "Create a new saved query",
+				"summary": "Create saved query",
 				"tags": [
 					"HeliconeSql"
 				],
-				"security": [],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
 				"parameters": [],
 				"requestBody": {
+					"description": "The saved query details",
 					"required": true,
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/CreateSavedQueryRequest"
-							}
-						}
-					}
-				}
-			},
-			"put": {
-				"operationId": "UpdateSavedQuery",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Result_HqlSavedQuery.string_"
-								}
-							}
-						}
-					}
-				},
-				"tags": [
-					"HeliconeSql"
-				],
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/UpdateSavedQueryRequest"
+								"$ref": "#/components/schemas/CreateSavedQueryRequest",
+								"description": "The saved query details"
 							}
 						}
 					}

--- a/valhalla/jawn/tsoa-private.json
+++ b/valhalla/jawn/tsoa-private.json
@@ -8,8 +8,9 @@
     "securityDefinitions": {
       "api_key": {
         "type": "apiKey",
-        "name": "authorization",
-        "in": "header"
+        "name": "Authorization",
+        "in": "header",
+        "description": "Bearer token authentication. Format: 'Bearer YOUR_API_KEY'"
       }
     },
     "spec": {

--- a/valhalla/jawn/tsoa-public.json
+++ b/valhalla/jawn/tsoa-public.json
@@ -8,8 +8,9 @@
     "securityDefinitions": {
       "api_key": {
         "type": "apiKey",
-        "name": "authorization",
-        "in": "header"
+        "name": "Authorization",
+        "in": "header",
+        "description": "Bearer token authentication. Format: 'Bearer YOUR_API_KEY'"
       }
     },
     "spec": {

--- a/web/components/templates/hql/constants.ts
+++ b/web/components/templates/hql/constants.ts
@@ -170,13 +170,16 @@ export const useSaveQueryMutation = (
       sql: string;
     }) => {
       if (savedQuery.id) {
-        const response = await $JAWN_API.PUT("/v1/helicone-sql/saved-query/{queryId}", {
-          params: { path: { queryId: savedQuery.id } },
-          body: {
-            name: savedQuery.name,
-            sql: savedQuery.sql,
+        const response = await $JAWN_API.PUT(
+          "/v1/helicone-sql/saved-query/{queryId}",
+          {
+            params: { path: { queryId: savedQuery.id } },
+            body: {
+              name: savedQuery.name,
+              sql: savedQuery.sql,
+            },
           },
-        });
+        );
         return response;
       } else {
         const response = await $JAWN_API.POST("/v1/helicone-sql/saved-query", {

--- a/web/components/templates/hql/constants.ts
+++ b/web/components/templates/hql/constants.ts
@@ -170,9 +170,9 @@ export const useSaveQueryMutation = (
       sql: string;
     }) => {
       if (savedQuery.id) {
-        const response = await $JAWN_API.PUT("/v1/helicone-sql/saved-query", {
+        const response = await $JAWN_API.PUT("/v1/helicone-sql/saved-query/{queryId}", {
+          params: { path: { queryId: savedQuery.id } },
           body: {
-            id: savedQuery.id,
             name: savedQuery.name,
             sql: savedQuery.sql,
           },

--- a/web/lib/clients/jawnTypes/private.ts
+++ b/web/lib/clients/jawnTypes/private.ts
@@ -3056,6 +3056,8 @@ Json: JsonObject;
      * @description The **`URL`** interface is used to parse, construct, normalize, and encode URL.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL)
+     * `URL` class is a global reference for `import { URL } from 'node:url'`
+     * https://nodejs.org/api/url.html#the-whatwg-url-api
      */
     "url.URL": string;
     /** @description The Application object. */

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -414,6 +414,10 @@ export interface paths {
     post: operations["GetCostsOverTime"];
   };
   "/v1/public/model-registry/models": {
+    /**
+     * Returns a comprehensive list of all AI models with their configurations, pricing, and capabilities
+     * @description Get all available models from the registry
+     */
     get: operations["GetModelRegistry"];
   };
   "/v1/public/compare/models": {
@@ -443,27 +447,62 @@ export interface paths {
     get: operations["GetSlackChannels"];
   };
   "/v1/helicone-sql/schema": {
-    /** @description Get ClickHouse schema (tables and columns) */
+    /**
+     * Get database schema
+     * @description Get ClickHouse schema (tables and columns)
+     */
     get: operations["GetClickHouseSchema"];
   };
   "/v1/helicone-sql/execute": {
+    /**
+     * Execute SQL query
+     * @description Execute a SQL query against ClickHouse
+     */
     post: operations["ExecuteSql"];
   };
   "/v1/helicone-sql/download": {
+    /**
+     * Download query results as CSV
+     * @description Execute a SQL query and download results as CSV
+     */
     post: operations["DownloadCsv"];
   };
   "/v1/helicone-sql/saved-queries": {
+    /**
+     * List saved queries
+     * @description Get all saved queries for the organization
+     */
     get: operations["GetSavedQueries"];
   };
   "/v1/helicone-sql/saved-query/{queryId}": {
+    /**
+     * Get saved query
+     * @description Get a specific saved query by ID
+     */
     get: operations["GetSavedQuery"];
+    /**
+     * Update saved query
+     * @description Update an existing saved query
+     */
+    put: operations["UpdateSavedQuery"];
+    /**
+     * Delete saved query
+     * @description Delete a saved query by ID
+     */
     delete: operations["DeleteSavedQuery"];
   };
   "/v1/helicone-sql/saved-queries/bulk-delete": {
+    /**
+     * Bulk delete saved queries
+     * @description Delete multiple saved queries at once
+     */
     post: operations["BulkDeleteSavedQueries"];
   };
   "/v1/helicone-sql/saved-query": {
-    put: operations["UpdateSavedQuery"];
+    /**
+     * Create saved query
+     * @description Create a new saved query
+     */
     post: operations["CreateSavedQuery"];
   };
   "/v1/experiment/new-empty": {
@@ -3084,11 +3123,6 @@ Json: JsonObject;
       error: null;
     };
     "Result_HqlSavedQuery.string_": components["schemas"]["ResultSuccess_HqlSavedQuery_"] | components["schemas"]["ResultError_string_"];
-    UpdateSavedQueryRequest: {
-      name: string;
-      sql: string;
-      id: string;
-    };
     "ResultSuccess__tableId-string--experimentId-string__": {
       data: {
         experimentId: string;
@@ -6348,9 +6382,13 @@ export interface operations {
       };
     };
   };
+  /**
+   * Returns a comprehensive list of all AI models with their configurations, pricing, and capabilities
+   * @description Get all available models from the registry
+   */
   GetModelRegistry: {
     responses: {
-      /** @description Ok */
+      /** @description Complete model registry with models and filter options */
       200: {
         content: {
           "application/json": components["schemas"]["Result_ModelRegistryResponse.string_"];
@@ -6496,10 +6534,13 @@ export interface operations {
       };
     };
   };
-  /** @description Get ClickHouse schema (tables and columns) */
+  /**
+   * Get database schema
+   * @description Get ClickHouse schema (tables and columns)
+   */
   GetClickHouseSchema: {
     responses: {
-      /** @description Ok */
+      /** @description Array of table schemas with columns */
       200: {
         content: {
           "application/json": components["schemas"]["Result_ClickHouseTableSchema-Array.string_"];
@@ -6507,14 +6548,19 @@ export interface operations {
       };
     };
   };
+  /**
+   * Execute SQL query
+   * @description Execute a SQL query against ClickHouse
+   */
   ExecuteSql: {
+    /** @description The SQL query to execute */
     requestBody: {
       content: {
         "application/json": components["schemas"]["ExecuteSqlRequest"];
       };
     };
     responses: {
-      /** @description Ok */
+      /** @description Query results with rows and metadata */
       200: {
         content: {
           "application/json": components["schemas"]["Result_ExecuteSqlResponse.string_"];
@@ -6522,14 +6568,19 @@ export interface operations {
       };
     };
   };
+  /**
+   * Download query results as CSV
+   * @description Execute a SQL query and download results as CSV
+   */
   DownloadCsv: {
+    /** @description The SQL query to execute */
     requestBody: {
       content: {
         "application/json": components["schemas"]["ExecuteSqlRequest"];
       };
     };
     responses: {
-      /** @description Ok */
+      /** @description URL to download the CSV file */
       200: {
         content: {
           "application/json": components["schemas"]["Result_string.string_"];
@@ -6537,9 +6588,13 @@ export interface operations {
       };
     };
   };
+  /**
+   * List saved queries
+   * @description Get all saved queries for the organization
+   */
   GetSavedQueries: {
     responses: {
-      /** @description Ok */
+      /** @description Array of saved queries */
       200: {
         content: {
           "application/json": components["schemas"]["Result_Array_HqlSavedQuery_.string_"];
@@ -6547,14 +6602,19 @@ export interface operations {
       };
     };
   };
+  /**
+   * Get saved query
+   * @description Get a specific saved query by ID
+   */
   GetSavedQuery: {
     parameters: {
       path: {
+        /** @description The ID of the saved query */
         queryId: string;
       };
     };
     responses: {
-      /** @description Ok */
+      /** @description The saved query details */
       200: {
         content: {
           "application/json": components["schemas"]["Result_HqlSavedQuery-or-null.string_"];
@@ -6562,9 +6622,40 @@ export interface operations {
       };
     };
   };
+  /**
+   * Update saved query
+   * @description Update an existing saved query
+   */
+  UpdateSavedQuery: {
+    parameters: {
+      path: {
+        /** @description The ID of the saved query to update */
+        queryId: string;
+      };
+    };
+    /** @description The updated query details */
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateSavedQueryRequest"];
+      };
+    };
+    responses: {
+      /** @description The updated saved query */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_HqlSavedQuery.string_"];
+        };
+      };
+    };
+  };
+  /**
+   * Delete saved query
+   * @description Delete a saved query by ID
+   */
   DeleteSavedQuery: {
     parameters: {
       path: {
+        /** @description The ID of the saved query to delete */
         queryId: string;
       };
     };
@@ -6577,7 +6668,12 @@ export interface operations {
       };
     };
   };
+  /**
+   * Bulk delete saved queries
+   * @description Delete multiple saved queries at once
+   */
   BulkDeleteSavedQueries: {
+    /** @description Array of query IDs to delete */
     requestBody: {
       content: {
         "application/json": components["schemas"]["BulkDeleteSavedQueriesRequest"];
@@ -6592,29 +6688,19 @@ export interface operations {
       };
     };
   };
-  UpdateSavedQuery: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateSavedQueryRequest"];
-      };
-    };
-    responses: {
-      /** @description Ok */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Result_HqlSavedQuery.string_"];
-        };
-      };
-    };
-  };
+  /**
+   * Create saved query
+   * @description Create a new saved query
+   */
   CreateSavedQuery: {
+    /** @description The saved query details */
     requestBody: {
       content: {
         "application/json": components["schemas"]["CreateSavedQueryRequest"];
       };
     };
     responses: {
-      /** @description Ok */
+      /** @description Array containing the created saved query */
       200: {
         content: {
           "application/json": components["schemas"]["Result_HqlSavedQuery-Array.string_"];


### PR DESCRIPTION
Added API documentation to swagger for the HQL API.
Also bundled into this PR:
API Restructuring: The updateSavedQuery endpoint is refactored from PUT /saved-query to PUT /saved-query/{queryId} to follow RESTful conventions where resource IDs should be in the URL path rather than request body.