### PR TITLE
Add Claude Opus 4.5 model to registries

### DIFF
--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -1261,6 +1261,90 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
       ],
     },
   },
+  "anthropic/claude-opus-4-5": {
+    "claude-opus-4-5:anthropic": {
+      "context": 200000,
+      "crossRegion": false,
+      "maxTokens": 64000,
+      "modelId": "claude-opus-4-5",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "anthropic",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+    "claude-opus-4-5:bedrock": {
+      "context": 200000,
+      "crossRegion": true,
+      "maxTokens": 64000,
+      "modelId": "anthropic.claude-opus-4-5-20251101-v1:0",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p",
+      ],
+      "provider": "bedrock",
+      "ptbEnabled": true,
+      "regions": [
+        "us-east-1",
+      ],
+    },
+    "claude-opus-4-5:openrouter": {
+      "context": 200000,
+      "crossRegion": false,
+      "maxTokens": 64000,
+      "modelId": "anthropic/claude-opus-4.5",
+      "parameters": [
+        "max_tokens",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p",
+      ],
+      "provider": "openrouter",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+    "claude-opus-4-5:vertex": {
+      "context": 200000,
+      "crossRegion": true,
+      "maxTokens": 64000,
+      "modelId": "claude-opus-4-5@20251101",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "vertex",
+      "ptbEnabled": true,
+      "regions": [
+        "global",
+      ],
+    },
+  },
   "anthropic/claude-sonnet-4": {
     "claude-sonnet-4:anthropic": {
       "context": 200000,
@@ -5072,6 +5156,12 @@ exports[`Registry Snapshots model coverage snapshot 1`] = `
     "openrouter",
     "vertex",
   ],
+  "anthropic/claude-opus-4-5": [
+    "anthropic",
+    "bedrock",
+    "openrouter",
+    "vertex",
+  ],
   "anthropic/claude-sonnet-4": [
     "anthropic",
     "bedrock",
@@ -5923,6 +6013,53 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
         },
         "input": 0.000015,
         "output": 0.000075,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+  },
+  "anthropic/claude-opus-4-5": {
+    "anthropic": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write1h": 2,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+    "bedrock": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+    "openrouter": [
+      {
+        "input": 0.000005275,
+        "output": 0.000026375,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+    "vertex": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
         "threshold": 0,
         "web_search": 0.01,
       },
@@ -6961,6 +7098,15 @@ exports[`Registry Snapshots verify registry state 1`] = `
       ],
     },
     {
+      "model": "claude-opus-4-5",
+      "providers": [
+        "anthropic",
+        "bedrock",
+        "openrouter",
+        "vertex",
+      ],
+    },
+    {
       "model": "claude-sonnet-4",
       "providers": [
         "anthropic",
@@ -7516,7 +7662,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
   ],
   "providerBreakdown": [
     {
-      "modelCount": 12,
+      "modelCount": 13,
       "provider": "anthropic",
     },
     {
@@ -7528,7 +7674,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "baseten",
     },
     {
-      "modelCount": 11,
+      "modelCount": 12,
       "provider": "bedrock",
     },
     {
@@ -7580,7 +7726,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "openai",
     },
     {
-      "modelCount": 53,
+      "modelCount": 54,
       "provider": "openrouter",
     },
     {
@@ -7588,7 +7734,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "perplexity",
     },
     {
-      "modelCount": 15,
+      "modelCount": 16,
       "provider": "vertex",
     },
     {
@@ -7608,6 +7754,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
     "claude-opus-4",
     "claude-opus-4-1",
     "claude-opus-4-1-20250805",
+    "claude-opus-4-5",
     "claude-sonnet-4",
     "claude-sonnet-4-5-20250929",
     "codex-mini-latest",
@@ -7694,9 +7841,9 @@ exports[`Registry Snapshots verify registry state 1`] = `
     "claude-3.5-haiku:anthropic:*",
   ],
   "totalArchivedConfigs": 0,
-  "totalEndpoints": 223,
-  "totalModelProviderConfigs": 223,
-  "totalModelsWithPtb": 87,
+  "totalEndpoints": 227,
+  "totalModelProviderConfigs": 227,
+  "totalModelsWithPtb": 88,
   "totalProviders": 20,
 }
 `;

--- a/packages/cost/models/authors/anthropic/claude-opus-4-5/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-opus-4-5/endpoints.ts
@@ -1,0 +1,147 @@
+import { ModelProviderName } from "../../../providers";
+import type { ModelProviderConfig } from "../../../types";
+import { ClaudeOpus45ModelName } from "./model";
+
+export const endpoints = {
+  "claude-opus-4-5:anthropic": {
+    providerModelId: "claude-opus-4-5",
+    provider: "anthropic",
+    author: "anthropic",
+    version: "20251101",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+          write1h: 2.0, // $10 / MTok (200% of $5)
+        },
+      },
+    ],
+    contextLength: 200000,
+    maxCompletionTokens: 64000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    supportedPlugins: ["web"],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+
+  "claude-opus-4-5:vertex": {
+    providerModelId: "claude-opus-4-5@20251101",
+    provider: "vertex",
+    author: "anthropic",
+    version: "vertex-2023-10-16",
+    ptbEnabled: true,
+    crossRegion: true,
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+        },
+      },
+    ],
+    contextLength: 200000,
+    maxCompletionTokens: 64000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      global: {
+        providerModelId: "claude-opus-4-5@20251101",
+      },
+    },
+  },
+  "claude-opus-4-5:bedrock": {
+    provider: "bedrock",
+    author: "anthropic",
+    providerModelId: "anthropic.claude-opus-4-5-20251101-v1:0",
+    version: "20251101",
+    crossRegion: true,
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+        },
+      },
+    ],
+    contextLength: 200000,
+    maxCompletionTokens: 64000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+      "top_p",
+      "top_k",
+    ],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "us-east-1": {},
+    },
+  },
+  "claude-opus-4-5:openrouter": {
+    provider: "openrouter",
+    author: "anthropic",
+    providerModelId: "anthropic/claude-opus-4.5",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005275, // $5.275/1M - worst-case: $5.00/1M (Anthropic/Google) * 1.055
+        output: 0.000026375, // $26.375/1M - worst-case: $25.00/1M (Anthropic/Google) * 1.055
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+      },
+    ],
+    contextLength: 200000,
+    maxCompletionTokens: 64000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "tools",
+      "tool_choice",
+      "top_p",
+      "top_k",
+    ],
+    ptbEnabled: true,
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+} satisfies Partial<
+  Record<`${ClaudeOpus45ModelName}:${ModelProviderName}`, ModelProviderConfig>
+>;

