### PR TITLE
bug: [ENG-3158] handle body processing normally regardless of isAIGateway

### DIFF
--- a/packages/llm-mapper/utils/getMapperType.ts
+++ b/packages/llm-mapper/utils/getMapperType.ts
@@ -25,17 +25,6 @@ export const getMapperTypeFromHeliconeRequest = (
   heliconeRequest: HeliconeRequest,
   model: string
 ) => {
-  if (heliconeRequest.request_referrer === "ai-gateway") {
-    // catch NO_MAPPING case for Anthropic SDK
-    if (
-      heliconeRequest.provider === "ANTHROPIC" &&
-      heliconeRequest.target_url?.includes("/v1/messages")
-    ) {
-      return "anthropic-chat";
-    }
-    return "openai-chat";
-  }
-
   if (heliconeRequest.request_body?._type === "vector_db") {
     return "vector-db";
   }
@@ -87,10 +76,6 @@ export const getMapperType = ({
     targetUrl.includes("chat/completions") &&
     provider === "GOOGLE"
   ) {
-    return "openai-chat";
-  }
-
-  if (requestReferrer === "ai-gateway") {
     return "openai-chat";
   }
 

--- a/valhalla/jawn/src/lib/handlers/ResponseBodyHandler.ts
+++ b/valhalla/jawn/src/lib/handlers/ResponseBodyHandler.ts
@@ -322,8 +322,6 @@ export class ResponseBodyHandler extends AbstractLogHandler {
         provider,
         responseBody,
         model,
-        log.request.requestReferrer,
-        log.request.targetUrl
       );
       return await parser.parse({
         responseBody: responseBody,
@@ -410,14 +408,8 @@ export class ResponseBodyHandler extends AbstractLogHandler {
     provider: string,
     responseBody: any,
     model?: string,
-    requestReferrer?: string,
-    targetUrl?: string
   ): IBodyProcessor {
-    const isAIGateway = requestReferrer?.includes("ai-gateway");
     if (!isStream) {
-      if (provider === "OPENAI" || isAIGateway) {
-        return new OpenAIBodyProcessor();
-      }
       if (provider === "ANTHROPIC" && responseBody) {
         return new AnthropicBodyProcessor();
       }
@@ -441,9 +433,6 @@ export class ResponseBodyHandler extends AbstractLogHandler {
     }
 
     if (isStream) {
-      if (isAIGateway && !targetUrl?.includes("anthropic.com/v1/messages")) {
-        return new OpenAIStreamProcessor();
-      }
       if (provider === "ANTHROPIC" || model?.includes("claude")) {
         return new AnthropicStreamBodyProcessor();
       }


### PR DESCRIPTION
before we just assumed all AI Gateway requests were OpenAI
assumption is incorrect, because we now store native formats when logging responses (and only pass OpenAI responses to the original call)
