### PR TITLE
Add cost model for kimi-k2-thinking

### DIFF
--- a/packages/cost/providers/fireworks/index.ts
+++ b/packages/cost/providers/fireworks/index.ts
@@ -235,4 +235,14 @@ export const costs: ModelRow[] = [
       completion_token: 0.0000001,
     },
   },
+  {
+    model: {
+      operator: "equals",
+      value: "accounts/fireworks/models/kimi-k2-thinking",
+    },
+    cost: {
+      prompt_token: 0.0000006,
+      completion_token: 0.0000025,
+    },
+  },
 ];


### PR DESCRIPTION
## Context
Added fireworks/models/kimi-k2-thinking pricing.

Ref: https://fireworks.ai/models/fireworks/kimi-k2-thinking