--- a/packages/cost/models/authors/anthropic/claude-opus-4-5/model.ts
+++ b/packages/cost/models/authors/anthropic/claude-opus-4-5/model.ts
@@ -1,0 +1,17 @@
+import type { ModelConfig } from "../../../types";
+
+export const models = {
+  "claude-opus-4-5": {
+    name: "Anthropic: Claude Opus 4.5",
+    author: "anthropic",
+    description:
+      "Claude Opus 4.5 is Anthropic's flagship model released November 2025, representing the highest level of intelligence and capability. Features extended thinking, multilingual capabilities, vision processing, and exceptional performance across complex reasoning tasks. Training data cut-off: March 2025. API model name: claude-opus-4-5",
+    contextLength: 200000,
+    maxOutputTokens: 64000,
+    created: "2025-11-24T00:00:00.000Z",
+    modality: { inputs: ["text", "image"], outputs: ["text"] },
+    tokenizer: "Claude",
+  },
+} satisfies Record<string, ModelConfig>;
+
+export type ClaudeOpus45ModelName = keyof typeof models;

--- a/packages/cost/models/authors/anthropic/index.ts
+++ b/packages/cost/models/authors/anthropic/index.ts
@@ -18,6 +18,7 @@ import { models as claude45HaikuModels } from "./claude-4.5-haiku/model";
 import { models as claudeSonnet4520250929Models } from "./claude-sonnet-4-5-20250929/model";
 import { models as claudeHaiku4520251001Models } from "./claude-haiku-4-5-20251001/model";
 import { models as claudeOpus4120250805Models } from "./claude-opus-4-1-20250805/model";
+import { models as claudeOpus45Models } from "./claude-opus-4-5/model";
 
 // Import endpoints
 import { endpoints as claudeOpus41Endpoints } from "./claude-opus-4-1/endpoints";
@@ -32,6 +33,7 @@ import { endpoints as claude45HaikuEndpoints } from "./claude-4.5-haiku/endpoint
 import { endpoints as claudeSonnet4520250929Endpoints } from "./claude-sonnet-4-5-20250929/endpoints";
 import { endpoints as claudeHaiku4520251001Endpoints } from "./claude-haiku-4-5-20251001/endpoints";
 import { endpoints as claudeOpus4120250805Endpoints } from "./claude-opus-4-1-20250805/endpoints";
+import { endpoints as claudeOpus45Endpoints } from "./claude-opus-4-5/endpoints";
 
 // Aggregate models
 export const anthropicModels = {
@@ -47,6 +49,7 @@ export const anthropicModels = {
   ...claudeSonnet4520250929Models,
   ...claudeHaiku4520251001Models,
   ...claudeOpus4120250805Models,
+  ...claudeOpus45Models,
 } satisfies Record<string, ModelConfig>;
 
 // Aggregate endpoints
@@ -63,4 +66,5 @@ export const anthropicEndpointConfig = {
   ...claudeSonnet4520250929Endpoints,
   ...claudeHaiku4520251001Endpoints,
   ...claudeOpus4120250805Endpoints,
+  ...claudeOpus45Endpoints,
 } satisfies Record<string, ModelProviderConfig>;

--- a/packages/cost/providers/anthropic/index.ts
+++ b/packages/cost/providers/anthropic/index.ts
@@ -230,6 +230,21 @@ export const costs: ModelRow[] = [
       prompt_cache_creation_1h: 0.00003, // $30 / MTok
     },
   },
