### PR TITLE
Update deepinfra max output tokens

### DIFF
--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -1789,7 +1789,7 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
     "mistral-nemo:deepinfra": {
       "context": 128000,
       "crossRegion": false,
-      "maxTokens": 16400,
+      "maxTokens": 16384,
       "modelId": "mistralai/Mistral-Nemo-Instruct-2407",
       "parameters": [
         "frequency_penalty",
@@ -1815,7 +1815,7 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
     "mistral-small:deepinfra": {
       "context": 128000,
       "crossRegion": false,
-      "maxTokens": 128000,
+      "maxTokens": 16384,
       "modelId": "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
       "parameters": [
         "frequency_penalty",

--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -32,7 +32,7 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
     "qwen3-30b-a3b:deepinfra": {
       "context": 32768,
       "crossRegion": false,
-      "maxTokens": 32768,
+      "maxTokens": 16384,
       "modelId": "Qwen/Qwen3-30B-A3B",
       "parameters": [
         "frequency_penalty",
@@ -750,7 +750,7 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
     "deepseek-reasoner:deepinfra": {
       "context": 128000,
       "crossRegion": false,
-      "maxTokens": 32000,
+      "maxTokens": 16384,
       "modelId": "deepseek-ai/DeepSeek-R1-0528",
       "parameters": [
         "frequency_penalty",
@@ -987,7 +987,7 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
     "deepseek-r1-distill-llama-70b:deepinfra": {
       "context": 131072,
       "crossRegion": false,
-      "maxTokens": 128000,
+      "maxTokens": 16384,
       "modelId": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
       "parameters": [
         "frequency_penalty",
@@ -1332,7 +1332,7 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
     "gemma-3-12b-it:deepinfra": {
       "context": 131072,
       "crossRegion": false,
-      "maxTokens": 8192,
+      "maxTokens": 16384,
       "modelId": "google/gemma-3-12b-it",
       "parameters": [
         "frequency_penalty",
@@ -1409,7 +1409,7 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
     "llama-3.1-8b-instruct-turbo:deepinfra": {
       "context": 128000,
       "crossRegion": false,
-      "maxTokens": 128000,
+      "maxTokens": 16384,
       "modelId": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
       "parameters": [
         "frequency_penalty",
@@ -1435,7 +1435,7 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
     "llama-3.1-8b-instruct:deepinfra": {
       "context": 131072,
       "crossRegion": false,
-      "maxTokens": 131072,
+      "maxTokens": 16384,
       "modelId": "meta-llama/Meta-Llama-3.1-8B-Instruct",
       "parameters": [
         "frequency_penalty",

--- a/packages/cost/models/authors/alibaba/qwen/endpoints.ts
+++ b/packages/cost/models/authors/alibaba/qwen/endpoints.ts
@@ -96,7 +96,7 @@ export const endpoints = {
       tpd: 6000000000,
     },
     contextLength: 32_768,
-    maxCompletionTokens: 32_768,
+    maxCompletionTokens: 16_384,
     supportedParameters: [
       "tools",
       "tool_choice",

--- a/packages/cost/models/authors/deepseek/deepseek-reasoner/endpoints.ts
+++ b/packages/cost/models/authors/deepseek/deepseek-reasoner/endpoints.ts
@@ -90,7 +90,7 @@ export const endpoints = {
       tpd: 6000000000,
     },
     contextLength: 128_000,
-    maxCompletionTokens: 32_000,
+    maxCompletionTokens: 16_384,
     supportedParameters: [
       "max_tokens",
       "temperature",

--- a/packages/cost/models/authors/deepseek/r1-distill/endpoints.ts
+++ b/packages/cost/models/authors/deepseek/r1-distill/endpoints.ts
@@ -88,7 +88,7 @@ export const endpoints = {
       },
     ],
     contextLength: 131_072,
-    maxCompletionTokens: 128_000,
+    maxCompletionTokens: 16_384,
     quantization: "fp8",
     supportedParameters: [
       "max_tokens",

--- a/packages/cost/models/authors/google/gemma-3/endpoints.ts
+++ b/packages/cost/models/authors/google/gemma-3/endpoints.ts
@@ -21,7 +21,7 @@ export const endpoints = {
     },
     quantization: "bf16",
     contextLength: 131_072,
-    maxCompletionTokens: 8_192,
+    maxCompletionTokens: 16_384,
     supportedParameters: [
       "max_tokens",
       "temperature",

--- a/packages/cost/models/authors/meta/llama/endpoints.ts
+++ b/packages/cost/models/authors/meta/llama/endpoints.ts
@@ -100,7 +100,7 @@ export const endpoints = {
       "repetition_penalty",
       "logit_bias",
       "functions",
-      "tools"
+      "tools",
     ],
     ptbEnabled: true,
     endpointConfigs: {
@@ -319,7 +319,7 @@ export const endpoints = {
       "repetition_penalty",
       "logit_bias",
       "functions",
-      "tools"
+      "tools",
     ],
     priority: 2,
     ptbEnabled: true,
@@ -470,7 +470,7 @@ export const endpoints = {
     ],
     quantization: "fp8",
     contextLength: 128_000,
-    maxCompletionTokens: 128_000,
+    maxCompletionTokens: 16_384,
     supportedParameters: [
       "max_tokens",
       "temperature",
@@ -536,7 +536,7 @@ export const endpoints = {
     ],
     quantization: "bf16",
     contextLength: 131_072,
-    maxCompletionTokens: 131_072,
+    maxCompletionTokens: 16_384,
     supportedParameters: [
       "max_tokens",
       "temperature",

--- a/packages/cost/models/authors/mistralai/mistral-nemo/endpoints.ts
+++ b/packages/cost/models/authors/mistralai/mistral-nemo/endpoints.ts
@@ -21,7 +21,7 @@ export const endpoints = {
     },
     quantization: "fp8",
     contextLength: 128_000,
-    maxCompletionTokens: 16_400,
+    maxCompletionTokens: 16_384,
     supportedParameters: [
       "max_tokens",
       "temperature",

--- a/packages/cost/models/authors/mistralai/mistral-small/endpoints.ts
+++ b/packages/cost/models/authors/mistralai/mistral-small/endpoints.ts
@@ -20,7 +20,7 @@ export const endpoints = {
       tpd: 6000000000,
     },
     contextLength: 128_000,
-    maxCompletionTokens: 128_000,
+    maxCompletionTokens: 16_384,
     supportedParameters: [
       "max_tokens",
       "temperature",


### PR DESCRIPTION
Based on information provided by the DeepInfra team and research, they max out output tokens to `16_384` unless otherwise specified in their API.

I've researched all our DeepInfra models and updated their output tokens accordingly!