### PR TITLE
Fix emoji stripping in unicode processing

### DIFF
--- a/valhalla/jawn/src/utils/__tests__/sanitize.test.ts
+++ b/valhalla/jawn/src/utils/__tests__/sanitize.test.ts
@@ -1,0 +1,151 @@
+import {
+  replaceLoneSurrogates,
+  sanitizeObject,
+  safeJSONStringify,
+} from "../sanitize";
+
+describe("replaceLoneSurrogates", () => {
+  it("should preserve valid emoji surrogate pairs", () => {
+    // 😀 is \uD83D\uDE00 (high + low surrogate pair)
+    const input = "Hello 😀 World";
+    const result = replaceLoneSurrogates(input);
+    expect(result).toBe("Hello 😀 World");
+  });
+
+  it("should preserve multiple emojis", () => {
+    const input = "Hello 😀🎉🚀 World";
+    const result = replaceLoneSurrogates(input);
+    expect(result).toBe("Hello 😀🎉🚀 World");
+  });
+
+  it("should replace lone high surrogate", () => {
+    // \uD83D alone without its pair
+    const input = "Hello \uD83D World";
+    const result = replaceLoneSurrogates(input);
+    expect(result).toBe("Hello \uFFFD World");
+  });
+
+  it("should replace lone low surrogate", () => {
+    // \uDE00 alone without its pair
+    const input = "Hello \uDE00 World";
+    const result = replaceLoneSurrogates(input);
+    expect(result).toBe("Hello \uFFFD World");
+  });
+
+  it("should replace lone high surrogate at end of string", () => {
+    const input = "Hello World\uD83D";
+    const result = replaceLoneSurrogates(input);
+    expect(result).toBe("Hello World\uFFFD");
+  });
+
+  it("should replace lone low surrogate at start of string", () => {
+    const input = "\uDE00Hello World";
+    const result = replaceLoneSurrogates(input);
+    expect(result).toBe("\uFFFDHello World");
+  });
+
+  it("should handle mixed valid and invalid surrogates", () => {
+    // Valid emoji followed by lone high surrogate
+    const input = "😀\uD83D";
+    const result = replaceLoneSurrogates(input);
+    expect(result).toBe("😀\uFFFD");
+  });
+
+  it("should handle empty string", () => {
+    const input = "";
+    const result = replaceLoneSurrogates(input);
+    expect(result).toBe("");
+  });
+
+  it("should handle string with no surrogates", () => {
+    const input = "Hello World! 123";
+    const result = replaceLoneSurrogates(input);
+    expect(result).toBe("Hello World! 123");
+  });
+
+  it("should preserve complex emoji sequences", () => {
+    // Family emoji with skin tones and ZWJ sequences
+    const input = "Test 👨‍👩‍👧‍👦 end";
+    const result = replaceLoneSurrogates(input);
+    expect(result).toBe("Test 👨‍👩‍👧‍👦 end");
+  });
+
+  it("should preserve flag emojis", () => {
+    const input = "USA 🇺🇸 flag";
+    const result = replaceLoneSurrogates(input);
+    expect(result).toBe("USA 🇺🇸 flag");
+  });
+});
+
+describe("sanitizeObject", () => {
+  it("should preserve emojis in strings", () => {
+    const input = { message: "Hello 😀 World" };
+    const result = sanitizeObject(input);
+    expect(result.message).toBe("Hello 😀 World");
+  });
+
+  it("should preserve emojis in nested objects", () => {
+    const input = {
+      outer: {
+        inner: "Emoji: 🎉",
+      },
+    };
+    const result = sanitizeObject(input);
+    expect(result.outer.inner).toBe("Emoji: 🎉");
+  });
+
+  it("should preserve emojis in arrays", () => {
+    const input = ["Hello 😀", "World 🌍"];
+    const result = sanitizeObject(input);
+    expect(result[0]).toBe("Hello 😀");
+    expect(result[1]).toBe("World 🌍");
+  });
+
+  it("should remove null characters", () => {
+    const input = "Hello\u0000World";
+    const result = sanitizeObject(input);
+    expect(result).toBe("HelloWorld");
+  });
+
+  it("should remove lone surrogates", () => {
+    const input = "Hello\uD83DWorld";
+    const result = sanitizeObject(input);
+    expect(result).toBe("HelloWorld");
+  });
+
+  it("should handle complex nested structures with emojis", () => {
+    const input = {
+      messages: [
+        { role: "user", content: "Hello 👋" },
+        { role: "assistant", content: "Hi there! 😊" },
+      ],
+      metadata: {
+        tags: ["greeting", "emoji 🏷️"],
+      },
+    };
+    const result = sanitizeObject(input);
+    expect(result.messages[0].content).toBe("Hello 👋");
+    expect(result.messages[1].content).toBe("Hi there! 😊");
+    expect(result.metadata.tags[1]).toBe("emoji 🏷️");
+  });
+});
+
+describe("safeJSONStringify", () => {
+  it("should preserve emojis when stringifying", () => {
+    const input = { message: "Hello 😀 World" };
+    const result = safeJSONStringify(input);
+    const parsed = JSON.parse(result);
+    expect(parsed.message).toBe("Hello 😀 World");
+  });
+
+  it("should handle complex emoji content", () => {
+    const input = {
+      text: "React with 👍 or 👎",
+      status: "🟢 Online",
+    };
+    const result = safeJSONStringify(input);
+    const parsed = JSON.parse(result);
+    expect(parsed.text).toBe("React with 👍 or 👎");
+    expect(parsed.status).toBe("🟢 Online");
+  });
+});

