### PR TITLE
Display tiered pricing with thresholds on models page

### DIFF
--- a/bifrost/app/models/ModelRegistryPage.tsx
+++ b/bifrost/app/models/ModelRegistryPage.tsx
@@ -602,18 +602,66 @@ export function ModelRegistryPage() {
                                   {formatContext(model.contextLength)} context
                                 </div>
                                 <div className="hidden sm:block">•</div>
-                                <div className="flex flex-wrap gap-1">
-                                  <span>
-                                    ${minInputCost < 1
-                                      ? minInputCost.toFixed(2)
-                                      : minInputCost.toFixed(1)}/M in
-                                  </span>
-                                  <span className="hidden sm:inline">,</span>
-                                  <span>
-                                    ${minOutputCost < 1
-                                      ? minOutputCost.toFixed(2)
-                                      : minOutputCost.toFixed(1)}/M out
-                                  </span>
+                                <div className="flex flex-col gap-1">
+                                  {(() => {
+                                    // Find the endpoint with pricing tiers that has the lowest base price
+                                    const endpointWithTiers = model.endpoints.find(
+                                      (e) => e.pricingTiers && e.pricingTiers.length > 1
+                                    );
+
+                                    if (endpointWithTiers?.pricingTiers) {
+                                      // Display each pricing tier with threshold
+                                      return endpointWithTiers.pricingTiers.map((tier, idx) => {
+                                        const inputCost = tier.prompt;
+                                        const outputCost = tier.completion;
+                                        const threshold = tier.threshold;
+
+                                        let thresholdLabel = "";
+                                        if (idx === 0) {
+                                          if (endpointWithTiers.pricingTiers!.length > 1) {
+                                            const nextThreshold = endpointWithTiers.pricingTiers![1].threshold;
+                                            thresholdLabel = ` (<=${formatContext(nextThreshold || 0)})`;
+                                          }
+                                        } else {
+                                          thresholdLabel = ` (>=${formatContext(threshold || 0)})`;
+                                        }
+
+                                        return (
+                                          <div key={idx} className="flex flex-wrap gap-1">
+                                            <span>
+                                              ${inputCost < 1
+                                                ? inputCost.toFixed(2)
+                                                : inputCost.toFixed(1)}/M in
+                                            </span>
+                                            <span className="hidden sm:inline">,</span>
+                                            <span>
+                                              ${outputCost < 1
+                                                ? outputCost.toFixed(2)
+                                                : outputCost.toFixed(1)}/M out
+                                            </span>
+                                            {thresholdLabel && <span>{thresholdLabel}</span>}
+                                          </div>
+                                        );
+                                      });
+                                    }
+
+                                    // Fallback to single pricing display if no tiers
+                                    return (
+                                      <div className="flex flex-wrap gap-1">
+                                        <span>
+                                          ${minInputCost < 1
+                                            ? minInputCost.toFixed(2)
+                                            : minInputCost.toFixed(1)}/M in
+                                        </span>
+                                        <span className="hidden sm:inline">,</span>
+                                        <span>
+                                          ${minOutputCost < 1
+                                            ? minOutputCost.toFixed(2)
+                                            : minOutputCost.toFixed(1)}/M out
+                                        </span>
+                                      </div>
+                                    );
+                                  })()}
                                 </div>
                               </div>
                             </div>


### PR DESCRIPTION
## Summary

Updates the `/models` page in bifrost to display pricing tiers with threshold information for models that have tiered pricing (e.g., Claude Sonnet 4).

## Changes

- Modified `ModelRegistryPage.tsx` to check if a model has multiple pricing tiers via the `pricingTiers` field
- When tiers exist, displays each tier with appropriate threshold labels
- First tier shows `(<=Xk)` where X is the next tier's threshold
- Subsequent tiers show `(>=Xk)` where X is the current tier's threshold
- Falls back to original single-price display for models without tiers

## Example Output

For Claude Sonnet 4:
- **Before:** `$3.0/M in, $15.0/M out`
- **After:**
  - `$3.0/M in, $15.0/M out (<=200k)`
  - `$6.0/M in, $22.5/M out (>=200k)`

## Technical Details

- Uses the existing `pricingTiers` data already provided by the backend API
- Leverages the existing `formatContext()` helper to format threshold values
- Maintains the same layout and styling as the current implementation
- Fully backwards compatible with models that have single-tier pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)