### PR TITLE
Update the correct naming for llama 3 70b instruct models

### DIFF
--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -1804,31 +1804,6 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
         "*",
       ],
     },
-    "llama-3.3-70b-instruct:groq": {
-      "context": 131072,
-      "crossRegion": false,
-      "maxTokens": 32678,
-      "modelId": "llama-3.3-70b-versatile",
-      "parameters": [
-        "frequency_penalty",
-        "logit_bias",
-        "max_tokens",
-        "min_p",
-        "presence_penalty",
-        "repetition_penalty",
-        "stop",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_k",
-        "top_p",
-      ],
-      "provider": "groq",
-      "ptbEnabled": true,
-      "regions": [
-        "*",
-      ],
-    },
     "llama-3.3-70b-instruct:novita": {
       "context": 131072,
       "crossRegion": false,
@@ -1875,6 +1850,31 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
         "top_p",
       ],
       "provider": "openrouter",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+    "llama-3.3-70b-versatile:groq": {
+      "context": 131072,
+      "crossRegion": false,
+      "maxTokens": 32678,
+      "modelId": "llama-3.3-70b-versatile",
+      "parameters": [
+        "frequency_penalty",
+        "logit_bias",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "repetition_penalty",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p",
+      ],
+      "provider": "groq",
       "ptbEnabled": true,
       "regions": [
         "*",
@@ -5238,9 +5238,14 @@ exports[`Registry Snapshots verify registry state 1`] = `
     {
       "model": "llama-3.3-70b-instruct",
       "providers": [
-        "groq",
         "novita",
         "openrouter",
+      ],
+    },
+    {
+      "model": "llama-3.3-70b-versatile",
+      "providers": [
+        "groq",
       ],
     },
     {
@@ -5479,6 +5484,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
     "llama-3.1-8b-instruct",
     "llama-3.1-8b-instruct-turbo",
     "llama-3.3-70b-instruct",
+    "llama-3.3-70b-versatile",
     "llama-4-maverick",
     "llama-4-scout",
     "llama-guard-4",
@@ -5510,7 +5516,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
   "totalArchivedConfigs": 0,
   "totalEndpoints": 152,
   "totalModelProviderConfigs": 152,
-  "totalModelsWithPtb": 66,
+  "totalModelsWithPtb": 67,
   "totalProviders": 14,
 }
 `;

--- a/packages/cost/models/authors/meta/llama/endpoints.ts
+++ b/packages/cost/models/authors/meta/llama/endpoints.ts
@@ -181,7 +181,7 @@ export const endpoints = {
       "*": {},
     },
   },
-  "llama-3.3-70b-instruct:groq": {
+  "llama-3.3-70b-versatile:groq": {
     providerModelId: "llama-3.3-70b-versatile",
     provider: "groq",
     author: "meta-llama",

--- a/packages/cost/models/authors/meta/llama/models.ts
+++ b/packages/cost/models/authors/meta/llama/models.ts
@@ -34,14 +34,25 @@ export const models = {
     modality: { inputs: ["text", "image"], outputs: ["text"] },
     tokenizer: "GPT",
   },
-  "llama-3.3-70b-instruct": {
+  "llama-3.3-70b-versatile": {
     name: "Meta Llama 3.3 70B Versatile",
     author: "meta-llama",
     description:
-      "Flagship 70B instruction-tuned model for high-quality chat, coding, and reasoning with strong instruction-following and multilingual support.",
+      "Llama-3.3-70B-Versatile is Meta's advanced multilingual large language model, optimized for a wide range of natural language processing tasks. With 70 billion parameters, it offers high performance across various benchmarks while maintaining efficiency suitable for diverse applications.",
     contextLength: 131_072,
     maxOutputTokens: 32_678,
-    created: "2024-12-01T00:00:00.000Z",
+    created: "2024-12-06T00:00:00.000Z",
+    modality: { inputs: ["text"], outputs: ["text"] },
+    tokenizer: "GPT",
+  },
+  "llama-3.3-70b-instruct": {
+    name: "Meta Llama 3.3 70B Instruct",
+    author: "meta-llama",
+    description:
+      "The Meta Llama 3.3 multilingual large language model (LLM) is a pretrained and instruction tuned generative model in 70B (text in/text out). The Llama 3.3 instruction tuned text only model is optimized for multilingual dialogue use cases and outperforms many of the available open source and closed chat models on common industry benchmarks. Supported languages: English, German, French, Italian, Portuguese, Hindi, Spanish, and Thai.",
+    contextLength: 128_000,
+    maxOutputTokens: 16_400,
+    created: "2024-12-06T00:00:00.000Z",
     modality: { inputs: ["text"], outputs: ["text"] },
     tokenizer: "GPT",
   },


### PR DESCRIPTION
We already had the meta-llama/llama-3.3-70b-instruct model integrated, but the naming was wrong because of the groq provider offering the versatile version.

This PR fixes it so we display both.