--- a/valhalla/jawn/src/utils/sanitize.ts
+++ b/valhalla/jawn/src/utils/sanitize.ts
@@ -1,3 +1,19 @@
+/**
+ * Replaces only lone (unpaired) surrogates with the Unicode replacement character.
+ * Valid surrogate pairs (used for emojis like 😀) are preserved.
+ *
+ * A valid surrogate pair is: high surrogate (\uD800-\uDBFF) followed by low surrogate (\uDC00-\uDFFF)
+ * Lone surrogates are invalid and cause issues with JSON parsing in databases.
+ */
+export function replaceLoneSurrogates(text: string): string {
+  // Match high surrogate NOT followed by low surrogate, OR
+  // low surrogate NOT preceded by high surrogate
+  return text.replace(
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
+    "\uFFFD"
+  );
+}
+
 export function sanitizeObject(obj: any): any {
   if (typeof obj === "string") {
     // Remove null characters


### PR DESCRIPTION
…gates

Previously, the sanitization logic was replacing all surrogate characters which incorrectly stripped valid emoji characters (emojis like 😀 are represented as surrogate pairs in JavaScript). This fix:

- Added replaceLoneSurrogates() function that only replaces unpaired surrogates while preserving valid surrogate pairs (emojis)
- Updated sanitizeJsonEscapeSequences() to use the new function
- Updated inline request_body sanitization to use the new function
- Added comprehensive tests for emoji preservation

## Ticket
Link to the ticket(s) this pull request addresses.

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Testing
- [ ] Added/updated unit tests
- [ ] Added/updated integration tests  
- [ ] Tested locally
- [ ] Verified in staging environment
- [ ] E2E tests pass (if applicable)

## Technical Considerations
- [ ] Database migrations included (if needed)
- [ ] API changes documented
- [ ] Breaking changes noted
- [ ] Performance impact assessed
- [ ] Security implications reviewed

## Dependencies
- [ ] No external dependencies added
- [ ] Dependencies added and documented
- [ ] Environment variables added/modified

## Deployment Notes
- [ ] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Context
Why are you making this change?

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
|                      |                   |

## Misc. Review Notes
