### PR TITLE
docs: [ENG-3130] caching docs to explain provider caching with anthropic

### DIFF
--- a/docs/features/advanced-usage/caching.mdx
+++ b/docs/features/advanced-usage/caching.mdx
@@ -6,11 +6,13 @@ sidebarTitle: "Caching"
 
 import QuestionsSection from "/snippets/questions-section.mdx";
 
-When developing and testing LLM applications, you often make the same requests repeatedly during debugging and iteration. Caching stores responses on the edge using Cloudflare Workers, eliminating redundant API calls and reducing both latency and costs.
+When developing and testing LLM applications, you often make the same requests repeatedly during debugging and iteration. Helicone caching stores complete responses on Cloudflare's edge network, eliminating redundant API calls and reducing both latency and costs.
 
-With the AI Gateway, caching works seamlessly across all providers - cache a Claude response and save on Anthropic API calls, or cache GPT-4 responses while testing different models.
+<Note>
+**Looking for provider-level caching?** Learn about [Prompt Caching](/gateway/concepts/prompt-caching) to cache prompts directly on provider servers (OpenAI, Anthropic, etc.) for reduced token costs.
+</Note>
 
-## Why Caching
+## Why Helicone Caching
 
 <CardGroup cols={3}>
 <Card title="Save Money" icon="dollar-sign">
