### PR TITLE
add button to restore deleted properties

### DIFF
--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -429,6 +429,12 @@ export interface paths {
   "/v1/property/hide": {
     post: operations["HideProperty"];
   };
+  "/v1/property/hidden/query": {
+    post: operations["GetHiddenProperties"];
+  };
+  "/v1/property/restore": {
+    post: operations["RestoreProperty"];
+  };
   "/v1/property/{propertyKey}/search": {
     post: operations["SearchProperties"];
   };
@@ -2575,6 +2581,7 @@ Json: JsonObject;
       /** @enum {number|null} */
       error: null;
     };
+    "Result_Property-Array.string_": components["schemas"]["ResultSuccess_Property-Array_"] | components["schemas"]["ResultError_string_"];
     "ResultSuccess__value-string--cost-number_-Array_": {
       data: {
           /** Format: double */
@@ -6456,6 +6463,38 @@ export interface operations {
     };
   };
   HideProperty: {
+    requestBody: {
+      content: {
+        "application/json": {
+          key: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ResultError_string_"] | components["schemas"]["ResultSuccess_unknown-Array_"] | components["schemas"]["ResultSuccess_string_"] | {
+            error: unknown;
+            data: {
+              ok: boolean;
+            };
+          };
+        };
+      };
+    };
+  };
+  GetHiddenProperties: {
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_Property-Array.string_"];
+        };
+      };
+    };
+  };
+  RestoreProperty: {
     requestBody: {
       content: {
         "application/json": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -7266,6 +7266,16 @@
 				"type": "object",
 				"additionalProperties": false
 			},
+			"Result_Property-Array.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_Property-Array_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
 			"ResultSuccess__value-string--cost-number_-Array_": {
 				"properties": {
 					"data": {
@@ -18535,6 +18545,107 @@
 		"/v1/property/hide": {
 			"post": {
 				"operationId": "HideProperty",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/ResultError_string_"
+										},
+										{
+											"$ref": "#/components/schemas/ResultSuccess_unknown-Array_"
+										},
+										{
+											"$ref": "#/components/schemas/ResultSuccess_string_"
+										},
+										{
+											"properties": {
+												"error": {},
+												"data": {
+													"properties": {
+														"ok": {
+															"type": "boolean"
+														}
+													},
+													"required": [
+														"ok"
+													],
+													"type": "object"
+												}
+											},
+											"required": [
+												"error",
+												"data"
+											],
+											"type": "object"
+										}
+									]
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Property"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"properties": {
+									"key": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"key"
+								],
+								"type": "object"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/v1/property/hidden/query": {
+			"post": {
+				"operationId": "GetHiddenProperties",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result_Property-Array.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Property"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": []
+			}
+		},
+		"/v1/property/restore": {
+			"post": {
+				"operationId": "RestoreProperty",
 				"responses": {
 					"200": {
 						"description": "Ok",

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -2363,6 +2363,11 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Result_Property-Array.string_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_Property-Array_"},{"ref":"ResultError_string_"}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ResultSuccess__value-string--cost-number_-Array_": {
         "dataType": "refObject",
         "properties": {
@@ -8827,6 +8832,69 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'hideProperty',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsPropertyController_getHiddenProperties: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+        };
+        app.post('/v1/property/hidden/query',
+            authenticateMiddleware([{"api_key":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(PropertyController)),
+            ...(fetchMiddlewares<RequestHandler>(PropertyController.prototype.getHiddenProperties)),
+
+            async function PropertyController_getHiddenProperties(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsPropertyController_getHiddenProperties, request, response });
+
+                const controller = new PropertyController();
+
+              await templateService.apiHandler({
+                methodName: 'getHiddenProperties',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsPropertyController_restoreProperty: Record<string, TsoaRoute.ParameterSchema> = {
+                requestBody: {"in":"body","name":"requestBody","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"key":{"dataType":"string","required":true}}},
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+        };
+        app.post('/v1/property/restore',
+            authenticateMiddleware([{"api_key":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(PropertyController)),
+            ...(fetchMiddlewares<RequestHandler>(PropertyController.prototype.restoreProperty)),
+
+            async function PropertyController_restoreProperty(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsPropertyController_restoreProperty, request, response });
+
+                const controller = new PropertyController();
+
+              await templateService.apiHandler({
+                methodName: 'restoreProperty',
                 controller,
                 response,
                 next,

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -7266,6 +7266,16 @@
 				"type": "object",
 				"additionalProperties": false
 			},
+			"Result_Property-Array.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess_Property-Array_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
 			"ResultSuccess__value-string--cost-number_-Array_": {
 				"properties": {
 					"data": {
@@ -18535,6 +18545,107 @@
 		"/v1/property/hide": {
 			"post": {
 				"operationId": "HideProperty",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/ResultError_string_"
+										},
+										{
+											"$ref": "#/components/schemas/ResultSuccess_unknown-Array_"
+										},
+										{
+											"$ref": "#/components/schemas/ResultSuccess_string_"
+										},
+										{
+											"properties": {
+												"error": {},
+												"data": {
+													"properties": {
+														"ok": {
+															"type": "boolean"
+														}
+													},
+													"required": [
+														"ok"
+													],
+													"type": "object"
+												}
+											},
+											"required": [
+												"error",
+												"data"
+											],
+											"type": "object"
+										}
+									]
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Property"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"properties": {
+									"key": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"key"
+								],
+								"type": "object"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/v1/property/hidden/query": {
+			"post": {
+				"operationId": "GetHiddenProperties",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result_Property-Array.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Property"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": []
+			}
+		},
+		"/v1/property/restore": {
+			"post": {
+				"operationId": "RestoreProperty",
 				"responses": {
 					"200": {
 						"description": "Ok",

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -429,6 +429,12 @@ export interface paths {
   "/v1/property/hide": {
     post: operations["HideProperty"];
   };
+  "/v1/property/hidden/query": {
+    post: operations["GetHiddenProperties"];
+  };
+  "/v1/property/restore": {
+    post: operations["RestoreProperty"];
+  };
   "/v1/property/{propertyKey}/search": {
     post: operations["SearchProperties"];
   };
@@ -2575,6 +2581,7 @@ Json: JsonObject;
       /** @enum {number|null} */
       error: null;
     };
+    "Result_Property-Array.string_": components["schemas"]["ResultSuccess_Property-Array_"] | components["schemas"]["ResultError_string_"];
     "ResultSuccess__value-string--cost-number_-Array_": {
       data: {
           /** Format: double */
@@ -6456,6 +6463,38 @@ export interface operations {
     };
   };
   HideProperty: {
+    requestBody: {
+      content: {
+        "application/json": {
+          key: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ResultError_string_"] | components["schemas"]["ResultSuccess_unknown-Array_"] | components["schemas"]["ResultSuccess_string_"] | {
+            error: unknown;
+            data: {
+              ok: boolean;
+            };
+          };
+        };
+      };
+    };
+  };
+  GetHiddenProperties: {
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result_Property-Array.string_"];
+        };
+      };
+    };
+  };
+  RestoreProperty: {
     requestBody: {
       content: {
         "application/json": {


### PR DESCRIPTION
## Ticket
[ENG-3284: Restore Deleted Properties button](https://linear.app/helicone/issue/ENG-3284/restore-deleted-properties-button)

## Summary
Add a button on the properties page to restore deleted properties.
On press it opens a modal that shows the user a list of what properties are deleted. then they can restore any of them to see them again in the dashboard

## Context
UI/UX improvements

## Screenshots
<img width="1050" height="536" alt="Screenshot 2025-10-07 at 3 18 10 PM" src="https://github.com/user-attachments/assets/ca52c8a2-799c-4928-a782-364e53c7871c" />
<img width="565" height="245" alt="Screenshot 2025-10-07 at 3 18 32 PM" src="https://github.com/user-attachments/assets/83a59078-4e52-45af-bf36-ca420e124991" />
<img width="533" height="277" alt="Screenshot 2025-10-07 at 3 18 56 PM" src="https://github.com/user-attachments/assets/527a433d-410e-4526-b79d-09c442f59767" />
<img width="540" height="280" alt="Screenshot 2025-10-07 at 3 19 11 PM" src="https://github.com/user-attachments/assets/71f54ae0-191c-481f-82d8-933a3074daa4" />
<img width="532" height="271" alt="Screenshot 2025-10-07 at 3 19 22 PM" src="https://github.com/user-attachments/assets/56ad8059-d789-4ceb-a0b5-0fa80f4fa334" />