### PR TITLE
fix: [ENG-3224] safely apply overrides and retrieve on buffer

### DIFF
--- a/worker/RequestBodyBufferContainer/src/app.ts
+++ b/worker/RequestBodyBufferContainer/src/app.ts
@@ -228,9 +228,12 @@ export function createApp(config: AppConfig, logger: any): FastifyInstance {
 
       const applyOverride = (body: any, override: object): object => {
         for (const [key, value] of Object.entries(override)) {
-          if (key in body && typeof value !== "object") {
+          if (typeof value !== "object" || value === null || Array.isArray(value)) {
             body[key] = value;
           } else {
+            if (!body[key] || typeof body[key] !== "object") {
+              body[key] = {};
+            }
             body[key] = applyOverride(body[key], value);
           }
         }

--- a/worker/src/RequestBodyBuffer/IRequestBodyBuffer.ts
+++ b/worker/src/RequestBodyBuffer/IRequestBodyBuffer.ts
@@ -15,6 +15,8 @@ export interface IRequestBodyBuffer {
 
   tempSetBody(body: string): Promise<void>;
 
+  setBodyOverride(override: object): Promise<void>;
+
   // For forwarding to providers without reading into memory when possible.
   getReadableStreamToBody(): Promise<ValidRequestBody>;
 

--- a/worker/src/RequestBodyBuffer/RequestBodyBuffer_InMemory.ts
+++ b/worker/src/RequestBodyBuffer/RequestBodyBuffer_InMemory.ts
@@ -48,6 +48,30 @@ export class RequestBodyBuffer_InMemory implements IRequestBodyBuffer {
     this.cachedText = body;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private applyOverride(body: any, override: object): object {
+    for (const [key, value] of Object.entries(override)) {
+      if (key in body && typeof value !== "object") {
+        body[key] = value;
+      } else {
+        body[key] = this.applyOverride(body[key], value);
+      }
+    }
+    return body;
+  }
+
+  public async setBodyOverride(override: object): Promise<void> {
+    try {
+      const text = await this.unsafeGetRawText();
+      const bodyJson = JSON.parse(text);
+      const modifiedBody = this.applyOverride(bodyJson, override);
+      this.cachedText = JSON.stringify(modifiedBody);
+    } catch (e) {
+      console.error("Failed to apply body override:", e);
+      throw e;
+    }
+  }
+
   // super unsafe and should only be used for cases we know will be smaller bodies
   async unsafeGetRawText(): Promise<string> {
     if (this.cachedText) {
@@ -148,6 +172,7 @@ export class RequestBodyBuffer_InMemory implements IRequestBodyBuffer {
   }
 
   async getReadableStreamToBody(): Promise<string> {
+    // Override is already applied in setBodyOverride, just return cached text
     return await this.unsafeGetRawText();
   }
 

--- a/worker/src/RequestBodyBuffer/RequestBodyBuffer_InMemory.ts
+++ b/worker/src/RequestBodyBuffer/RequestBodyBuffer_InMemory.ts
@@ -51,9 +51,12 @@ export class RequestBodyBuffer_InMemory implements IRequestBodyBuffer {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private applyOverride(body: any, override: object): object {
     for (const [key, value] of Object.entries(override)) {
-      if (key in body && typeof value !== "object") {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
         body[key] = value;
       } else {
+        if (!body[key] || typeof body[key] !== "object") {
+          body[key] = {};
+        }
         body[key] = this.applyOverride(body[key], value);
       }
     }

--- a/worker/src/RequestBodyBuffer/RequestBodyBuffer_Remote.ts
+++ b/worker/src/RequestBodyBuffer/RequestBodyBuffer_Remote.ts
@@ -172,6 +172,17 @@ export class RequestBodyBuffer_Remote implements IRequestBodyBuffer {
       }
     );
   }
+
+  public async setBodyOverride(override: object): Promise<void> {
+    await this.requestBodyBuffer.fetch(
+      `${BASE_URL}/${this.uniqueId}/body-override`,
+      {
+        method: "POST",
+        body: JSON.stringify({ override: override }),
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
   // super unsafe and should only be used for cases we know will be smaller bodies
   async unsafeGetRawText(): Promise<string> {
     console.log(

--- a/worker/src/lib/ai-gateway/SimpleAIGateway.ts
+++ b/worker/src/lib/ai-gateway/SimpleAIGateway.ts
@@ -178,7 +178,8 @@ export class SimpleAIGateway {
     Result<{ modelStrings: string[]; body: any }, Response>
   > {
     // Get raw text body once
-    const rawBody = await this.requestWrapper.unsafeGetText();
+    // TODO: change to use safelyGetBody
+    const rawBody = await this.requestWrapper.unsafeGetBodyText();
     const parsedBody: any = tryJSONParse(rawBody ?? "{}");
 
     if (!parsedBody || !parsedBody.model) {

--- a/worker/src/lib/models/HeliconeProxyRequest.ts
+++ b/worker/src/lib/models/HeliconeProxyRequest.ts
@@ -155,6 +155,13 @@ export class HeliconeProxyRequestMapper {
         isStream || targetUrl.pathname.includes("invoke-with-response-stream");
     }
 
+    let body: ValidRequestBody;
+    try {
+      body = await this.request.safelyGetBody();
+    } catch (e) {
+      body = await this.request.unsafeGetBodyText();
+    }
+
     return {
       data: {
         heliconePromptTemplate: await this.getHeliconeTemplate(),
@@ -173,8 +180,8 @@ export class HeliconeProxyRequestMapper {
         heliconeErrors: this.heliconeErrors,
         api_base,
         isStream: isStream,
-        body: await this.request.requestBodyBuffer.getReadableStreamToBody(),
-        unsafeGetBodyText: this.unsafeGetBody.bind(this),
+        body: body,
+        unsafeGetBodyText: this.request.unsafeGetBodyText.bind(this),
 
         startTime,
         url: this.request.url,
@@ -188,24 +195,6 @@ export class HeliconeProxyRequestMapper {
       },
       error: null,
     };
-  }
-
-  private async unsafeGetBody(): Promise<string | null> {
-    if (this.request.getMethod() === "GET") {
-      return null;
-    }
-
-    if (this.request.heliconeHeaders.featureFlags.streamUsage) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const jsonBody = (await this.request.unsafeGetJson()) as any;
-      if (!jsonBody["stream_options"]) {
-        jsonBody["stream_options"] = {};
-      }
-      jsonBody["stream_options"]["include_usage"] = true;
-      return JSON.stringify(jsonBody);
-    }
-
-    return await this.request.unsafeGetText();
   }
 
   private validateApiConfiguration(api_base: string | undefined): boolean {

--- a/worker/src/lib/models/HeliconeProxyRequest.ts
+++ b/worker/src/lib/models/HeliconeProxyRequest.ts
@@ -181,7 +181,7 @@ export class HeliconeProxyRequestMapper {
         api_base,
         isStream: isStream,
         body: body,
-        unsafeGetBodyText: this.request.unsafeGetBodyText.bind(this),
+        unsafeGetBodyText: this.request.unsafeGetBodyText.bind(this.request),
 
         startTime,
         url: this.request.url,

--- a/worker/src/lib/util/cache/cacheFunctions.ts
+++ b/worker/src/lib/util/cache/cacheFunctions.ts
@@ -50,8 +50,9 @@ export async function kvKeyFromRequest(
   const ignoreKeys =
     request.requestWrapper.heliconeHeaders.cacheHeaders.cacheIgnoreKeys ?? [];
 
+  // TODO: change to use safelyGetBody
   const body = tryGetBodyAndRemoveKeys(
-    await request.requestWrapper.unsafeGetText(),
+    await request.requestWrapper.unsafeGetBodyText(),
     ignoreKeys
   );
 

--- a/worker/test/ai-gateway/test-framework.ts
+++ b/worker/test/ai-gateway/test-framework.ts
@@ -174,15 +174,17 @@ export async function runGatewayTest(
           expect(requestWrapper.getMethod()).toBe(method);
         }
 
-        if (bodyContains && requestWrapper.unsafeGetText) {
-          const body = await requestWrapper.unsafeGetText();
+        // TODO: change to use safelyGetBody
+        if (bodyContains && requestWrapper.unsafeGetBodyText) {
+          const body = await requestWrapper.unsafeGetBodyText();
           for (const text of bodyContains) {
             expect(body).toContain(text);
           }
         }
 
-        if (bodyDoesNotContain && requestWrapper.unsafeGetText) {
-          const body = await requestWrapper.unsafeGetText();
+        // TODO: change to use safelyGetBody
+        if (bodyDoesNotContain && requestWrapper.unsafeGetBodyText) {
+          const body = await requestWrapper.unsafeGetBodyText();
           for (const text of bodyDoesNotContain) {
             expect(body).not.toContain(text);
           }
@@ -190,8 +192,9 @@ export async function runGatewayTest(
       }
 
       // Automatic model validation - validate request body contains expected model
-      if (expectation?.model && requestWrapper.unsafeGetText) {
-        const body = await requestWrapper.unsafeGetText();
+      // TODO: change to use safelyGetBody
+      if (expectation?.model && requestWrapper.unsafeGetBodyText) {
+        const body = await requestWrapper.unsafeGetBodyText();
         try {
           const parsed = JSON.parse(body);
           expect(parsed.model).toBe(expectation.model);

--- a/worker/test/cache/cacheFunctions.spec.ts
+++ b/worker/test/cache/cacheFunctions.spec.ts
@@ -20,7 +20,7 @@ describe("cacheFunctions", () => {
       mockRequest = {
         url: "https://api.openai.com/v1/chat/completions",
         requestWrapper: {
-          unsafeGetText: vi.fn() as Mock<[], Promise<string>>,
+          unsafeGetBodyText: vi.fn() as Mock<[], Promise<string>>,
           getHeaders: vi.fn(() => headers) as Mock<[], Headers>,
           heliconeHeaders: {
             cacheHeaders: {
@@ -44,13 +44,13 @@ describe("cacheFunctions", () => {
         timestamp: "2024-01-01T00:00:00Z",
       });
       
-      (mockRequest.requestWrapper.unsafeGetText as Mock).mockResolvedValue(requestBody);
+      (mockRequest.requestWrapper.unsafeGetBodyText as Mock).mockResolvedValue(requestBody);
 
       const result = await kvKeyFromRequest(mockRequest, 0, null);
 
       // The hash should include the full request body
       expect(result).toContain("hashed_");
-      expect(mockRequest.requestWrapper.unsafeGetText).toHaveBeenCalled();
+      expect(mockRequest.requestWrapper.unsafeGetBodyText).toHaveBeenCalled();
       expect(result).toContain(requestBody);
     });
 
@@ -62,7 +62,7 @@ describe("cacheFunctions", () => {
         timestamp: "2024-01-01T00:00:00Z",
       };
       
-      (mockRequest.requestWrapper.unsafeGetText as Mock).mockResolvedValue(JSON.stringify(requestBody));
+      (mockRequest.requestWrapper.unsafeGetBodyText as Mock).mockResolvedValue(JSON.stringify(requestBody));
       mockRequest.requestWrapper.heliconeHeaders.cacheHeaders.cacheIgnoreKeys = ["request_id", "timestamp"];
 
       const result = await kvKeyFromRequest(mockRequest, 0, null);
@@ -82,7 +82,7 @@ describe("cacheFunctions", () => {
     it("should handle non-JSON body gracefully", async () => {
       const textBody = "This is plain text, not JSON";
       
-      (mockRequest.requestWrapper.unsafeGetText as Mock).mockResolvedValue(textBody);
+      (mockRequest.requestWrapper.unsafeGetBodyText as Mock).mockResolvedValue(textBody);
       mockRequest.requestWrapper.heliconeHeaders.cacheHeaders.cacheIgnoreKeys = ["some_key"];
 
       const result = await kvKeyFromRequest(mockRequest, 0, null);
@@ -99,7 +99,7 @@ describe("cacheFunctions", () => {
         request_id: "unique-123",
       });
       
-      (mockRequest.requestWrapper.unsafeGetText as Mock).mockResolvedValue(requestBody);
+      (mockRequest.requestWrapper.unsafeGetBodyText as Mock).mockResolvedValue(requestBody);
       mockRequest.requestWrapper.heliconeHeaders.cacheHeaders.cacheIgnoreKeys = [];
 
       const result = await kvKeyFromRequest(mockRequest, 0, null);
@@ -120,7 +120,7 @@ describe("cacheFunctions", () => {
         request_id: "top-level-123",
       };
       
-      (mockRequest.requestWrapper.unsafeGetText as Mock).mockResolvedValue(JSON.stringify(requestBody));
+      (mockRequest.requestWrapper.unsafeGetBodyText as Mock).mockResolvedValue(JSON.stringify(requestBody));
       mockRequest.requestWrapper.heliconeHeaders.cacheHeaders.cacheIgnoreKeys = ["request_id"];
 
       const result = await kvKeyFromRequest(mockRequest, 0, null);
@@ -156,10 +156,10 @@ describe("cacheFunctions", () => {
       
       mockRequest.requestWrapper.heliconeHeaders.cacheHeaders.cacheIgnoreKeys = ["request_id"];
 
-      (mockRequest.requestWrapper.unsafeGetText as Mock).mockResolvedValue(requestBody1);
+      (mockRequest.requestWrapper.unsafeGetBodyText as Mock).mockResolvedValue(requestBody1);
       const result1 = await kvKeyFromRequest(mockRequest, 0, null);
 
-      (mockRequest.requestWrapper.unsafeGetText as Mock).mockResolvedValue(requestBody2);
+      (mockRequest.requestWrapper.unsafeGetBodyText as Mock).mockResolvedValue(requestBody2);
       const result2 = await kvKeyFromRequest(mockRequest, 0, null);
 
       // Keys should be different because model is different (not ignored)
@@ -183,10 +183,10 @@ describe("cacheFunctions", () => {
       
       mockRequest.requestWrapper.heliconeHeaders.cacheHeaders.cacheIgnoreKeys = ["request_id", "timestamp"];
 
-      (mockRequest.requestWrapper.unsafeGetText as Mock).mockResolvedValue(requestBody1);
+      (mockRequest.requestWrapper.unsafeGetBodyText as Mock).mockResolvedValue(requestBody1);
       const result1 = await kvKeyFromRequest(mockRequest, 0, null);
 
-      (mockRequest.requestWrapper.unsafeGetText as Mock).mockResolvedValue(requestBody2);
+      (mockRequest.requestWrapper.unsafeGetBodyText as Mock).mockResolvedValue(requestBody2);
       const result2 = await kvKeyFromRequest(mockRequest, 0, null);
 
       // Keys should be the same because only ignored fields are different
@@ -199,7 +199,7 @@ describe("cacheFunctions", () => {
         messages: [{ role: "user", content: "Hello" }],
       });
       
-      (mockRequest.requestWrapper.unsafeGetText as Mock).mockResolvedValue(requestBody);
+      (mockRequest.requestWrapper.unsafeGetBodyText as Mock).mockResolvedValue(requestBody);
 
       const resultWithSeed = await kvKeyFromRequest(mockRequest, 0, "test-seed");
       const resultWithoutSeed = await kvKeyFromRequest(mockRequest, 0, null);
@@ -215,7 +215,7 @@ describe("cacheFunctions", () => {
         messages: [{ role: "user", content: "Hello" }],
       });
       
-      (mockRequest.requestWrapper.unsafeGetText as Mock).mockResolvedValue(requestBody);
+      (mockRequest.requestWrapper.unsafeGetBodyText as Mock).mockResolvedValue(requestBody);
 
       const resultWithIndex0 = await kvKeyFromRequest(mockRequest, 0, null);
       const resultWithIndex1 = await kvKeyFromRequest(mockRequest, 1, null);
@@ -243,7 +243,7 @@ describe("cacheFunctions", () => {
         "Helicone-Cache-Control": "max-age=3600",
       });
       
-      (mockRequest.requestWrapper.unsafeGetText as Mock).mockResolvedValue(requestBody);
+      (mockRequest.requestWrapper.unsafeGetBodyText as Mock).mockResolvedValue(requestBody);
       mockRequest.requestWrapper.headers = googleHeaders;
       mockRequest.requestWrapper.getHeaders = vi.fn(() => googleHeaders);
 

--- a/worker/test/cache/simpleCache.spec.ts
+++ b/worker/test/cache/simpleCache.spec.ts
@@ -54,7 +54,7 @@ describe("Simple Cache Test", () => {
     mockRequest = {
       url: "https://api.openai.com/v1/chat/completions",
       requestWrapper: {
-        unsafeGetText: vi.fn().mockResolvedValue(
+        unsafeGetBodyText: vi.fn().mockResolvedValue(
           JSON.stringify({
             model: "gpt-4",
             messages: [{ role: "user", content: "What is 2+2?" }],
@@ -145,7 +145,7 @@ describe("Simple Cache Test", () => {
       return {
         url: "https://api.openai.com/v1/chat/completions",
         requestWrapper: {
-          unsafeGetText: vi.fn().mockResolvedValue(body),
+          unsafeGetBodyText: vi.fn().mockResolvedValue(body),
           getHeaders: vi.fn(() => headers),
           heliconeHeaders: {
             cacheHeaders: {
@@ -225,7 +225,7 @@ describe("Simple Cache Test", () => {
       request_id: "req-123",
     });
 
-    mockRequest.requestWrapper.unsafeGetText.mockResolvedValue(request1);
+    mockRequest.requestWrapper.unsafeGetBodyText.mockResolvedValue(request1);
     mockRequest.requestWrapper.heliconeHeaders.cacheHeaders.cacheIgnoreKeys = [
       "timestamp",
       "request_id",
@@ -251,7 +251,7 @@ describe("Simple Cache Test", () => {
       request_id: "req-456",
     });
 
-    mockRequest.requestWrapper.unsafeGetText.mockResolvedValue(request2);
+    mockRequest.requestWrapper.unsafeGetBodyText.mockResolvedValue(request2);
 
     // Should hit cache despite different timestamp and request_id
     const cachedResponse = await getCachedResponse(
@@ -272,7 +272,7 @@ describe("Simple Cache Test", () => {
       model: "gpt-4",
       messages: [{ role: "user", content: "Tell me a joke" }],
     });
-    mockRequest.requestWrapper.unsafeGetText.mockResolvedValue(requestBody);
+    mockRequest.requestWrapper.unsafeGetBodyText.mockResolvedValue(requestBody);
 
     // Save 3 different responses in different buckets
     const responses = [


### PR DESCRIPTION
Fix problem where:
- We were not updating stream usage or applying body key overrides to the body before we sent to the provider

Solution:
- Add interface for the RequestBodyBuffers to let you apply body key overrides (allowing us to update the body without loading the whole thing into memory, e.g with modifying the stream usage inclusion parameter)
- For InMemory, just apply override locally
- For Remote, send req to new container endpoint which applies it locally

Then in `HeliconeProxyRequest`, we try to safelyGetBody. 
- If we need to format it to prompts (legacy prompts system) then we can't really avoid loading it into memory so we just bite the bullet and load it. (TODO: fix) If this is the case, then we just cry, load into memory and return.
- Otherwise, we use the body buffer after applying the body overrides.
- HeliconeProxyRequest has function `unsafeGetBodyText` used for prompt security and moderations. In these scenarios, we load into memory - so its bound to the unsafe func.