### PR TITLE
remove provider key from admin for openai on nightly e2e

### DIFF
--- a/scripts/populate-keys/main.py
+++ b/scripts/populate-keys/main.py
@@ -33,6 +33,16 @@ def snake_to_camel(s: str) -> str:
     return parts[0] + ''.join(p.capitalize() for p in parts[1:])
 
 
+# Delete the seeded provider key first (from supabase/seeds/0_seed.sql)
+seeded_key_id = "697e2a38-dacf-4073-b96b-de7a8fbf20f5"
+delete_result = requests.delete(f"http://localhost:8585/v1/api-keys/provider-key/{seeded_key_id}",
+                                headers={
+                                    "Authorization": "Bearer sk-helicone-zk6xu4a-kluegtq-sbljk7q-drnixzi",
+                                    "Content-Type": "application/json",
+})
+print(
+    f"Deleted seeded key: {delete_result.status_code} - {delete_result.text}")
+
 for d in data:
     d = {snake_to_camel(k): v for k, v in d.items()}
     print(d)


### PR DESCRIPTION
## Ticket
Link to the ticket(s) this pull request addresses.

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Testing
- [ ] Added/updated unit tests
- [ ] Added/updated integration tests  
- [ ] Tested locally
- [ ] Verified in staging environment
- [ ] E2E tests pass (if applicable)

## Technical Considerations
- [ ] Database migrations included (if needed)
- [ ] API changes documented
- [ ] Breaking changes noted
- [ ] Performance impact assessed
- [ ] Security implications reviewed

## Dependencies
- [ ] No external dependencies added
- [ ] Dependencies added and documented
- [ ] Environment variables added/modified

## Deployment Notes
- [ ] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Context
Why are you making this change?

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
|                      |                   |

## Misc. Review Notes
