### PR TITLE
docs: fix Docker self-hosting curl example

### DIFF
--- a/docs/getting-started/self-host/docker.mdx
+++ b/docs/getting-started/self-host/docker.mdx
@@ -15,7 +15,7 @@ docker run -d --name helicone-all-in-one -p 3000:3000 -p 8585:8585 -p 5432:5432 
 
 ## Example to test the Jawn service
 ```bash
-curl --location 'https://localhost:8585/jawn/v1/gateway/oai/v1/completions' \
+curl --location 'http://localhost:8585/v1/gateway/oai/v1/completions' \
 --header "Content-Type: application/json" \
 --header "Authorization: Bearer {{OPENAI_API_KEY}}" \
 --header "Helicone-Auth: Bearer {{HELICONE_API_KEY}}" \


### PR DESCRIPTION
Fixes the Docker self-hosting documentation curl example that currently doesn't work.

**Changes:**
- Change `https://` to `http://` (Docker setup runs on HTTP only)  
- Remove `/jawn` prefix from endpoint path (not used in actual API routes)

**Before:**
```bash
curl --location 'https://localhost:8585/jawn/v1/gateway/oai/v1/completions'
# Returns: curl: (35) LibreSSL/3.3.6: error:1404B42E:SSL routines:ST_CONNECT:tlsv1 alert protocol version
```

**After SSL fix only:**
```bash
curl --location 'http://localhost:8585/jawn/v1/gateway/oai/v1/completions'
# Returns: {"error":"No API key found","trace":"isAuthenticated.error"}
```

**After both fixes:**  
```bash
curl --location 'http://localhost:8585/v1/gateway/oai/v1/completions'  
# Returns: {"error":{"message":"Incorrect API key provided: sk-test123...","type":"invalid_request_error"}}
```

Fixes #5242 and #5244