### PR TITLE
skip PTB attempts if orgID of a request is from THE helicone org

### DIFF
--- a/worker/src/lib/ai-gateway/AttemptBuilder.ts
+++ b/worker/src/lib/ai-gateway/AttemptBuilder.ts
@@ -306,7 +306,9 @@ export class AttemptBuilder {
     plugins?: Plugin[]
   ): Promise<Attempt[]> {
     // Skip PTB if caller org is the master org (same keys as PTB)
+    // (BYOK and PTB keys are identical for the master organization)
     if (orgId === this.env.HELICONE_ORG_ID) {
+      console.debug(`Skipping PTB attempts for master org: ${orgId}`);
       return [];
     }
     // Check if we have PTB endpoints


### PR DESCRIPTION
## Ticket
no ticket

## Summary
skip PTB if the helicone API key that was used for the request is THE helicone org (master org with all keys)

## Context
playground calls use the master helicone org for the 30 monthly free calls

When the user makes requests, it hits duplicate endpoints with duplicate keys.

This happens because the ai gateway attempts calls with BYOK and then PTB, but in the unique case of the master org, BYOK.keys.map() == PTB.keys.map(), so the requests are duplicate

technically its fine to have the extra errors, but the open ai requests were being weird so I wanna see if this fixes prod