### PR TITLE
fix: use disallowlist when registry cost undefined

### DIFF
--- a/worker/src/lib/HeliconeProxyRequest/ProxyForwarder.ts
+++ b/worker/src/lib/HeliconeProxyRequest/ProxyForwarder.ts
@@ -523,7 +523,6 @@ async function log(
 
       const rawResponse = rawResponseResult.data;
       let cost: number | undefined = undefined;
-      let responseData = null;
 
       // handle AI Gateway requests (successful Attempt)
       const successfulAttempt =
@@ -566,7 +565,7 @@ async function log(
           console.error("Error parsing response:", responseBodyResult.error);
           return;
         }
-        responseData = responseBodyResult.data;
+        const responseData = responseBodyResult.data;
 
         const model = responseData?.response.model;
         const provider = proxyRequest.provider;
@@ -620,7 +619,7 @@ async function log(
       }
 
       // Handle escrow finalization if needed
-      if (responseData && proxyRequest.escrowInfo) {
+      if (proxyRequest.escrowInfo) {
         const walletId = env.WALLET.idFromName(orgData.organizationId);
         const walletStub = env.WALLET.get(walletId);
         const walletManager = new WalletManager(env, ctx, walletStub);


### PR DESCRIPTION
- we want to have harder failures for the AI Gateway PTB requests, so when the new registry cant parse the cost/usage, we should add it to the disallow list to prevent abuse
- if the request is not an ai gateway ptb request, then we should first attempt the new registry parsing, and then fallback, rather than only attempting the new registry parsing for new AI Gateway requests

