### PR TITLE
gemma-2-9b-it/chutes

### DIFF
--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -2055,27 +2055,23 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
     },
   },
   "google/gemma": {
-    "gemma2-9b-it:groq": {
+    "gemma2-9b-it:chutes": {
       "context": 8192,
       "crossRegion": false,
       "maxTokens": 8192,
-      "modelId": "gemma2-9b-it",
+      "modelId": "unsloth/gemma-2-9b-it",
       "parameters": [
         "frequency_penalty",
-        "logit_bias",
-        "logprobs",
         "max_tokens",
-        "min_p",
         "presence_penalty",
         "repetition_penalty",
         "seed",
         "stop",
         "temperature",
         "top_k",
-        "top_logprobs",
         "top_p",
       ],
-      "provider": "groq",
+      "provider": "chutes",
       "ptbEnabled": true,
       "regions": [
         "*",
@@ -4603,7 +4599,7 @@ exports[`Registry Snapshots model coverage snapshot 1`] = `
     "vertex",
   ],
   "google/gemma": [
-    "groq",
+    "chutes",
     "openrouter",
   ],
   "google/gemma-3": [
@@ -5757,11 +5753,10 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
     ],
   },
   "google/gemma": {
-    "groq": [
+    "chutes": [
       {
-        "image": 0,
-        "input": 2e-7,
-        "output": 2e-7,
+        "input": 1e-8,
+        "output": 3e-8,
         "threshold": 0,
       },
     ],
@@ -6377,7 +6372,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
     {
       "model": "gemma2-9b-it",
       "providers": [
-        "groq",
+        "chutes",
         "openrouter",
       ],
     },
@@ -6756,7 +6751,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "bedrock",
     },
     {
-      "modelCount": 1,
+      "modelCount": 2,
       "provider": "chutes",
     },
     {
@@ -6772,7 +6767,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "google-ai-studio",
     },
     {
-      "modelCount": 14,
+      "modelCount": 13,
       "provider": "groq",
     },
     {

--- a/packages/cost/models/authors/google/gemma/endpoints.ts
+++ b/packages/cost/models/authors/google/gemma/endpoints.ts
@@ -3,34 +3,29 @@ import type { ModelProviderConfig } from "../../../types";
 import { GemmaModelName } from "./model";
 
 export const endpoints = {
-  "gemma2-9b-it:groq": {
-    providerModelId: "gemma2-9b-it",
-    provider: "groq",
+  "gemma2-9b-it:chutes": {
+    providerModelId: "unsloth/gemma-2-9b-it",
+    provider: "chutes",
     author: "google",
     pricing: [
       {
         threshold: 0,
-        input: 0.0000002,
-        output: 0.0000002,
-        image: 0.0,
+        input: 0.00000001,
+        output: 0.00000003,
       },
     ],
     contextLength: 8192,
     maxCompletionTokens: 8192,
     supportedParameters: [
-      "frequency_penalty",
-      "logit_bias",
-      "logprobs",
       "max_tokens",
-      "min_p",
-      "presence_penalty",
-      "repetition_penalty",
-      "seed",
-      "stop",
       "temperature",
-      "top_k",
-      "top_logprobs",
       "top_p",
+      "stop",
+      "frequency_penalty",
+      "presence_penalty",
+      "seed",
+      "top_k",
+      "repetition_penalty",
     ],
     ptbEnabled: true,
     endpointConfigs: {


### PR DESCRIPTION
Now that Groq removed support for the Gemma 2 9B model, we are replacing it with Chutes support