### PR TITLE
feat: handle refunds for cloud credits

### DIFF
--- a/bifrost/lib/clients/jawnTypes/private.ts
+++ b/bifrost/lib/clients/jawnTypes/private.ts
@@ -706,6 +706,25 @@ export interface components {
         completion_token: number;
       };
     };
+    PaymentIntentRecord: {
+      id: string;
+      /** Format: double */
+      amount: number;
+      /** Format: double */
+      created: number;
+      status: string;
+      isRefunded?: boolean;
+      /** Format: double */
+      refundedAmount?: number;
+      refundIds?: string[];
+    };
+    StripePaymentIntentsResponse: {
+      data: components["schemas"]["PaymentIntentRecord"][];
+      has_more: boolean;
+      next_page: string | null;
+      /** Format: double */
+      count: number;
+    };
 Json: JsonObject;
     "ResultSuccess__40_Database-at-public_91_Tables_93_-at-organization_91_Row_93_-and-_role-string__41_-Array_": {
       data: (({
@@ -16348,7 +16367,7 @@ export interface operations {
       /** @description Ok */
       200: {
         content: {
-          "application/json": unknown;
+          "application/json": components["schemas"]["StripePaymentIntentsResponse"];
         };
       };
     };

--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -2185,6 +2185,25 @@ Json: JsonObject;
         completion_token: number;
       };
     };
+    PaymentIntentRecord: {
+      id: string;
+      /** Format: double */
+      amount: number;
+      /** Format: double */
+      created: number;
+      status: string;
+      isRefunded?: boolean;
+      /** Format: double */
+      refundedAmount?: number;
+      refundIds?: string[];
+    };
+    StripePaymentIntentsResponse: {
+      data: components["schemas"]["PaymentIntentRecord"][];
+      has_more: boolean;
+      next_page: string | null;
+      /** Format: double */
+      count: number;
+    };
     ValidationError: {
       field: string;
       message: string;
@@ -5878,7 +5897,7 @@ export interface operations {
       /** @description Ok */
       200: {
         content: {
-          "application/json": unknown;
+          "application/json": components["schemas"]["StripePaymentIntentsResponse"];
         };
       };
     };

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5809,6 +5809,74 @@
 				"type": "object",
 				"additionalProperties": false
 			},
+			"PaymentIntentRecord": {
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"amount": {
+						"type": "number",
+						"format": "double"
+					},
+					"created": {
+						"type": "number",
+						"format": "double"
+					},
+					"status": {
+						"type": "string"
+					},
+					"isRefunded": {
+						"type": "boolean"
+					},
+					"refundedAmount": {
+						"type": "number",
+						"format": "double"
+					},
+					"refundIds": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"id",
+					"amount",
+					"created",
+					"status"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"StripePaymentIntentsResponse": {
+				"properties": {
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/PaymentIntentRecord"
+						},
+						"type": "array"
+					},
+					"has_more": {
+						"type": "boolean"
+					},
+					"next_page": {
+						"type": "string",
+						"nullable": true
+					},
+					"count": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"data",
+					"has_more",
+					"next_page",
+					"count"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
 			"ValidationError": {
 				"properties": {
 					"field": {
@@ -16990,7 +17058,9 @@
 						"description": "Ok",
 						"content": {
 							"application/json": {
-								"schema": {}
+								"schema": {
+									"$ref": "#/components/schemas/StripePaymentIntentsResponse"
+								}
 							}
 						}
 					}

--- a/valhalla/jawn/src/controllers/public/stripeController.ts
+++ b/valhalla/jawn/src/controllers/public/stripeController.ts
@@ -47,8 +47,18 @@ export interface SearchPaymentIntentsRequest {
   page?: string;
 }
 
+export interface PaymentIntentRecord {
+  id: string; // Always the payment intent ID
+  amount: number;
+  created: number;
+  status: string;
+  isRefunded?: boolean;
+  refundedAmount?: number;
+  refundIds?: string[];
+}
+
 export interface StripePaymentIntentsResponse {
-  data: Stripe.PaymentIntent[];
+  data: PaymentIntentRecord[];
   has_more: boolean;
   next_page: string | null;
   count: number;
@@ -387,7 +397,7 @@ export class StripeController extends Controller {
     @Query() search_kind: string,
     @Query() limit?: number,
     @Query() page?: string
-  ): Promise<any> {
+  ): Promise<StripePaymentIntentsResponse> {
     // Check if search_kind is valid
     if (!Object.values(PaymentIntentSearchKind).includes(search_kind as PaymentIntentSearchKind)) {
       this.setStatus(400);

--- a/valhalla/jawn/src/managers/inputs/InputsManager.ts
+++ b/valhalla/jawn/src/managers/inputs/InputsManager.ts
@@ -291,7 +291,6 @@ export class InputsManager extends BaseManager {
       `,
       [this.authParams.organizationId, promptVersion, datasetId]
     );
-    console.log("result", result);
     const bodyStore = new RequestResponseBodyStore(
       this.authParams.organizationId
     );

--- a/valhalla/jawn/src/tsoa-build/private/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/private/routes.ts
@@ -298,6 +298,31 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "PaymentIntentRecord": {
+        "dataType": "refObject",
+        "properties": {
+            "id": {"dataType":"string","required":true},
+            "amount": {"dataType":"double","required":true},
+            "created": {"dataType":"double","required":true},
+            "status": {"dataType":"string","required":true},
+            "isRefunded": {"dataType":"boolean"},
+            "refundedAmount": {"dataType":"double"},
+            "refundIds": {"dataType":"array","array":{"dataType":"string"}},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "StripePaymentIntentsResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "data": {"dataType":"array","array":{"dataType":"refObject","ref":"PaymentIntentRecord"},"required":true},
+            "has_more": {"dataType":"boolean","required":true},
+            "next_page": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
+            "count": {"dataType":"double","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Json": {
         "dataType": "refAlias",
         "type": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"double"},{"dataType":"boolean"},{"dataType":"enum","enums":[null]},{"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"dataType":"union","subSchemas":[{"ref":"Json"},{"dataType":"undefined"}]}},{"dataType":"array","array":{"dataType":"refAlias","ref":"Json"}}],"validators":{}},

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -728,6 +728,74 @@
 				"type": "object",
 				"additionalProperties": false
 			},
+			"PaymentIntentRecord": {
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"amount": {
+						"type": "number",
+						"format": "double"
+					},
+					"created": {
+						"type": "number",
+						"format": "double"
+					},
+					"status": {
+						"type": "string"
+					},
+					"isRefunded": {
+						"type": "boolean"
+					},
+					"refundedAmount": {
+						"type": "number",
+						"format": "double"
+					},
+					"refundIds": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"id",
+					"amount",
+					"created",
+					"status"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"StripePaymentIntentsResponse": {
+				"properties": {
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/PaymentIntentRecord"
+						},
+						"type": "array"
+					},
+					"has_more": {
+						"type": "boolean"
+					},
+					"next_page": {
+						"type": "string",
+						"nullable": true
+					},
+					"count": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"data",
+					"has_more",
+					"next_page",
+					"count"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
 			"Json": {
 				"anyOf": [
 					{
@@ -48554,7 +48622,9 @@
 						"description": "Ok",
 						"content": {
 							"application/json": {
-								"schema": {}
+								"schema": {
+									"$ref": "#/components/schemas/StripePaymentIntentsResponse"
+								}
 							}
 						}
 					}

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -1867,6 +1867,31 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "PaymentIntentRecord": {
+        "dataType": "refObject",
+        "properties": {
+            "id": {"dataType":"string","required":true},
+            "amount": {"dataType":"double","required":true},
+            "created": {"dataType":"double","required":true},
+            "status": {"dataType":"string","required":true},
+            "isRefunded": {"dataType":"boolean"},
+            "refundedAmount": {"dataType":"double"},
+            "refundIds": {"dataType":"array","array":{"dataType":"string"}},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "StripePaymentIntentsResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "data": {"dataType":"array","array":{"dataType":"refObject","ref":"PaymentIntentRecord"},"required":true},
+            "has_more": {"dataType":"boolean","required":true},
+            "next_page": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
+            "count": {"dataType":"double","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ValidationError": {
         "dataType": "refObject",
         "properties": {

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -5809,6 +5809,74 @@
 				"type": "object",
 				"additionalProperties": false
 			},
+			"PaymentIntentRecord": {
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"amount": {
+						"type": "number",
+						"format": "double"
+					},
+					"created": {
+						"type": "number",
+						"format": "double"
+					},
+					"status": {
+						"type": "string"
+					},
+					"isRefunded": {
+						"type": "boolean"
+					},
+					"refundedAmount": {
+						"type": "number",
+						"format": "double"
+					},
+					"refundIds": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"id",
+					"amount",
+					"created",
+					"status"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"StripePaymentIntentsResponse": {
+				"properties": {
+					"data": {
+						"items": {
+							"$ref": "#/components/schemas/PaymentIntentRecord"
+						},
+						"type": "array"
+					},
+					"has_more": {
+						"type": "boolean"
+					},
+					"next_page": {
+						"type": "string",
+						"nullable": true
+					},
+					"count": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"data",
+					"has_more",
+					"next_page",
+					"count"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
 			"ValidationError": {
 				"properties": {
 					"field": {
@@ -16990,7 +17058,9 @@
 						"description": "Ok",
 						"content": {
 							"application/json": {
-								"schema": {}
+								"schema": {
+									"$ref": "#/components/schemas/StripePaymentIntentsResponse"
+								}
 							}
 						}
 					}

--- a/web/lib/clients/jawnTypes/private.ts
+++ b/web/lib/clients/jawnTypes/private.ts
@@ -706,6 +706,25 @@ export interface components {
         completion_token: number;
       };
     };
+    PaymentIntentRecord: {
+      id: string;
+      /** Format: double */
+      amount: number;
+      /** Format: double */
+      created: number;
+      status: string;
+      isRefunded?: boolean;
+      /** Format: double */
+      refundedAmount?: number;
+      refundIds?: string[];
+    };
+    StripePaymentIntentsResponse: {
+      data: components["schemas"]["PaymentIntentRecord"][];
+      has_more: boolean;
+      next_page: string | null;
+      /** Format: double */
+      count: number;
+    };
 Json: JsonObject;
     "ResultSuccess__40_Database-at-public_91_Tables_93_-at-organization_91_Row_93_-and-_role-string__41_-Array_": {
       data: (({
@@ -16348,7 +16367,7 @@ export interface operations {
       /** @description Ok */
       200: {
         content: {
-          "application/json": unknown;
+          "application/json": components["schemas"]["StripePaymentIntentsResponse"];
         };
       };
     };

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -2185,6 +2185,25 @@ Json: JsonObject;
         completion_token: number;
       };
     };
+    PaymentIntentRecord: {
+      id: string;
+      /** Format: double */
+      amount: number;
+      /** Format: double */
+      created: number;
+      status: string;
+      isRefunded?: boolean;
+      /** Format: double */
+      refundedAmount?: number;
+      refundIds?: string[];
+    };
+    StripePaymentIntentsResponse: {
+      data: components["schemas"]["PaymentIntentRecord"][];
+      has_more: boolean;
+      next_page: string | null;
+      /** Format: double */
+      count: number;
+    };
     ValidationError: {
       field: string;
       message: string;
@@ -5878,7 +5897,7 @@ export interface operations {
       /** @description Ok */
       200: {
         content: {
-          "application/json": unknown;
+          "application/json": components["schemas"]["StripePaymentIntentsResponse"];
         };
       };
     };

--- a/web/pages/credits.tsx
+++ b/web/pages/credits.tsx
@@ -381,6 +381,35 @@ const Credits: NextPageWithLayout<void> = () => {
 
                               // Determine status display properties
                               const getStatusDisplay = () => {
+                                // Handle fully refunded transactions
+                                if (status === "refunded") {
+                                  return {
+                                    label: "Refunded",
+                                    icon: AlertCircle,
+                                    className:
+                                      "text-amber-600 dark:text-amber-500",
+                                    showAmount: true,
+                                    showNetAmount: false,
+                                  };
+                                }
+
+                                // Handle partially refunded transactions
+                                if (
+                                  transaction.isRefunded &&
+                                  transaction.refundedAmount &&
+                                  transaction.refundedAmount > 0
+                                ) {
+                                  return {
+                                    label: "Partially refunded",
+                                    icon: AlertCircle,
+                                    className:
+                                      "text-amber-600 dark:text-amber-500",
+                                    showAmount: true,
+                                    showNetAmount: true,
+                                  };
+                                }
+
+                                // Handle regular payments
                                 switch (status) {
                                   case "succeeded":
                                     return {
@@ -389,6 +418,7 @@ const Credits: NextPageWithLayout<void> = () => {
                                       className:
                                         "text-green-600 dark:text-green-500",
                                       showAmount: true,
+                                      showNetAmount: false,
                                     };
                                   case "processing":
                                     return {
@@ -397,6 +427,7 @@ const Credits: NextPageWithLayout<void> = () => {
                                       className:
                                         "text-blue-600 dark:text-blue-500",
                                       showAmount: true,
+                                      showNetAmount: false,
                                     };
                                   case "canceled":
                                     return {
@@ -404,6 +435,7 @@ const Credits: NextPageWithLayout<void> = () => {
                                       icon: XCircle,
                                       className: "text-muted-foreground",
                                       showAmount: false,
+                                      showNetAmount: false,
                                     };
                                   case "requires_action":
                                   case "requires_capture":
@@ -415,6 +447,7 @@ const Credits: NextPageWithLayout<void> = () => {
                                       className:
                                         "text-amber-600 dark:text-amber-500",
                                       showAmount: true,
+                                      showNetAmount: false,
                                     };
                                   default:
                                     return {
@@ -423,12 +456,16 @@ const Credits: NextPageWithLayout<void> = () => {
                                       className:
                                         "text-green-600 dark:text-green-500",
                                       showAmount: true,
+                                      showNetAmount: false,
                                     };
                                 }
                               };
 
                               const statusDisplay = getStatusDisplay();
                               const StatusIcon = statusDisplay.icon;
+                              const refundedAmountCents =
+                                transaction.refundedAmount ?? 0;
+                              const netCents = amount - refundedAmountCents;
 
                               return (
                                 <div
@@ -458,14 +495,62 @@ const Credits: NextPageWithLayout<void> = () => {
                                     </div>
                                   </div>
                                   {statusDisplay.showAmount && (
-                                    <div
-                                      className={`text-sm font-medium ${statusDisplay.className}`}
-                                    >
-                                      {status === "succeeded" ? "+" : ""}
-                                      {(amount / 100).toLocaleString("en-US", {
-                                        style: "currency",
-                                        currency: "usd",
-                                      })}
+                                    <div className="flex flex-col items-end gap-0.5">
+                                      {/* Always show original payment amount */}
+                                      <div
+                                        className={`text-sm font-medium ${
+                                          status === "refunded"
+                                            ? "text-muted-foreground line-through"
+                                            : transaction.isRefunded
+                                              ? "text-green-600 dark:text-green-500"
+                                              : statusDisplay.className
+                                        }`}
+                                      >
+                                        {status !== "refunded" &&
+                                        (status === "succeeded" ||
+                                          status === "processing")
+                                          ? "+"
+                                          : ""}
+                                        {(amount / 100).toLocaleString(
+                                          "en-US",
+                                          {
+                                            style: "currency",
+                                            currency: "usd",
+                                          },
+                                        )}
+                                      </div>
+
+                                      {/* Show refunded amount if there are refunds */}
+                                      {transaction.refundedAmount &&
+                                        transaction.refundedAmount > 0 && (
+                                          <div className="text-sm font-medium text-red-600 dark:text-red-500">
+                                            -
+                                            {(
+                                              transaction.refundedAmount / 100
+                                            ).toLocaleString("en-US", {
+                                              style: "currency",
+                                              currency: "usd",
+                                            })}
+                                          </div>
+                                        )}
+
+                                      {/* Show net amount for partially refunded payments */}
+                                      {statusDisplay.showNetAmount &&
+                                        refundedAmountCents > 0 &&
+                                        netCents > 0 && (
+                                          <div className="mt-0.5 border-t border-border pt-0.5">
+                                            <XSmall className="font-medium text-foreground">
+                                              Net: +
+                                              {(netCents / 100).toLocaleString(
+                                                "en-US",
+                                                {
+                                                  style: "currency",
+                                                  currency: "usd",
+                                                },
+                                              )}
+                                            </XSmall>
+                                          </div>
+                                        )}
                                     </div>
                                   )}
                                 </div>

--- a/worker/src/routers/api/apiRouter.ts
+++ b/worker/src/routers/api/apiRouter.ts
@@ -618,6 +618,12 @@ function getAPIRouterV1(
 
       if (handleError) {
         console.error("Error handling webhook event:", handleError);
+        
+        // Check if error is related to insufficient balance (refund exceeds effective balance)
+        if (handleError.includes("Refund amount exceeds effective balance")) {
+          return new Response(handleError, { status: 400 });
+        }
+        
         return new Response("", { status: 500 });
       }
 


### PR DESCRIPTION
one thing to note, is that when we issue refunds via stripe's dashboard, we need to ensure that we refund *less* than what their current effective balance is.

ie, we need to check what they've spent before we refund their whole purchase.

refunding the entire amount, including credits already spent, introduces a lot more complexity we dont want to manage right now