### PR TITLE
misc: redux devtools

### DIFF
--- a/web/store/requestRenderModeStore.ts
+++ b/web/store/requestRenderModeStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { devtools, persist } from "zustand/middleware";
 
 export const MODE_LABELS = {
   rendered: "Rendered",
@@ -24,17 +24,23 @@ type RequestRenderModeState = {
 };
 
 export const useRequestRenderModeStore = create<RequestRenderModeState>()(
-  persist(
-    (set) => ({
-      mode: "rendered",
-      setMode: (mode) => set({ mode }),
-      toggleMode: (isShiftPressed) =>
-        set((state) => ({
-          mode: isShiftPressed ? "debug" : cycleMode(state.mode),
-        })),
-    }),
+  devtools(
+    persist(
+      (set) => ({
+        mode: "rendered",
+        setMode: (mode) => set({ mode }),
+        toggleMode: (isShiftPressed) =>
+          set((state) => ({
+            mode: isShiftPressed ? "debug" : cycleMode(state.mode),
+          })),
+      }),
+      {
+        name: "helicone-request-render-mode",
+      },
+    ),
     {
-      name: "helicone-request-render-mode",
+      name: "request-render-mode-store",
+      enabled: process.env.NODE_ENV !== "production",
     },
   ),
 );

--- a/web/store/store.ts
+++ b/web/store/store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { devtools } from "zustand/middleware";
 
 type ExperimentsState = {
   openAddExperimentModal: boolean;
@@ -6,7 +7,13 @@ type ExperimentsState = {
 };
 
 // Create store instance once, outside of any component
-export const useExperimentsStore = create<ExperimentsState>()((set) => ({
-  openAddExperimentModal: false,
-  setOpenAddExperimentModal: (open) => set({ openAddExperimentModal: open }),
-}));
+export const useExperimentsStore = create<ExperimentsState>()(
+  devtools(
+    (set) => ({
+      openAddExperimentModal: false,
+      setOpenAddExperimentModal: (open) =>
+        set({ openAddExperimentModal: open }),
+    }),
+    { name: "experiments-store", enabled: process.env.NODE_ENV !== "production" },
+  ),
+);


### PR DESCRIPTION
This pull request introduces the use of the `devtools` middleware from Zustand to two stores in the codebase, enabling easier debugging and state inspection during development.

* Added `devtools` middleware to `useRequestRenderModeStore` in `web/store/requestRenderModeStore.ts`, enabled based on `NODE_ENV`. [[1]](diffhunk://#diff-b6549137693e6e2ab6839e68512ec2a74b911e7654a99ab2721b3520f2439c0fL2-R2) [[2]](diffhunk://#diff-b6549137693e6e2ab6839e68512ec2a74b911e7654a99ab2721b3520f2439c0fR27) [[3]](diffhunk://#diff-b6549137693e6e2ab6839e68512ec2a74b911e7654a99ab2721b3520f2439c0fR41-R45)