### PR TITLE
fix: Broken cost calculation in proxyforwarder

### DIFF
--- a/bifrost/lib/clients/jawnTypes/private.ts
+++ b/bifrost/lib/clients/jawnTypes/private.ts
@@ -15973,7 +15973,7 @@ export interface operations {
         content: {
           "application/json": ({
             /** @enum {string} */
-            providerName: "anthropic" | "openai" | "bedrock" | "vertex" | "azure" | "perplexity" | "groq" | "deepseek" | "cohere" | "xai" | "google-ai-studio" | "openrouter";
+            providerName: "anthropic" | "openai" | "bedrock" | "vertex" | "azure" | "perplexity" | "groq" | "deepseek" | "cohere" | "xai" | "deepinfra" | "google-ai-studio" | "openrouter";
           }) | {
             error: string;
           };

--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -2882,7 +2882,7 @@ Json: JsonObject;
       timeZoneDifference: number;
     };
     /** @enum {string} */
-    ModelProviderName: "anthropic" | "openai" | "bedrock" | "vertex" | "azure" | "perplexity" | "groq" | "deepseek" | "cohere" | "xai" | "google-ai-studio" | "openrouter";
+    ModelProviderName: "anthropic" | "openai" | "bedrock" | "vertex" | "azure" | "perplexity" | "groq" | "deepseek" | "cohere" | "xai" | "deepinfra" | "google-ai-studio" | "openrouter";
     /** @enum {string} */
     AuthorName: "anthropic" | "openai" | "perplexity" | "deepseek" | "cohere" | "xai" | "google" | "meta-llama" | "mistralai" | "amazon" | "microsoft" | "nvidia" | "qwen" | "moonshotai" | "alibaba" | "passthrough";
     /** @enum {string} */
@@ -4128,7 +4128,7 @@ export interface operations {
         content: {
           "application/json": ({
             /** @enum {string} */
-            providerName: "anthropic" | "openai" | "bedrock" | "vertex" | "azure" | "perplexity" | "groq" | "deepseek" | "cohere" | "xai" | "google-ai-studio" | "openrouter";
+            providerName: "anthropic" | "openai" | "bedrock" | "vertex" | "azure" | "perplexity" | "groq" | "deepseek" | "cohere" | "xai" | "deepinfra" | "google-ai-studio" | "openrouter";
           }) | {
             error: string;
           };

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -7841,6 +7841,7 @@
 					"deepseek",
 					"cohere",
 					"xai",
+					"deepinfra",
 					"google-ai-studio",
 					"openrouter"
 				],
@@ -12424,6 +12425,7 @@
 														"deepseek",
 														"cohere",
 														"xai",
+														"deepinfra",
 														"google-ai-studio",
 														"openrouter"
 													]

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -47431,6 +47431,7 @@
 														"deepseek",
 														"cohere",
 														"xai",
+														"deepinfra",
 														"google-ai-studio",
 														"openrouter"
 													]

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -2530,7 +2530,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ModelProviderName": {
         "dataType": "refAlias",
-        "type": {"dataType":"enum","enums":["anthropic","openai","bedrock","vertex","azure","perplexity","groq","deepseek","cohere","xai","google-ai-studio","openrouter"],"validators":{}},
+        "type": {"dataType":"enum","enums":["anthropic","openai","bedrock","vertex","azure","perplexity","groq","deepseek","cohere","xai","deepinfra","google-ai-studio","openrouter"],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "AuthorName": {

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -7841,6 +7841,7 @@
 					"deepseek",
 					"cohere",
 					"xai",
+					"deepinfra",
 					"google-ai-studio",
 					"openrouter"
 				],
@@ -12424,6 +12425,7 @@
 														"deepseek",
 														"cohere",
 														"xai",
+														"deepinfra",
 														"google-ai-studio",
 														"openrouter"
 													]

