### PR TITLE
fix: [ENG-3339] parse json schema and show errors in playground editors

### DIFF
--- a/web/components/templates/playground/components/ToolsConfigurationModal.tsx
+++ b/web/components/templates/playground/components/ToolsConfigurationModal.tsx
@@ -13,8 +13,8 @@ import { FlaskConicalIcon, PlusIcon, Trash2, WrenchIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Tool } from "@helicone-package/llm-mapper/types";
 import MarkdownEditor from "@/components/shared/markdownEditor";
-import { logger } from "@/lib/telemetry/logger";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import useNotification from "@/components/shared/notification/useNotification";
 import clsx from "clsx";
 import {
   Tooltip,
@@ -45,6 +45,7 @@ export default function ToolsConfigurationModal({
     tools ? (tools.length > 0 ? 0 : null) : null,
   );
   const [currentTools, setCurrentTools] = useState<Tool[]>(tools || []);
+  const { setNotification } = useNotification();
 
   useEffect(() => {
     setSelectedToolIndex(tools ? (tools.length > 0 ? 0 : null) : null);
@@ -353,7 +354,7 @@ export default function ToolsConfigurationModal({
                   }
                   setToolsDialogOpen(false);
                 } catch (error) {
-                  logger.error("Invalid JSON");
+                  setNotification("Invalid JSON", "error");
                 }
               }}
             >


### PR DESCRIPTION
## Ticket
https://linear.app/helicone/issue/ENG-3339/improve-error-handling-in-prompts-dashboard-for-tool-setup


Just makes it shows `Invalid JSON` if the input is invalid when you save