### PR TITLE
fix: Cast latency to Int32 for correct numeric sorting in ClickHouse

### DIFF
--- a/valhalla/jawn/src/lib/shared/sorts/requests/sorts.test.ts
+++ b/valhalla/jawn/src/lib/shared/sorts/requests/sorts.test.ts
@@ -1,0 +1,35 @@
+import { buildRequestSortClickhouse, SortLeafRequest } from "./sorts";
+
+describe("buildRequestSortClickhouse", () => {
+  it("should cast latency to Int32 for proper numeric sorting", () => {
+    const sort: SortLeafRequest = { latency: "desc" };
+    const result = buildRequestSortClickhouse(sort);
+    expect(result).toBe("toInt32(request_response_rmt.latency) desc");
+  });
+
+  it("should cast latency to Int32 for ascending sort", () => {
+    const sort: SortLeafRequest = { latency: "asc" };
+    const result = buildRequestSortClickhouse(sort);
+    expect(result).toBe("toInt32(request_response_rmt.latency) asc");
+  });
+
+  it("should handle created_at sorting without casting", () => {
+    const sort: SortLeafRequest = { created_at: "desc" };
+    const result = buildRequestSortClickhouse(sort);
+    expect(result).toBe("request_response_rmt.request_created_at desc");
+  });
+
+  it("should handle cost sorting", () => {
+    const sort: SortLeafRequest = { cost: "desc" };
+    const result = buildRequestSortClickhouse(sort);
+    expect(result).toBe("cost desc");
+  });
+
+  it("should handle total_tokens with calculation", () => {
+    const sort: SortLeafRequest = { total_tokens: "desc" };
+    const result = buildRequestSortClickhouse(sort);
+    expect(result).toBe(
+      "(request_response_rmt.prompt_tokens + request_response_rmt.completion_tokens) desc"
+    );
+  });
+});

--- a/valhalla/jawn/src/lib/shared/sorts/requests/sorts.ts
+++ b/valhalla/jawn/src/lib/shared/sorts/requests/sorts.ts
@@ -121,7 +121,7 @@ export function buildRequestSortClickhouse(sort: SortLeafRequest): string {
   }
   if (sort.latency) {
     assertValidSortDirection(sort.latency);
-    return `request_response_rmt.latency ${sort.latency}`;
+    return `toInt32(request_response_rmt.latency) ${sort.latency}`;
   }
   if (sort.total_tokens) {
     assertValidSortDirection(sort.total_tokens);


### PR DESCRIPTION
When sorting requests by latency DESC, the ordering was incorrect because the latency field was being sorted lexicographically (as a string) rather than numerically. This caused values like:
- 120.892s, 113.131s, 129.367s, 94.619s, 89.644s to be sorted incorrectly instead of in proper descending order.

Changes:
- Modified buildRequestSortClickhouse() to cast latency to Int32 in the ORDER BY clause: `toInt32(request_response_rmt.latency)`
- Added comprehensive unit tests for sort functionality
- All tests pass and build succeeds

Fixes: ENG-3171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

