### PR TITLE
feat: datadog traces for hql

### DIFF
--- a/valhalla/jawn/src/controllers/public/heliconeSqlController.ts
+++ b/valhalla/jawn/src/controllers/public/heliconeSqlController.ts
@@ -24,7 +24,7 @@ import {
   HQL_FEATURE_FLAG,
 } from "../../lib/utils/featureFlags";
 import { HqlQueryManager } from "../../managers/HqlQueryManager";
-import tracer from "../../tracer";
+import { TracedController, withActiveSpan } from "../../lib/decorators/tracing";
 
 // --- Response Types ---
 export interface ClickHouseTableSchema {
@@ -89,35 +89,28 @@ export class HeliconeSqlController extends Controller {
    */
   @Security("api_key")
   @Get("schema")
+  @TracedController("hql.controller.getClickHouseSchema", {
+    baseTags: ({ args }) => {
+      const [request] = args as [JawnAuthenticatedRequest];
+      return {
+        organizationId: request.authParams.organizationId,
+        component: "hql",
+        "operation.name": "getClickHouseSchema",
+        "span.kind": "server",
+      };
+    },
+    formatError: formatHqlError,
+    successStatus: 200,
+  })
   public async getClickHouseSchema(
     @Request() request: JawnAuthenticatedRequest
   ): Promise<Result<ClickHouseTableSchema[], string>> {
-    return await tracer.trace("hql.controller.getClickHouseSchema", async (span) => {
-      span.setTag("organizationId", request.authParams.organizationId);
-      span.setTag("component", "hql");
-      span.setTag("operation.name", "getClickHouseSchema");
-      span.setTag("span.kind", "server");
-
-      try {
-        const heliconeSqlManager = new HeliconeSqlManager(request.authParams);
-        const result = await heliconeSqlManager.getClickhouseSchema();
-        
-        if (isError(result)) {
-          span.setTag("error", true);
-          span.setTag("error.type", result.error.code || "unknown");
-          span.setTag("error.message", result.error.message);
-          this.setStatus(result.error.statusCode || 500);
-          return err(formatHqlError(result.error));
-        }
-        
-        span.setTag("schema.table_count", result.data.length);
-        return ok(result.data);
-      } catch (error) {
-        span.setTag("error", true);
-        span.setTag("error.message", error instanceof Error ? error.message : String(error));
-        throw error;
-      }
-    });
+    const heliconeSqlManager = new HeliconeSqlManager(request.authParams);
+    const result = await heliconeSqlManager.getClickhouseSchema();
+    if (isError(result)) {
+      return err(formatHqlError(result.error));
+    }
+    return ok(result.data);
   }
 
   /**
@@ -128,66 +121,45 @@ export class HeliconeSqlController extends Controller {
    */
   @Security("api_key")
   @Post("execute")
+  @TracedController("hql.controller.executeSql", {
+    baseTags: ({ args }) => {
+      const [requestBody, request] = args as [ExecuteSqlRequest, JawnAuthenticatedRequest];
+      return {
+        organizationId: request.authParams.organizationId,
+        service: "helicone-sql",
+        operation: "executeSql",
+        "sql.length": requestBody.sql?.length || 0,
+      };
+    },
+    formatError: formatHqlError,
+    successStatus: 200,
+  })
   public async executeSql(
     @Body() requestBody: ExecuteSqlRequest,
     @Request() request: JawnAuthenticatedRequest
   ): Promise<Result<ExecuteSqlResponse, string>> {
-    return await tracer.trace("hql.controller.executeSql", async (span) => {
-      span.setTag("organizationId", request.authParams.organizationId);
-      span.setTag("service", "helicone-sql");
-      span.setTag("operation", "executeSql");
-      span.setTag("sql.length", requestBody.sql?.length || 0);
+    // Feature flag
+    const featureFlagResult = await checkFeatureFlag(
+      request.authParams.organizationId,
+      HQL_FEATURE_FLAG
+    );
+    if (isError(featureFlagResult)) {
+      const error = createHqlError(HqlErrorCode.FEATURE_NOT_ENABLED);
+      return err(formatHqlError(error));
+    }
 
-      try {
-        // Check feature flag access
-        const featureFlagResult = await checkFeatureFlag(
-          request.authParams.organizationId,
-          HQL_FEATURE_FLAG
-        );
-        if (isError(featureFlagResult)) {
-          const error = createHqlError(HqlErrorCode.FEATURE_NOT_ENABLED);
-          span.setTag("error", true);
-          span.setTag("error.type", "FEATURE_NOT_ENABLED");
-          span.setTag("error.message", error.message);
-          this.setStatus(error.statusCode || 403);
-          return err(formatHqlError(error));
-        }
+    // Validate input
+    if (!requestBody.sql?.trim()) {
+      const error = createHqlError(HqlErrorCode.MISSING_QUERY_SQL);
+      return err(formatHqlError(error));
+    }
 
-        // Validate request
-        if (!requestBody.sql?.trim()) {
-          const error = createHqlError(HqlErrorCode.MISSING_QUERY_SQL);
-          span.setTag("error", true);
-          span.setTag("error.type", "MISSING_QUERY_SQL");
-          span.setTag("error.message", error.message);
-          this.setStatus(error.statusCode || 400);
-          return err(formatHqlError(error));
-        }
-
-        span.setTag("sql.query", requestBody.sql.substring(0, 200)); // First 200 chars for debugging
-        
-        const heliconeSqlManager = new HeliconeSqlManager(request.authParams);
-        const result = await heliconeSqlManager.executeSql(requestBody.sql);
-        
-        if (isError(result)) {
-          span.setTag("error", true);
-          span.setTag("error.type", result.error.code || "unknown");
-          span.setTag("error.message", result.error.message);
-          this.setStatus(result.error.statusCode || 500);
-          return err(formatHqlError(result.error));
-        }
-
-        span.setTag("result.row_count", result.data.rowCount);
-        span.setTag("result.size_bytes", result.data.size);
-        span.setTag("result.elapsed_ms", result.data.elapsedMilliseconds);
-        
-        this.setStatus(200);
-        return ok(result.data);
-      } catch (error) {
-        span.setTag("error", true);
-        span.setTag("error.message", error instanceof Error ? error.message : String(error));
-        throw error;
-      }
-    });
+    const heliconeSqlManager = new HeliconeSqlManager(request.authParams);
+    const result = await heliconeSqlManager.executeSql(requestBody.sql);
+    if (isError(result)) {
+      return err(formatHqlError(result.error));
+    }
+    return ok(result.data);
   }
 
   /**
@@ -198,64 +170,45 @@ export class HeliconeSqlController extends Controller {
    */
   @Security("api_key")
   @Post("download")
+  @TracedController("hql.controller.downloadCsv", {
+    baseTags: ({ args }) => {
+      const [requestBody, request] = args as [ExecuteSqlRequest, JawnAuthenticatedRequest];
+      return {
+        organizationId: request.authParams.organizationId,
+        service: "helicone-sql",
+        operation: "downloadCsv",
+        "sql.length": requestBody.sql?.length || 0,
+      };
+    },
+    formatError: formatHqlError,
+    successStatus: 200,
+  })
   public async downloadCsv(
     @Body() requestBody: ExecuteSqlRequest,
     @Request() request: JawnAuthenticatedRequest
   ): Promise<Result<string, string>> {
-    return await tracer.trace("hql.controller.downloadCsv", async (span) => {
-      span.setTag("organizationId", request.authParams.organizationId);
-      span.setTag("service", "helicone-sql");
-      span.setTag("operation", "downloadCsv");
-      span.setTag("sql.length", requestBody.sql?.length || 0);
+    // Feature flag
+    const featureFlagResult = await checkFeatureFlag(
+      request.authParams.organizationId,
+      HQL_FEATURE_FLAG
+    );
+    if (isError(featureFlagResult)) {
+      const error = createHqlError(HqlErrorCode.FEATURE_NOT_ENABLED);
+      return err(formatHqlError(error));
+    }
 
-      try {
-        // Check feature flag access
-        const featureFlagResult = await checkFeatureFlag(
-          request.authParams.organizationId,
-          HQL_FEATURE_FLAG
-        );
-        if (isError(featureFlagResult)) {
-          const error = createHqlError(HqlErrorCode.FEATURE_NOT_ENABLED);
-          span.setTag("error", true);
-          span.setTag("error.type", "FEATURE_NOT_ENABLED");
-          span.setTag("error.message", error.message);
-          this.setStatus(error.statusCode || 403);
-          return err(formatHqlError(error));
-        }
+    // Validate request
+    if (!requestBody.sql?.trim()) {
+      const error = createHqlError(HqlErrorCode.MISSING_QUERY_SQL, "CSV download requires a SQL query");
+      return err(formatHqlError(error));
+    }
 
-        // Validate request
-        if (!requestBody.sql?.trim()) {
-          const error = createHqlError(HqlErrorCode.MISSING_QUERY_SQL, "CSV download requires a SQL query");
-          span.setTag("error", true);
-          span.setTag("error.type", "MISSING_QUERY_SQL");
-          span.setTag("error.message", error.message);
-          this.setStatus(error.statusCode || 400);
-          return err(formatHqlError(error));
-        }
-
-        span.setTag("sql.query", requestBody.sql.substring(0, 200)); // First 200 chars for debugging
-        
-        const heliconeSqlManager = new HeliconeSqlManager(request.authParams);
-        const result = await heliconeSqlManager.downloadCsv(requestBody.sql);
-        
-        if (isError(result)) {
-          span.setTag("error", true);
-          span.setTag("error.type", result.error.code || "unknown");
-          span.setTag("error.message", result.error.message);
-          this.setStatus(result.error.statusCode || 500);
-          return err(formatHqlError(result.error));
-        }
-
-        span.setTag("download.url_generated", !!result.data);
-        
-        this.setStatus(200);
-        return ok(result.data);
-      } catch (error) {
-        span.setTag("error", true);
-        span.setTag("error.message", error instanceof Error ? error.message : String(error));
-        throw error;
-      }
-    });
+    const heliconeSqlManager = new HeliconeSqlManager(request.authParams);
+    const result = await heliconeSqlManager.downloadCsv(requestBody.sql);
+    if (isError(result)) {
+      return err(formatHqlError(result.error));
+    }
+    return ok(result.data);
   }
 
   /**

--- a/valhalla/jawn/src/lib/decorators/tracing.ts
+++ b/valhalla/jawn/src/lib/decorators/tracing.ts
@@ -1,0 +1,110 @@
+import tracer from "../../tracer";
+import { isError, err, ok } from "../../packages/common/result";
+
+type Tags = Record<string, string | number | boolean | undefined>;
+type TagFactory = (ctx: { thisArg: any; args: any[] }) => Tags | undefined;
+
+export function withActiveSpan() {
+  try {
+    return tracer.scope().active() || null;
+  } catch {
+    return null;
+  }
+}
+
+export function Traced(name: string, baseTags?: Tags | TagFactory) {
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    const original = descriptor.value;
+    descriptor.value = async function (...args: any[]) {
+      return tracer.trace(name, async (span) => {
+        const tags =
+          typeof baseTags === "function" ? baseTags({ thisArg: this, args }) : baseTags;
+        if (tags) {
+          for (const [k, v] of Object.entries(tags)) {
+            if (v !== undefined) span.setTag(k, v);
+          }
+        }
+        try {
+          const res = await original.apply(this, args);
+          if (isError(res)) {
+            const e = (res as any).error;
+            span.setTag("error", true);
+            span.setTag("error.type", e?.code || "unknown");
+            span.setTag("error.message", e?.message);
+          }
+          return res;
+        } catch (e) {
+          span.setTag("error", true);
+          span.setTag("error.type", "UNEXPECTED_ERROR");
+          span.setTag("error.message", e instanceof Error ? e.message : String(e));
+          throw e;
+        }
+      });
+    };
+    return descriptor;
+  };
+}
+
+export function TracedController<TError extends { statusCode?: number; code?: string; message: string }>(
+  name: string,
+  options: {
+    baseTags?: Tags | TagFactory;
+    formatError: (e: TError) => string;
+    successStatus?: number | ((res: any) => number);
+  }
+) {
+  const { baseTags, formatError, successStatus = 200 } = options;
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    const original = descriptor.value;
+    descriptor.value = async function (...args: any[]) {
+      return tracer.trace(name, async (span) => {
+        const tags =
+          typeof baseTags === "function" ? baseTags({ thisArg: this, args }) : baseTags;
+        if (tags) {
+          for (const [k, v] of Object.entries(tags)) {
+            if (v !== undefined) span.setTag(k, v);
+          }
+        }
+        try {
+          const res = await original.apply(this, args);
+          if (isError(res)) {
+            const e = (res as any).error as TError;
+            span.setTag("error", true);
+            span.setTag("error.type", e?.code || "unknown");
+            span.setTag("error.message", e?.message);
+            // "this" is the Controller instance from TSOA
+            if (typeof (this as any).setStatus === "function") {
+              (this as any).setStatus(e?.statusCode || 500);
+            }
+            return err(formatError(e));
+          }
+          const status =
+            typeof successStatus === "function" ? successStatus(res) : successStatus;
+          if (typeof (this as any).setStatus === "function") {
+            (this as any).setStatus(status);
+          }
+          return res;
+        } catch (e) {
+          span.setTag("error", true);
+          span.setTag("error.type", "UNEXPECTED_ERROR");
+          span.setTag("error.message", e instanceof Error ? e.message : String(e));
+          if (typeof (this as any).setStatus === "function") {
+            (this as any).setStatus(500);
+          }
+          return err(formatError({ message: e instanceof Error ? e.message : String(e) } as TError));
+        }
+      });
+    };
+    return descriptor;
+  };
+}
+
+


### PR DESCRIPTION
This pull request introduces comprehensive tracing for HQL. It adds new tracing decorators, applies them to all public endpoints and core logic, and enriches traces with detailed tags for both successful and error cases.
This will give an idea of how customers use HQL.