### PR TITLE
feat: feature flag as decorator

### DIFF
--- a/valhalla/jawn/src/controllers/public/heliconeSqlController.ts
+++ b/valhalla/jawn/src/controllers/public/heliconeSqlController.ts
@@ -46,6 +46,7 @@ export interface ClickHouseTableColumn {
   ttl_expression?: string;
 }
 
+// TODO DRY these interfaces
 export interface ExecuteSqlRequest {
   sql: string;
 }


### PR DESCRIPTION
This pull request introduces a new `RequireFeatureFlag` decorator to centralize and simplify feature flag enforcement, replacing manual in-method checks.
Context: violation of dry (and annoying) to have to place the same logic for feature flag every time.