+  {
+    model: {
+      operator: "equals",
+      value: "claude-opus-4-5",
+    },
+    cost: {
+      prompt_token: 0.000005, // $5 / MTok
+      completion_token: 0.000025, // $25 / MTok
+      prompt_cache_write_token: 0.00000625, // 5m cache write: $6.25 / MTok
+      prompt_cache_read_token: 0.0000005, // Cache hits/refreshes: $0.5 / MTok
+      prompt_cache_creation_5m: 0.00000625, // $6.25 / MTok
+      prompt_cache_creation_1h: 0.00001, // 1h cache write: $10 / MTok
+    },
+    showInPlayground: true,
+  },
 ];
 
 export const modelDetails: ModelDetailsMap = {
@@ -605,6 +620,60 @@ export const modelDetails: ModelDetailsMap = {
         "Quick-response systems",
         "Parallel processing workflows",
         "Resource-constrained environments",
+      ],
+    },
+  },
+  "claude-4.5-opus": {
+    matches: ["claude-opus-4-5"],
+    searchTerms: ["claude 4.5 opus", "claude-4.5-opus", "opus 4.5"],
+    info: {
+      maxTokens: 200000,
+      releaseDate: "2025-11-24",
+      description:
+        "Claude Opus 4.5 is Anthropic's flagship model released November 2025, representing the highest level of intelligence and capability. It features extended thinking, multilingual capabilities, vision processing, and exceptional performance across complex reasoning tasks with 64k max output tokens. Training data cut-off: March 2025, Training cut-off: August 2025.",
+      tradeOffs: [
+        "Premium pricing for flagship capabilities",
+        "Highest intelligence and reasoning ability",
+        "Extended output capacity (64k tokens)",
+        "Advanced thinking and reasoning features",
+      ],
+      benchmarks: {},
+      capabilities: [
+        "Extended thinking and reasoning",
+        "Complex multi-step problem solving",
+        "Advanced code generation and analysis",
+        "Vision processing (text and image inputs)",
+        "Multilingual capabilities",
+        "Tool and function calling",
+        "JSON mode support",
+        "Context window up to 200k tokens",
+        "Maximum output up to 64k tokens",
+        "Web search integration",
+      ],
+      strengths: [
+        "Highest level of intelligence",
+        "Exceptional reasoning capabilities",
+        "Extended output length (64k tokens)",
+        "Advanced thinking features",
+        "Superior complex task performance",
+        "Comprehensive multilingual support",
+        "Latest training data (March 2025)",
+        "Vision and text multimodal processing",
+      ],
+      weaknesses: [
+        "Premium pricing model",
+        "Higher latency due to advanced capabilities",
+        "Resource-intensive processing",
+      ],
+      recommendations: [
+        "Complex reasoning and analysis tasks",
+        "Advanced code generation and review",
+        "Multi-step problem solving",
+        "Research and academic applications",
+        "Long-form content generation",
+        "Complex data analysis and extraction",
+        "Vision and multimodal processing",
+        "Enterprise-critical applications",
       ],
     },
   },


### PR DESCRIPTION
## Summary

Adds support for Claude Opus 4.5, Anthropic's flagship model released November 2025.

## Changes

- Added Claude Opus 4.5 model configuration in `/packages/cost/models/authors/anthropic/claude-opus-4-5/`
- Updated model registry to include the new model
- Added cost definitions in provider registry
- Updated test snapshots

## Model Details

- **Model ID**: `claude-opus-4-5`
- **Context Window**: 200k tokens
- **Max Output**: 64k tokens
- **Release Date**: November 24, 2025
- **Knowledge Cutoff**: March 2025
- **Training Cutoff**: August 2025

## Provider Support

| Provider | Model ID |
|----------|----------|
| Anthropic | `claude-opus-4-5` |
| Vertex AI (GCP) | `claude-opus-4-5@20251101` |
| Bedrock (AWS) | `anthropic.claude-opus-4-5-20251101-v1:0` |
| OpenRouter | `anthropic/claude-opus-4.5` |

## Pricing

| Type | Cost per MTok |
|------|---------------|
| Input | $5.00 |
| Output | $25.00 |
| Cache Read | $0.50 |
| Cache Write (5min) | $6.25 |
| Cache Write (1hr) | $10.00 |

## Features

- Extended thinking and reasoning capabilities
- Vision processing (text + image inputs)
- Multilingual support
- Tool/function calling
- Web search integration
- Prompt caching support