@@ -157,8 +159,12 @@ All header values must be strings. For example, `"Helicone-Cache-Bucket-Max-Size
 ## Examples
 
 <Tabs>
-<Tab title="OpenAI Prompt Caching">
-Combine Helicone caching with OpenAI's native prompt caching by ignoring the `prompt_cache_key` parameter:
+<Tab title="Combined with Provider Caching">
+Use both provider caching and Helicone caching together by ignoring provider-specific cache keys:
+
+<Note>
+Learn more about provider caching [here](/gateway/concepts/prompt-caching).
+</Note>
 
 ```typescript
 const response = await client.chat.completions.create(
@@ -238,57 +244,30 @@ response = client.chat.completions.create(
 </CodeGroup>
 </Tab>
 
-<Tab title="Code Explanation Bot">
-Cache explanations for commonly asked code snippets across your team:
+<Tab title="User-Specific Caching">
+Cache responses separately for different users or contexts:
 
 ```typescript
-// Use a consistent identifier for the code snippet
-const codeIdentifier = `code-${codeSnippet.length}-${codeSnippet.slice(0, 20)}`;
+const userId = "user-123";
 
 const response = await client.chat.completions.create(
   {
-    model: "claude-3.5-sonnet",  // Use any model through the gateway
+    model: "claude-3.5-sonnet",
     messages: [{ 
       role: "user", 
-      content: `Explain this code:\n\n${codeSnippet}` 
+      content: "What are my account settings?" 
     }]
   },
   {
     headers: {
       "Helicone-Cache-Enabled": "true",
-      "Helicone-Cache-Seed": codeIdentifier,    // Same code = same cache
-      "Cache-Control": "max-age=604800"         // Cache for 1 week
+      "Helicone-Cache-Seed": userId,           // User-specific cache
+      "Cache-Control": "max-age=3600"          // Cache for 1 hour
     }
   }
 );
 
-// Multiple developers asking about the same function get instant responses
-```
-</Tab>
-
-<Tab title="Documentation Q&A">
-Cache answers to frequently asked questions about your API or product:
-
-```typescript
-const response = await client.chat.completions.create(
-  {
-    model: "gemini-2.5-flash",  // Use fast, cost-effective models
-    messages: [{ 
-      role: "user", 
-      content: "How do I authenticate with the API?" 
-    }]
-  },
-  {
-    headers: {
-      "Helicone-Cache-Enabled": "true",
-      "Cache-Control": "max-age=86400",          // Cache for 24 hours
-      "Helicone-Cache-Bucket-Max-Size": "1"     // Consistent answers
-    }
-  }
-);
-
-// Common documentation questions get instant, consistent responses
-// Perfect for chatbots, help widgets, and FAQ systems
+// Each user gets their own cached responses
 ```
 </Tab>
 </Tabs>
@@ -448,7 +427,7 @@ const response2 = await openai.chat.completions.create(
 - Ignore tracking IDs that don't affect the response
 - Exclude timestamps for time-independent queries
 - Remove session or user metadata when caching shared content
-- Ignore `prompt_cache_key` when using OpenAI prompt caching alongside Helicone caching
+- Ignore `prompt_cache_key` when using provider caching alongside Helicone caching
 
 ### Cache Limitations
 
@@ -460,6 +439,10 @@ const response2 = await openai.chat.completions.create(
 ## Related Features
 
 <CardGroup cols={2}>
+<Card title="Prompt Caching" icon="server" href="/gateway/concepts/prompt-caching">
+Cache prompts on provider servers for reduced token costs and faster processing
+</Card>
+
 <Card title="Custom Properties" icon="tag" href="/features/advanced-usage/custom-properties">
 Add metadata to cached requests for better filtering and analysis
 </Card>
@@ -470,10 +453,6 @@ Control request frequency and combine with caching for cost optimization
 
 <Card title="User Metrics" icon="chart-line" href="/features/advanced-usage/user-metrics">
 Track cache hit rates and savings per user or application
-</Card>
-
-<Card title="Webhooks" icon="webhook" href="/features/webhooks">
-Get notified about cache performance and optimization opportunities
 </Card>
 </CardGroup>
 

--- a/docs/gateway/concepts/prompt-caching.mdx
+++ b/docs/gateway/concepts/prompt-caching.mdx
@@ -1,22 +1,164 @@
 ---
 title: "Prompt Caching"
-description: "Understanding prompt caching pricing and mechanics across LLM providers"
+description: "Cache frequently-used context across LLM providers for reduced costs and faster responses"
 ---
 
-Prompt caching allows you to cache frequently-used context (system prompts, examples, documents) and reuse it across multiple requests at a discounted rate. This guide explains how caching works and is priced across different providers.
+Prompt caching allows you to cache frequently-used context (system prompts, examples, documents) and reuse it across multiple requests at significantly reduced costs.
 
-## Overview
+## Why Prompt Caching
 
-When you cache content:
-1. **Cache Write**: You pay to store content in the cache (first use)
-2. **Cache Read**: You pay a discounted rate when reusing cached content
-3. **Storage** (Google only): Additional hourly storage costs
+<CardGroup cols={3}>
+<Card title="Reduce Token Costs" icon="dollar-sign">
+  Cached prompts are processed at significantly reduced rates by providers (up to 90% savings)
+</Card>
+<Card title="Faster Processing" icon="bolt">
+  Providers skip re-processing cached prompt segments for faster response times
+</Card>
+<Card title="Automatic Optimization" icon="puzzle-piece">
+  Works out-of-the-box with OpenAI compatible AI Gateway across all providers
+</Card>
+</CardGroup>
+
+---
+
+## OpenAI and Compatible Providers
+
+**Automatic caching** for prompts over 1024 tokens. Use the `prompt_cache_key` parameter for better cache hit control.
+
+**Compatible providers:** OpenAI, Grok, Groq, Deepseek, Moonshot AI, Azure OpenAI
+
+### Quick Start
+
+```typescript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://ai-gateway.helicone.ai",
+  apiKey: process.env.HELICONE_API_KEY,
+});
+
+const response = await client.chat.completions.create({
+  model: "gpt-4o-mini",
+  messages: [
+    {
+      role: "system",
+      content: "Very long system prompt that will be automatically cached..." // 1024+ tokens
+    },
+    {
+      role: "user", 
+      content: "What is machine learning?"
+    }
+  ],
+  prompt_cache_key: `doc-analysis-${documentId}` // Optional: control caching keys
+});
+```
+
+### Pricing
+
+OpenAI charges standard rates for cache writes and offers significant discounts for cache reads. Exact pricing varies by model.
+
+<CardGroup cols={2}>
+    <Card title="Helicone Model Registry" href="https://helicone.ai/models">
+    View supported models and their caching capabilities
+    </Card>
+
+    <Card title="OpenAI Prompt Caching Documentation" href="https://platform.openai.com/docs/guides/prompt-caching">
+    Official OpenAI prompt caching guide
+    </Card>
+</CardGroup>
+
+---
 
 ## Anthropic (Claude)
 
-Anthropic uses a simple multiplier-based pricing model for prompt caching.
+Anthropic provides advanced caching with **cache control breakpoints** (up to 4 per request) and TTL control.
+
+### Using OpenAI SDK with Helicone Types
+
+The `@helicone/helpers` SDK extends OpenAI types to support Anthropic's cache control through the OpenAI-compatible interface:
+
+```bash
+npm install @helicone/helpers
+```
+
+```typescript
+import OpenAI from "openai";
+import { HeliconeChatCreateParams } from "@helicone/helpers";
+
+const client = new OpenAI({
+  baseURL: "https://ai-gateway.helicone.ai",
+  apiKey: process.env.HELICONE_API_KEY,
+});
+
+const response = await client.chat.completions.create({
+  model: "claude-3.5-haiku",
+  messages: [
+    {
+      role: "system",
+      content: "You are a helpful assistant...",
+      cache_control: {
+        type: "ephemeral",
+        ttl: "1h"
+      }
+    },
+    {
+        role: "assistant",
+        content: "Example assistant message.",
+        cache_control: { type: "ephemeral" }
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "This content will be cached.",
+          cache_control: {
+            type: "ephemeral",
+            ttl: "5m"
+          }
+        },
+        {
+          type: "image_url",
+          image_url: {
+            url: "https://example.com/image.jpg",
+            detail: "low"
+          },
+          cache_control: { type: "ephemeral" }
+        }
+      ]
+    }
+  ],
+  temperature: 0.7
+} as HeliconeChatCreateParams);
+```
+
+### Cache Key Mapping
+
+Anthropic uses `user_id` as a cache key on their servers. When using the OpenAI-compatible AI Gateway, these parameters automatically map to Anthropic's `user_id`:
+
+- `prompt_cache_key`
+- `safety_identifier` 
+- `user`
+
+```typescript
+const response = await client.chat.completions.create({
+  model: "claude-3.5-haiku",
+  messages: [/* your messages */],
+  prompt_cache_key: "doc-analysis-v1", // Maps to Anthropic's user_id for cache keying
+  cache_control: {
+    type: "ephemeral", 
+    ttl: "1h"
+  }
+} as HeliconeChatCreateParams);
+```
+
+<Note>
+**Current Limitation**: Anthropic cache control is currently enabled for caching messages only. Support for caching tools is coming soon.
+</Note>
 
 ### Pricing Structure
+
+Anthropic uses a simple multiplier-based pricing model for prompt caching.
 
 | Operation | Multiplier | Example (Claude Sonnet @ $3/MTok) |
 |-----------|------------|-----------------------------------|
@@ -37,6 +179,12 @@ Base input price: $3/MTok
 1-hour cache write: $3 × 2.0 = $6.00/MTok
 Cache read: $3 × 0.1 = $0.30/MTok
 ```
+
+<Card title="Learn More" href="https://docs.claude.com/en/docs/build-with-claude/prompt-caching">
+  Anthropic Prompt Caching Documentation
+</Card>
+
+---
 
 ## Google Gemini
 


### PR DESCRIPTION
Since we've added provider caching with Anthropic via cache control breakpoints to AI Gateway, update the docs accordingly:
<img width="384" height="854" alt="Screenshot 2025-09-18 at 1 23 41 PM" src="https://github.com/user-attachments/assets/91800f09-69c2-4b61-b0ef-c22020985134" />
<img width="420" height="539" alt="Screenshot 2025-09-18 at 1 23 53 PM" src="https://github.com/user-attachments/assets/010b56e2-4862-4da0-b27f-b6d51a7b075a" />
