### PR TITLE
feat:[ ENG-31887] support for archived endpoint configs in gateway registry

### DIFF
--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -3022,6 +3022,8 @@ Json: JsonObject;
     "Record_string.EndpointConfig_": {
       [key: string]: components["schemas"]["EndpointConfig"];
     };
+    /** @enum {string} */
+    ResponseFormat: "ANTHROPIC" | "OPENAI";
     ModelProviderConfig: {
       pricing: components["schemas"]["ModelPricing"][];
       /** Format: double */
@@ -3039,6 +3041,7 @@ Json: JsonObject;
       crossRegion?: boolean;
       /** Format: double */
       priority?: number;
+      responseFormat?: components["schemas"]["ResponseFormat"];
     };
     UserEndpointConfig: {
       region?: string;

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -8316,6 +8316,13 @@
 				"type": "object",
 				"description": "Construct a type with a set of properties K of type T"
 			},
+			"ResponseFormat": {
+				"type": "string",
+				"enum": [
+					"ANTHROPIC",
+					"OPENAI"
+				]
+			},
 			"ModelProviderConfig": {
 				"properties": {
 					"pricing": {
@@ -8365,6 +8372,9 @@
 					"priority": {
 						"type": "number",
 						"format": "double"
+					},
+					"responseFormat": {
+						"$ref": "#/components/schemas/ResponseFormat"
 					}
 				},
 				"required": [

--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`Registry Snapshots archived endpoints snapshot 1`] = `{}`;
+
 exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
 {
   "alibaba/qwen": {
@@ -4045,6 +4047,7 @@ exports[`Registry Snapshots registry builds correctly 1`] = `
     "qwen3-30b-a3b",
     "qwen3-32b",
   ],
+  "sampleArchivedKeys": [],
   "sampleEndpointIds": [
     "chatgpt-4o-latest:openai:*",
     "chatgpt-4o-latest:openrouter:*",
@@ -4052,6 +4055,7 @@ exports[`Registry Snapshots registry builds correctly 1`] = `
     "claude-3.5-haiku:bedrock:us-east-1",
     "claude-3.5-haiku:openrouter:*",
   ],
+  "totalArchivedConfigs": 0,
   "totalEndpoints": 113,
   "totalModelProviderConfigs": 113,
   "totalModelsWithPtb": 44,

--- a/packages/cost/models/authors/anthropic/claude-3.5-haiku/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-3.5-haiku/endpoints.ts
@@ -34,6 +34,7 @@ export const endpoints = {
     endpointConfigs: {
       "*": {},
     },
+    responseFormat: "ANTHROPIC",
   },
   "claude-3.5-haiku:vertex": {
     provider: "vertex",
@@ -66,6 +67,7 @@ export const endpoints = {
     endpointConfigs: {
       global: {},
     },
+    responseFormat: "ANTHROPIC",
   },
   "claude-3.5-haiku:bedrock": {
     provider: "bedrock",
@@ -99,6 +101,7 @@ export const endpoints = {
     endpointConfigs: {
       "us-east-1": {},
     },
+    responseFormat: "ANTHROPIC",
   },
   "claude-3.5-haiku:openrouter": {
     provider: "openrouter",

--- a/packages/cost/models/authors/anthropic/claude-3.5-sonnet-v2/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-3.5-sonnet-v2/endpoints.ts
@@ -31,6 +31,7 @@ export const endpoints = {
       "stop",
     ],
     ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       "*": {},
     },
@@ -64,6 +65,7 @@ export const endpoints = {
       "stop",
     ],
     ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       global: {
         providerModelId: "claude-3-5-sonnet-v2@20241022",
@@ -99,6 +101,7 @@ export const endpoints = {
       "stop",
     ],
     ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       "us-east-1": {},
     },

--- a/packages/cost/models/authors/anthropic/claude-3.7-sonnet/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-3.7-sonnet/endpoints.ts
@@ -32,6 +32,7 @@ export const endpoints = {
       "stop",
     ],
     ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       "*": {},
     },
@@ -66,6 +67,7 @@ export const endpoints = {
       "stop",
     ],
     ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       global: {},
     },
@@ -99,6 +101,7 @@ export const endpoints = {
       "stop",
     ],
     ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       "us-east-1": {},
     },

--- a/packages/cost/models/authors/anthropic/claude-opus-4-1/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-opus-4-1/endpoints.ts
@@ -32,6 +32,7 @@ export const endpoints = {
       "tool_choice",
     ],
     ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       "*": {},
     },
@@ -66,6 +67,7 @@ export const endpoints = {
       "tools",
       "tool_choice",
     ],
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       global: {
         providerModelId: "claude-opus-4-1@20250805",
@@ -103,6 +105,7 @@ export const endpoints = {
       "top_k",
     ],
     ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       "us-east-1": {},
     },

--- a/packages/cost/models/authors/anthropic/claude-opus-4/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-opus-4/endpoints.ts
@@ -32,6 +32,7 @@ export const endpoints = {
       "tool_choice",
     ],
     ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       "*": {},
     },
