### PR TITLE
feat: [ENG-3145] add error details via the direct provider response

### DIFF
--- a/packages/cost/models/provider-helpers.ts
+++ b/packages/cost/models/provider-helpers.ts
@@ -11,7 +11,6 @@ import { providers, ModelProviderName } from "./providers";
 import { BaseProvider } from "./providers/base";
 import { Provider } from "@helicone-package/llm-mapper/types";
 
-// Helper function to convert legacy Provider type to ModelProviderName
 export function heliconeProviderToModelProviderName(
   provider: Provider
 ): ModelProviderName | null {
@@ -115,9 +114,6 @@ export const dbProviderToProvider = (
   }
   if (provider === "Azure OpenAI") {
     return "azure";
-  }
-  if (provider === "deepseek" || provider === "DeepSeek") {
-    return "deepseek";
   }
   return null;
 };
@@ -248,4 +244,21 @@ export async function buildRequestBody(
       error instanceof Error ? error.message : "Failed to build request body"
     );
   }
+}
+
+export async function buildErrorMessage(
+  endpoint: Endpoint,
+  response: Response
+): Promise<Result<string>> {
+  const providerResult = getProvider(endpoint.provider);
+  if (providerResult.error) {
+    return err(providerResult.error);
+  }
+
+  const provider = providerResult.data;
+  if (!provider) {
+    return err(`Provider data is null for: ${endpoint.provider}`);
+  }
+
+  return ok(await provider.buildErrorMessage(response));
 }

--- a/packages/cost/models/providers/base.ts
+++ b/packages/cost/models/providers/base.ts
@@ -48,4 +48,12 @@ export abstract class BaseProvider {
       model: endpoint.providerModelId,
     });
   }
+
+  async buildErrorMessage(response: Response): Promise<string> {
+    const respJson = await response.json();
+    if (respJson.error.message) {
+      return respJson.error.message;
+    }
+    return `Request failed with status ${response.status}`;
+  }
 }


### PR DESCRIPTION
Add a `buildErrorMessage` function to the `BaseProvider` that tries pulling `response.error.message` so that error details will be filled accordingly with provider errors, for example:
```
error: {
    code: 'all_attempts_failed',
    message: 'All attempts failed',
    details: '[{"attempt":"claude-3.5-haiku/anthropic/byok","error":"A maximum of 4 blocks with cache_control may be provided. Found 5.","type":"request_failed","statusCode":400}]'
  },
```