--- a/web/lib/clients/jawnTypes/private.ts
+++ b/web/lib/clients/jawnTypes/private.ts
@@ -15973,7 +15973,7 @@ export interface operations {
         content: {
           "application/json": ({
             /** @enum {string} */
-            providerName: "anthropic" | "openai" | "bedrock" | "vertex" | "azure" | "perplexity" | "groq" | "deepseek" | "cohere" | "xai" | "google-ai-studio" | "openrouter";
+            providerName: "anthropic" | "openai" | "bedrock" | "vertex" | "azure" | "perplexity" | "groq" | "deepseek" | "cohere" | "xai" | "deepinfra" | "google-ai-studio" | "openrouter";
           }) | {
             error: string;
           };

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -2882,7 +2882,7 @@ Json: JsonObject;
       timeZoneDifference: number;
     };
     /** @enum {string} */
-    ModelProviderName: "anthropic" | "openai" | "bedrock" | "vertex" | "azure" | "perplexity" | "groq" | "deepseek" | "cohere" | "xai" | "google-ai-studio" | "openrouter";
+    ModelProviderName: "anthropic" | "openai" | "bedrock" | "vertex" | "azure" | "perplexity" | "groq" | "deepseek" | "cohere" | "xai" | "deepinfra" | "google-ai-studio" | "openrouter";
     /** @enum {string} */
     AuthorName: "anthropic" | "openai" | "perplexity" | "deepseek" | "cohere" | "xai" | "google" | "meta-llama" | "mistralai" | "amazon" | "microsoft" | "nvidia" | "qwen" | "moonshotai" | "alibaba" | "passthrough";
     /** @enum {string} */
@@ -4128,7 +4128,7 @@ export interface operations {
         content: {
           "application/json": ({
             /** @enum {string} */
-            providerName: "anthropic" | "openai" | "bedrock" | "vertex" | "azure" | "perplexity" | "groq" | "deepseek" | "cohere" | "xai" | "google-ai-studio" | "openrouter";
+            providerName: "anthropic" | "openai" | "bedrock" | "vertex" | "azure" | "perplexity" | "groq" | "deepseek" | "cohere" | "xai" | "deepinfra" | "google-ai-studio" | "openrouter";
           }) | {
             error: string;
           };

--- a/worker/src/lib/HeliconeProxyRequest/ProxyForwarder.ts
+++ b/worker/src/lib/HeliconeProxyRequest/ProxyForwarder.ts
@@ -34,10 +34,10 @@ import {
 } from "./ProxyRequestHandler";
 import { WalletManager } from "../managers/WalletManager";
 import { costOfPrompt } from "@helicone-package/cost";
-import { getUsageProcessor } from "@helicone-package/cost/usage/getUsageProcessor";
 import { EscrowInfo } from "../ai-gateway/types";
+import { CostBreakdown } from "@helicone-package/cost/models/calculate-cost";
+import { getUsageProcessor } from "@helicone-package/cost/usage/getUsageProcessor";
 import { modelCostBreakdownFromRegistry } from "@helicone-package/cost/costCalc";
-import { heliconeProviderToModelProviderName } from "@helicone-package/cost/models/provider-helpers";
 
 export async function proxyForwarder(
   request: RequestWrapper,
@@ -521,11 +521,10 @@ async function log(
       }
 
       const rawResponse = rawResponseResult.data;
-      let cost: number | undefined = undefined;
-      let responseData: any = null;
+      const successfulAttempt =
+        proxyRequest.requestWrapper.getSuccessfulAttempt();
+      let modernCostBreakdown: CostBreakdown | null = null;
 
-      // handle AI Gateway requests (successful Attempt)
-      const successfulAttempt = proxyRequest.requestWrapper.getSuccessfulAttempt();
       if (rawResponse && successfulAttempt) {
         const attemptModel = successfulAttempt.endpoint.providerModelId;
         const attemptProvider = successfulAttempt.endpoint.provider;
@@ -536,82 +535,54 @@ async function log(
             responseBody: rawResponse,
             isStream: proxyRequest.isStream,
           });
-          if (usage.data) {
-            const breakdown = modelCostBreakdownFromRegistry({
+
+          if (usage.error !== null) {
+            console.warn(
+              `Error parsing usage for provider ${attemptProvider}: ${usage.error}`
+            );
+          } else if (usage.data) {
+            modernCostBreakdown = modelCostBreakdownFromRegistry({
               modelUsage: usage.data,
               providerModelId: attemptModel,
               provider: attemptProvider,
             });
-
-            cost = breakdown?.totalCost;
-          } else {
-            console.error(
-              `No usage data found for AI Gateway model ${attemptModel} with provider ${attemptProvider}`
-            );
           }
-        } else {
-          console.error(
-            `No usage processor available for provider ${attemptProvider}`
-          );
         }
+      }
+
+      const responseBodyResult = await loggable.parseRawResponse(rawResponse);
+      if (responseBodyResult.error !== null) {
+        console.error("Error parsing response:", responseBodyResult.error);
+        return;
+      }
+
+      const responseData = responseBodyResult.data;
+      const model = responseData.response.model;
+      const provider = proxyRequest.provider;
+
+      let cost;
+      if (
+        (modernCostBreakdown?.totalCost === undefined ||
+          modernCostBreakdown?.totalCost === null) &&
+        model &&
+        provider
+      ) {
+        cost =
+          costOfPrompt({
+            model,
+            promptTokens: responseData.response.prompt_tokens ?? 0,
+            completionTokens: responseData.response.completion_tokens ?? 0,
+            provider,
+            promptCacheWriteTokens:
+              responseData.response.prompt_cache_write_tokens ?? 0,
+            promptCacheReadTokens:
+              responseData.response.prompt_cache_read_tokens ?? 0,
+            promptAudioTokens: responseData.response.prompt_audio_tokens ?? 0,
+            completionAudioTokens:
+              responseData.response.completion_audio_tokens ?? 0,
+          }) ?? 0;
       } else {
-        // for non AI Gateway requests, we need to fall back to legacy methods when applicable
-        // parse response body to help get usage (legacy method compatibility)
-        const responseBodyResult = await loggable.parseRawResponse(rawResponse);
-        if (responseBodyResult.error !== null) {
-          console.error("Error parsing response:", responseBodyResult.error);
-          // return;
-        }
-        responseData = responseBodyResult.data;
-
-        const model = responseData?.response.model;
-        const provider = proxyRequest.provider;
-
-        if (model && provider && responseData) {
-          // Provider -> ModelProviderName to try and use new registry
-          const modelProviderName = heliconeProviderToModelProviderName(provider);
-
-          if (modelProviderName) {
-            // try usage processor + new registry first
-            const usageProcessor = getUsageProcessor(modelProviderName);
-            
-            if (usageProcessor) {
-              const usage = await usageProcessor.parse({
-                responseBody: rawResponse,
-                isStream: proxyRequest.isStream,
-              });
-
-              if (usage.data) {
-                const breakdown = modelCostBreakdownFromRegistry({
-                  modelUsage: usage.data,
-                  providerModelId: model,
-                  provider: modelProviderName,
-                });
-
-                cost = breakdown?.totalCost;
-              }
-            }
-          }
-
-          // final fallback for providers not in ModelProviderName
-          if (cost === undefined) {
-            cost =
-              costOfPrompt({
-                model,
-                promptTokens: responseData.response.prompt_tokens ?? 0,
-                completionTokens: responseData.response.completion_tokens ?? 0,
-                provider,
-                promptCacheWriteTokens:
-                  responseData.response.prompt_cache_write_tokens ?? 0,
-                promptCacheReadTokens:
-                  responseData.response.prompt_cache_read_tokens ?? 0,
-                promptAudioTokens:
-                  responseData.response.prompt_audio_tokens ?? 0,
-                completionAudioTokens:
-                  responseData.response.completion_audio_tokens ?? 0,
-              }) ?? 0;
-          }
-        }
+        cost = modernCostBreakdown?.totalCost ?? 0;
       }
 
       // Handle escrow finalization if needed
@@ -646,7 +617,7 @@ async function log(
           !orgError &&
           orgData?.organizationId
         ) {
-          const costInCents = (cost ?? 0) * 100;
+          const costInCents = cost * 100;
           await updateRateLimitCounterDO({
             organizationId: orgData?.organizationId,
             heliconeProperties:


### PR DESCRIPTION
there was a regression in the cost calculation in the proxyforwarder, where escrows were never being finalized (and thus spend not being recorded), AND we were attempting to parse the usage even for failed requests (for which the response body would just be an error message without any usage)

the issue with the escrows not being finalized means in prod any requests during this time did not have the spend recorded in the wallet and have these escrows stuck

eg

```
helicone/packages on  tom/eng-3125 [$] via  v24.8.0 via 🐍 v3.13.7 on ☁️   took 7s
λ curl  https://api.worker.helicone.ai/wallet/state -H "Helicone-Auth: Bearer $HELICONE_API_KEY"
{"balance":799.99629,"effectiveBalance":799.14189,"totalEscrow":0.8544,"totalDebits":0.00371,"totalCredits":800,"disallowList":[],"disputeStatus":"active","activeDisputes":[]}⏎
```

