### PR TITLE
Update pricing for DeepInfra DeepSeek R1 Distill model 

### DIFF
--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -5567,8 +5567,8 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
   "deepseek/r1-distill": {
     "deepinfra": [
       {
-        "input": 2e-7,
-        "output": 6e-7,
+        "input": 6e-7,
+        "output": 0.0000012,
         "threshold": 0,
       },
     ],

--- a/packages/cost/models/authors/deepseek/r1-distill/endpoints.ts
+++ b/packages/cost/models/authors/deepseek/r1-distill/endpoints.ts
@@ -82,8 +82,8 @@ export const endpoints = {
     pricing: [
       {
         threshold: 0,
-        input: 0.0000002, // $0.20 per 1M tokens
-        output: 0.0000006, // $0.60 per 1M tokens
+        input: 0.0000006, // $0.60 per 1M tokens
+        output: 0.0000012, // $1.20 per 1M tokens
       },
     ],
     contextLength: 131_072,


### PR DESCRIPTION
DeepInfra is updating their pricing on the DeepInfra R1 Distill model starting November 6th. 

<img width="1732" height="1244" alt="image" src="https://github.com/user-attachments/assets/211c27ea-a711-4baf-b071-e775669e88e4" />
