### PR TITLE
feat: add nebius provider to llama-3.3-70b-instruct

### DIFF
--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -2513,6 +2513,28 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
         "*",
       ],
     },
+    "llama-3.3-70b-instruct:nebius": {
+      "context": 128000,
+      "crossRegion": false,
+      "maxTokens": 128000,
+      "modelId": "meta-llama/Llama-3.3-70B-Instruct",
+      "parameters": [
+        "frequency_penalty",
+        "max_tokens",
+        "presence_penalty",
+        "repetition_penalty",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p",
+      ],
+      "provider": "nebius",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
     "llama-3.3-70b-instruct:novita": {
       "context": 131072,
       "crossRegion": false,
@@ -5656,6 +5678,7 @@ exports[`Registry Snapshots model coverage snapshot 1`] = `
     "groq",
     "groq",
     "nebius",
+    "nebius",
     "novita",
     "novita",
     "novita",
@@ -7970,6 +7993,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
     {
       "model": "llama-3.3-70b-instruct",
       "providers": [
+        "nebius",
         "novita",
         "openrouter",
       ],
@@ -8221,7 +8245,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "mistral",
     },
     {
-      "modelCount": 3,
+      "modelCount": 4,
       "provider": "nebius",
     },
     {
@@ -8351,8 +8375,8 @@ exports[`Registry Snapshots verify registry state 1`] = `
     "claude-3.5-haiku:anthropic:*",
   ],
   "totalArchivedConfigs": 0,
-  "totalEndpoints": 244,
-  "totalModelProviderConfigs": 244,
+  "totalEndpoints": 245,
+  "totalModelProviderConfigs": 245,
   "totalModelsWithPtb": 91,
   "totalProviders": 21,
 }

--- a/packages/cost/models/authors/meta/llama/endpoints.ts
+++ b/packages/cost/models/authors/meta/llama/endpoints.ts
@@ -484,6 +484,36 @@ export const endpoints = {
       "*": {},
     },
   },
+  "llama-3.3-70b-instruct:nebius": {
+    provider: "nebius",
+    author: "meta-llama",
+    providerModelId: "meta-llama/Llama-3.3-70B-Instruct",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.00000013, // $0.13/1M tokens
+        output: 0.0000004, // $0.40/1M tokens
+      },
+    ],
+    quantization: "fp8",
+    contextLength: 128_000,
+    maxCompletionTokens: 128_000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "top_p",
+      "frequency_penalty",
+      "presence_penalty",
+      "top_k",
+      "repetition_penalty",
+      "tools",
+      "tool_choice",
+    ],
+    ptbEnabled: true,
+    endpointConfigs: {
+      "*": {},
+    },
+  },
   "llama-3.1-8b-instant:openrouter": {
     provider: "openrouter",
     author: "meta-llama",


### PR DESCRIPTION
## Ticket
[[ENG-3745]](https://linear.app/helicone/issue/ENG-3745/new-llama-33-70b-instruct-providers) - Add new Llama-3.3-70b-instruct providers

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [x] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [x] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Testing
- [ ] Added/updated unit tests
- [ ] Added/updated integration tests  
- [ ] Tested locally
- [ ] Verified in staging environment
- [ ] E2E tests pass (if applicable)

## Technical Considerations
- [ ] Database migrations included (if needed)
- [ ] API changes documented
- [ ] Breaking changes noted
- [ ] Performance impact assessed
- [ ] Security implications reviewed

## Dependencies
- [x] No external dependencies added
- [ ] Dependencies added and documented
- [ ] Environment variables added/modified

## Deployment Notes
- [x] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Context
_Why are you making this change?_
Clients requesting better uptime for this model.