### PR TITLE
add cost support for sonnet 4.5 through openrouter

### DIFF
--- a/packages/cost/providers/openrouter/index.ts
+++ b/packages/cost/providers/openrouter/index.ts
@@ -583,6 +583,18 @@ export const costs: ModelRow[] = [
   {
     model: {
       operator: "equals",
+      value: "anthropic/claude-sonnet-4.5",
+    },
+    cost: {
+      prompt_token: 3e-6,
+      completion_token: 1.5e-5,
+      prompt_cache_read_token: 3e-7,
+      prompt_cache_write_token: 3.75e-6,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
       value: "mistralai/devstral-small-2505:free",
     },
     cost: {
@@ -2132,7 +2144,7 @@ export const costs: ModelRow[] = [
       prompt_cache_write_token: 1.25e-6,
       prompt_cache_creation_5m: 1.25e-6,
       prompt_cache_creation_1h: 2e-6,
-    }
+    },
   },
   {
     model: {


### PR DESCRIPTION
## Sources
<img width="471" height="766" alt="Screenshot 2025-10-15 at 5 36 46 PM" src="https://github.com/user-attachments/assets/b37f86d3-6f6d-4364-844d-e284c65fe4c5" />

went with the <= 200k costs

## Tests
<img width="403" height="71" alt="Screenshot 2025-10-15 at 5 45 07 PM" src="https://github.com/user-attachments/assets/3c74ee59-8fd8-4da7-9e32-3415c68ef57f" />