### PR TITLE
fix: resolve ClickHouse URL malformation error

### DIFF
--- a/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
@@ -22,14 +22,19 @@ export class ClickhouseClientWrapper {
   private clickHouseHqlClient: ClickHouseClient;
 
   constructor(env: ClickhouseEnv) {
+    // Ensure the host contains the full URL with protocol
+    const clickhouseHost = env.CLICKHOUSE_HOST.startsWith('http') 
+      ? env.CLICKHOUSE_HOST 
+      : `http://${env.CLICKHOUSE_HOST}`;
+    
     this.clickHouseClient = createClient({
-      host: env.CLICKHOUSE_HOST,
+      host: clickhouseHost,
       username: env.CLICKHOUSE_USER,
       password: env.CLICKHOUSE_PASSWORD,
     });
 
     this.clickHouseHqlClient = createClient({
-      host: env.CLICKHOUSE_HOST,
+      host: clickhouseHost,
       username: env.CLICKHOUSE_HQL_USER,
       password: env.CLICKHOUSE_HQL_PASSWORD,
     });


### PR DESCRIPTION
- Update ClickhouseWrapper to ensure host parameter contains full URL with protocol
- Add logic to prefix hostname with http:// if not already present
- Fixes the 'ClickHouse URL is malformed' error that was causing Jawn service crashes (#4770)
- Resolves issue where ClickHouse client received just hostname instead of full URL

The error was occurring because the ClickHouse client was receiving 'helicone-clickhouse' 
instead of 'http://helicone-clickhouse:8123', causing the service to crash repeatedly."