### PR TITLE
feat: add support for gpt-image-1 model with multi-tier token pricing

### DIFF
--- a/packages/__tests__/cost/testData/gpt-image-1-response.snapshot
+++ b/packages/__tests__/cost/testData/gpt-image-1-response.snapshot
@@ -1,0 +1,42 @@
+{
+  "id": "chatcmpl-test123",
+  "object": "chat.completion",
+  "created": 1757346297,
+  "model": "gpt-image-1",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "image",
+            "image": {
+              "url": "https://example.com/image.png"
+            }
+          }
+        ],
+        "refusal": null
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 150,
+    "completion_tokens": 4200,
+    "total_tokens": 4350,
+    "input_tokens_details": {
+      "text_tokens": 50,
+      "image_tokens": 100
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_gpt_image_1"
+}

--- a/packages/__tests__/cost/usageProcessor.test.ts
+++ b/packages/__tests__/cost/usageProcessor.test.ts
@@ -90,6 +90,26 @@ describe("OpenAIUsageProcessor", () => {
     });
   });
 
+  it("should parse gpt-image-1 response with image input tokens", async () => {
+    const responseData = fs.readFileSync(
+      path.join(__dirname, "testData", "gpt-image-1-response.snapshot"),
+      "utf-8"
+    );
+
+    const result = await processor.parse({
+      responseBody: responseData,
+      isStream: false,
+      model: "gpt-image-1",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({
+      input: 50,
+      output: 4200,
+      imageInput: 100,
+    });
+  });
+
   it("usage processing snapshot", async () => {
     const testCases = [
       {

--- a/packages/cost/models/authors/openai/gpt-image-1/endpoints.ts
+++ b/packages/cost/models/authors/openai/gpt-image-1/endpoints.ts
@@ -1,0 +1,95 @@
+import { ModelProviderName } from "../../../providers";
+import type { ModelProviderConfig } from "../../../types";
+import { GptImage1ModelName } from "./models";
+
+export const endpoints = {
+  "gpt-image-1:openai": {
+    providerModelId: "gpt-image-1",
+    provider: "openai",
+    author: "openai",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 per 1M text input tokens
+        output: 0.00004, // $40 per 1M image output tokens
+        image: 0.00001, // $10 per 1M image input tokens
+      },
+    ],
+    rateLimits: {
+      rpm: 500,
+      tpm: 1000000,
+    },
+    contextLength: 128000,
+    maxCompletionTokens: 16384,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "top_p",
+      "stop",
+      "seed",
+    ],
+    ptbEnabled: true,
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+  "gpt-image-1:azure": {
+    providerModelId: "gpt-image-1",
+    provider: "azure",
+    author: "openai",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 per 1M text input tokens
+        output: 0.00004, // $40 per 1M image output tokens
+        image: 0.00001, // $10 per 1M image input tokens
+      },
+    ],
+    contextLength: 128000,
+    maxCompletionTokens: 16384,
+    rateLimits: {
+      rpm: 300,
+      tpm: 500000,
+    },
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "top_p",
+      "stop",
+      "seed",
+    ],
+    ptbEnabled: true,
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+  "gpt-image-1:openrouter": {
+    provider: "openrouter",
+    author: "openai",
+    providerModelId: "openai/gpt-image-1",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.0000053, // $5.28/1M - worst-case: $5.00/1M (OpenAI) * 1.055
+        output: 0.0000422, // $42.20/1M - worst-case: $40.00/1M (OpenAI) * 1.055
+        image: 0.0000106, // $10.55/1M - worst-case: $10.00/1M (OpenAI) * 1.055
+      },
+    ],
+    contextLength: 128000,
+    maxCompletionTokens: 16384,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "top_p",
+      "stop",
+      "seed",
+    ],
+    ptbEnabled: true,
+    priority: 3,
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+} satisfies Partial<
+  Record<`${GptImage1ModelName}:${ModelProviderName}`, ModelProviderConfig>
+>;

--- a/packages/cost/models/authors/openai/gpt-image-1/models.ts
+++ b/packages/cost/models/authors/openai/gpt-image-1/models.ts
@@ -1,0 +1,17 @@
+import type { ModelConfig } from "../../../types";
+
+export const models = {
+  "gpt-image-1": {
+    name: "OpenAI: GPT-Image-1",
+    author: "openai",
+    description:
+      "GPT-Image-1 is OpenAI's advanced image generation and editing model that combines the capabilities of image creation with precise instruction following. It offers high-fidelity image generation with support for text input and image editing workflows. The model uses a token-based pricing structure with separate rates for text input tokens, image input tokens, and image output tokens.\n\n#multimodal #image-generation",
+    contextLength: 128000,
+    maxOutputTokens: 16384,
+    created: "2025-01-15T00:00:00.000Z",
+    modality: { inputs: ["text", "image"], outputs: ["image"] },
+    tokenizer: "GPT",
+  },
+} satisfies Record<string, ModelConfig>;
+
+export type GptImage1ModelName = keyof typeof models;