@@ -66,6 +67,7 @@ export const endpoints = {
       "tools",
       "tool_choice",
     ],
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       global: {
         providerModelId: "claude-opus-4@20250514",
@@ -103,6 +105,7 @@ export const endpoints = {
       "top_k",
     ],
     ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       "us-east-1": {},
     },

--- a/packages/cost/models/authors/anthropic/claude-sonnet-4/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-sonnet-4/endpoints.ts
@@ -38,6 +38,7 @@ export const endpoints = {
       "tool_choice",
     ],
     ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       "*": {},
     },
@@ -76,6 +77,7 @@ export const endpoints = {
       "tools",
       "tool_choice",
     ],
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       global: {
         providerModelId: "claude-sonnet-4@20250514",
@@ -118,6 +120,7 @@ export const endpoints = {
       "top_k",
     ],
     ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
     endpointConfigs: {
       "us-east-1": {},
     },

--- a/packages/cost/models/build-indexes.ts
+++ b/packages/cost/models/build-indexes.ts
@@ -57,10 +57,12 @@ export interface ModelIndexes {
   modelToProviderData: Map<ModelName, ModelProviderEntry[]>;
   modelProviderToData: Map<ModelProviderConfigId, ModelProviderEntry>;
   providerModelIdToConfig: Map<string, ModelProviderConfig>;
+  modelToArchivedEndpointConfigs: Map<string, ModelProviderConfig>;
 }
 
 export function buildIndexes(
-  modelProviderConfigs: Record<string, ModelProviderConfig>
+  modelProviderConfigs: Record<string, ModelProviderConfig>,
+  archivedModelProviderConfigs: Record<string, ModelProviderConfig> = {}
 ): ModelIndexes {
   const endpointIdToEndpoint: Map<EndpointId, Endpoint> = new Map();
   const endpointConfigIdToEndpointConfig: Map<
@@ -78,6 +80,7 @@ export function buildIndexes(
   const modelToProviderData: Map<ModelName, ModelProviderEntry[]> = new Map();
   const modelProviderToData: Map<ModelProviderConfigId, ModelProviderEntry> = new Map();
   const providerModelIdToConfig: Map<string, ModelProviderConfig> = new Map();
+  const modelToArchivedEndpointConfigs: Map<string, ModelProviderConfig> = new Map();
 
   for (const [configKey, config] of Object.entries(modelProviderConfigs)) {
     const typedConfigKey = configKey as ModelProviderConfigId;
@@ -159,6 +162,10 @@ export function buildIndexes(
     }
   }
 
+  for (const [versionKey, archivedConfig] of Object.entries(archivedModelProviderConfigs)) {
+    modelToArchivedEndpointConfigs.set(versionKey, archivedConfig);
+  }
+
   // Sort endpoints by cost (ascending)
   const sortByCost = (a: Endpoint, b: Endpoint) => {
     const aCost = (a.pricing[0]?.input ?? 0) + (a.pricing[0]?.output ?? 0);
@@ -188,5 +195,6 @@ export function buildIndexes(
     modelToProviderData,
     modelProviderToData,
     providerModelIdToConfig,
+    modelToArchivedEndpointConfigs,
   };
 }

--- a/packages/cost/models/registry.ts
+++ b/packages/cost/models/registry.ts
@@ -58,7 +58,12 @@ const modelProviderConfigs = {
   ...mistralEndpointConfig,
 } satisfies Record<string, ModelProviderConfig>;
 
-const indexes: ModelIndexes = buildIndexes(modelProviderConfigs);
+// Combine all archived endpoints
+const archivedModelProviderConfigs = {
+  // TODO: if any archived endpoints are added, make sure they are included here
+} satisfies Record<string, ModelProviderConfig>;
+
+const indexes: ModelIndexes = buildIndexes(modelProviderConfigs, archivedModelProviderConfigs);
 
 function getAllModelIds(): Result<ModelName[]> {
   return ok(Object.keys(allModels) as ModelName[]);
@@ -207,6 +212,17 @@ function getPtbEndpointsForProvider(
   return ok(topLevelEndpoints);
 }
 
+function getArchivedModelProviderConfig(
+  model: string,
+  provider: ModelProviderName,
+  version: string
+): Result<ModelProviderConfig | null> {
+  const versionKey = `${model}:${provider}:${version}`;
+  const archivedConfig = indexes.modelToArchivedEndpointConfigs.get(versionKey);
+
+  return ok(archivedConfig || null);
+}
+
 export const registry = {
   getAllModelIds,
   getAllModelsWithIds,
@@ -223,4 +239,5 @@ export const registry = {
   getEndpointsByModel,
   getModelProviderEntriesByModel,
   getModelProviderEntry,
+  getArchivedModelProviderConfig,
 };

--- a/packages/cost/models/types.ts
+++ b/packages/cost/models/types.ts
@@ -165,6 +165,7 @@ export interface ModelProviderConfig extends BaseConfig {
   endpointConfigs: Record<string, EndpointConfig>;
   crossRegion?: boolean;
   priority?: number;
+  responseFormat?: ResponseFormat;
 }
 
 export interface EndpointConfig extends UserEndpointConfig {

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -2711,6 +2711,11 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"additionalProperties":{"ref":"EndpointConfig"},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ResponseFormat": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["ANTHROPIC"]},{"dataType":"enum","enums":["OPENAI"]}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ModelProviderConfig": {
         "dataType": "refObject",
         "properties": {
@@ -2727,6 +2732,7 @@ const models: TsoaRoute.Models = {
             "endpointConfigs": {"ref":"Record_string.EndpointConfig_","required":true},
             "crossRegion": {"dataType":"boolean"},
             "priority": {"dataType":"double"},
+            "responseFormat": {"ref":"ResponseFormat"},
         },
         "additionalProperties": false,
     },

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -8316,6 +8316,13 @@
 				"type": "object",
 				"description": "Construct a type with a set of properties K of type T"
 			},
+			"ResponseFormat": {
+				"type": "string",
+				"enum": [
+					"ANTHROPIC",
+					"OPENAI"
+				]
+			},
 			"ModelProviderConfig": {
 				"properties": {
 					"pricing": {
@@ -8365,6 +8372,9 @@
 					"priority": {
 						"type": "number",
 						"format": "double"
+					},
+					"responseFormat": {
+						"$ref": "#/components/schemas/ResponseFormat"
 					}
 				},
 				"required": [

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -3022,6 +3022,8 @@ Json: JsonObject;
     "Record_string.EndpointConfig_": {
       [key: string]: components["schemas"]["EndpointConfig"];
     };
+    /** @enum {string} */
+    ResponseFormat: "ANTHROPIC" | "OPENAI";
     ModelProviderConfig: {
       pricing: components["schemas"]["ModelPricing"][];
       /** Format: double */
@@ -3039,6 +3041,7 @@ Json: JsonObject;
       crossRegion?: boolean;
       /** Format: double */
       priority?: number;
+      responseFormat?: components["schemas"]["ResponseFormat"];
     };
     UserEndpointConfig: {
       region?: string;


### PR DESCRIPTION
Allow for old versions of endpoint configs to preserve snapshots of pricing, response format, etc.
