### PR TITLE
feat: [ENG-3174] cleaner error handling, and log when providers not found

### DIFF
--- a/worker/src/lib/HeliconeProxyRequest/ErrorForwarder.ts
+++ b/worker/src/lib/HeliconeProxyRequest/ErrorForwarder.ts
@@ -16,6 +16,7 @@ import { Valhalla } from "../db/valhalla";
 import { RequestResponseManager } from "../managers/RequestResponseManager";
 import { S3Client } from "../clients/S3Client";
 import { HeliconeProducer } from "../clients/producers/HeliconeProducer";
+import { AttemptError } from "../ai-gateway/types";
 
 export async function errorForwarder(
   request: RequestWrapper,
@@ -24,7 +25,7 @@ export async function errorForwarder(
   error: {
     code: string;
     message: string;
-    details?: string;
+    details?: Array<AttemptError>;
     statusCode?: number;
   }
 ) {
@@ -42,6 +43,7 @@ export async function errorForwarder(
         code: error.code,
         message: error.message,
         details: error.details,
+        param: null,
       },
     }),
     status: error.statusCode ?? 500,
@@ -90,6 +92,7 @@ export async function errorForwarder(
             code: error.code,
             message: error.message,
             details: error.details,
+            param: null,
           },
         }),
         {

--- a/worker/src/lib/ai-gateway/types.ts
+++ b/worker/src/lib/ai-gateway/types.ts
@@ -34,8 +34,10 @@ export type AttemptError = {
     | "missing_provider_key"
     | "request_failed"
     | "invalid_prompt"
-    | "model_not_supported";
+    | "model_not_supported"
+    | "disallowed";
   message: string;
   statusCode: number;
+  source?: string;
   details?: string;
 };


### PR DESCRIPTION
for AI Gateway, make everything use the `AttemptError` type. update the gateway so that, if no providers are found, we still will log this to helicone.
+ other misc fixes