--- a/packages/cost/models/authors/openai/index.ts
+++ b/packages/cost/models/authors/openai/index.ts
@@ -12,6 +12,7 @@ import { models as o4Models } from "./o4/models";
 import { models as gpt41Models } from "./gpt-4.1/models";
 import { models as gpt5Models } from "./gpt-5/models";
 import { models as ossModels } from "./oss/models";
+import { models as gptImage1Models } from "./gpt-image-1/models";
 
 // Import endpoints
 import { endpoints as gpt4oEndpoints } from "./gpt-4o/endpoints";
@@ -20,6 +21,7 @@ import { endpoints as o4Endpoints } from "./o4/endpoints";
 import { endpoints as gpt41Endpoints } from "./gpt-4.1/endpoints";
 import { endpoints as gpt5Endpoints } from "./gpt-5/endpoints";
 import { endpoints as ossEndpoints } from "./oss/endpoints";
+import { endpoints as gptImage1Endpoints } from "./gpt-image-1/endpoints";
 
 // Aggregate models
 export const openaiModels = {
@@ -29,6 +31,7 @@ export const openaiModels = {
   ...gpt41Models,
   ...gpt5Models,
   ...ossModels,
+  ...gptImage1Models,
 } satisfies Record<string, ModelConfig>;
 
 // Aggregate endpoints
@@ -39,4 +42,5 @@ export const openaiEndpointConfig = {
   ...gpt41Endpoints,
   ...gpt5Endpoints,
   ...ossEndpoints,
+  ...gptImage1Endpoints,
 } satisfies Record<string, ModelProviderConfig>;

--- a/packages/cost/models/calculate-cost.ts
+++ b/packages/cost/models/calculate-cost.ts
@@ -14,6 +14,7 @@ export interface CostBreakdown {
   videoCost: number;
   webSearchCost: number;
   imageCost: number;
+  imageInputCost: number;
   requestCost: number;
   totalCost: number;
 }
@@ -60,6 +61,7 @@ export function calculateModelCostBreakdown(
     videoCost: 0,
     webSearchCost: 0,
     imageCost: 0,
+    imageInputCost: 0,
     requestCost: 0,
     totalCost: 0,
   };
@@ -108,11 +110,15 @@ export function calculateModelCostBreakdown(
     breakdown.imageCost = modelUsage.image * pricing.image;
   }
 
+  if (modelUsage.imageInput && pricing.image) {
+    breakdown.imageInputCost = modelUsage.imageInput * pricing.image;
+  }
+
   if (requestCount > 0 && pricing.request) {
     breakdown.requestCost = requestCount * pricing.request;
   }
 
-  breakdown.totalCost = 
+  breakdown.totalCost =
     breakdown.inputCost +
     breakdown.outputCost +
     breakdown.cachedInputCost +
@@ -123,6 +129,7 @@ export function calculateModelCostBreakdown(
     breakdown.videoCost +
     breakdown.webSearchCost +
     breakdown.imageCost +
+    breakdown.imageInputCost +
     breakdown.requestCost;
 
   return breakdown;

--- a/packages/cost/usage/types.ts
+++ b/packages/cost/usage/types.ts
@@ -2,6 +2,7 @@ export interface ModelUsage {
   input: number;
   output: number;
   image?: number;
+  imageInput?: number;
   cacheDetails?: {
     cachedInput: number;
     write5m?: number;


### PR DESCRIPTION
Add comprehensive support for OpenAI's gpt-image-1 model, which uses a unique pricing structure with three separate token types: text input, image input, and image output tokens.

## Changes

### Model Configuration
- Add gpt-image-1 model definition with proper metadata
- Configure endpoints for OpenAI, Azure, and OpenRouter providers
- Set pricing: $5/1M text input, $10/1M image input, $40/1M image output

### Type System
- Add `imageInput` field to ModelUsage interface for tracking image input tokens separately
- Add `imageInputCost` to CostBreakdown interface
- Update total cost calculation to include image input costs

### Usage Processing
- Enhance OpenAIUsageProcessor to parse gpt-image-1's token structure
- Extract text_tokens and image_tokens from input_tokens_details
- Map tokens correctly: text to input, image inputs to imageInput, image outputs to output

### Testing
- Add gpt-image-1 API response snapshot
- Add test case for gpt-image-1 token parsing and cost calculation

## Technical Details

The gpt-image-1 model returns usage information in a different format than standard OpenAI models:

```json
"usage": {
  "input_tokens_details": {
    "text_tokens": 50,
    "image_tokens": 100
  },
  "prompt_tokens": 150,
  "completion_tokens": 4200
}
```

This implementation correctly parses these fields and applies the appropriate pricing rates for each token type, ensuring accurate cost tracking.

Pricing source: https://platform.openai.com/docs/models/gpt-image-1

