### PR TITLE
feat: [ENG-3478] Add check for empty messages on Anthropic reqs

### DIFF
--- a/packages/llm-mapper/transform/providers/openai/request/toAnthropic.ts
+++ b/packages/llm-mapper/transform/providers/openai/request/toAnthropic.ts
@@ -48,6 +48,12 @@ export function toAnthropic(
     antBody.system = system;
   }
 
+  if (antBody.messages.length === 0) {
+    throw new Error(
+      "Request with Anthropic models must contain at least one non-system message."
+    );
+  }
+
   const user_id =
     openAIBody.safety_identifier ||
     openAIBody.prompt_cache_key ||


### PR DESCRIPTION
https://linear.app/helicone/issue/ENG-3478/add-fix-for-claude-api-call-to-documentation

Prevents the confusing Anthropic API error "messages must have at least one element" when users send only system messages, which get mapped to the system field leaving the messages array empty.

Changes:
- add validation in toAnthropic() after system message extraction
- throw rror message explaining the issue and how to fix it
- Propagate the error back