### PR TITLE
fix: [ENG-3664] remove incorrect grouping of tool call events when mapping responses api requests

### DIFF
--- a/packages/__tests__/llm-mapper/openai-responses.test.ts
+++ b/packages/__tests__/llm-mapper/openai-responses.test.ts
@@ -324,7 +324,7 @@ describe("OpenAI Responses API Mapper", () => {
       });
     });
 
-    it("should handle multiple function calls in sequence", () => {
+    it("should handle multiple function calls in sequence - each as separate message", () => {
       const request = {
         model: "gpt-4",
         input: [
@@ -349,7 +349,8 @@ describe("OpenAI Responses API Mapper", () => {
         model: "gpt-4",
       });
 
-      expect(result.schema.request?.messages).toHaveLength(1);
+      // Each function_call should be a separate assistant message to preserve chronological order
+      expect(result.schema.request?.messages).toHaveLength(2);
       expect(result.schema.request?.messages?.[0]).toMatchObject({
         _type: "message",
         role: "assistant" as const,
@@ -361,6 +362,13 @@ describe("OpenAI Responses API Mapper", () => {
             arguments: { param1: "[REDACTED_VALUE_1]" },
             type: "function",
           },
+        ],
+      });
+      expect(result.schema.request?.messages?.[1]).toMatchObject({
+        _type: "message",
+        role: "assistant" as const,
+        content: "",
+        tool_calls: [
           {
             id: "call_[REDACTED_2]",
             name: "[REDACTED_FUNCTION_2]",


### PR DESCRIPTION
Fixes bug with our responses API mapping on the frontend where it would group all the tool calls into one assistant message, which disrupts the chronological ordering of the input in the responses API.

As a minimal example, an input with this order:
`system message → function_call_1 → function_output_1 → user message → function_call_2 → function_output_2`

Would show up after mapping as:
`system message → assistant (with ALL tool_calls: [call_1, call_2]) → function_output_1 → user message → function_output_2`

Now correctly maps to:
`system message → assistant (tool_call_1) → function_output_1 → user message → assistant (tool_call_2) → function_output_2`