### PR TITLE
feat: Redirect /alerts domain to default to app domain

### DIFF
--- a/bifrost/middleware.ts
+++ b/bifrost/middleware.ts
@@ -29,6 +29,8 @@ export async function middleware(request: NextRequest) {
       return NextResponse.redirect(`${appUrl}/prompts`, 301);
     case "/requests":
       return NextResponse.redirect(`${appUrl}/requests`, 301);
+    case "/alerts":
+      return NextResponse.redirect(`${appUrl}/alerts`, 301);
   }
 
   // Continue to next middleware or page
@@ -44,5 +46,6 @@ export const config = {
     "/prompts",
     "/requests",
     "/dashboard",
+    "/alerts",
   ],
 };


### PR DESCRIPTION
## Ticket
[[ENG-3732]](https://linear.app/helicone/issue/ENG-3732/redirect-alerts-endpoint-to-usheliconeaialerts) - Redirect /alerts endpoint to app domain /alerts

## Context
_Why are you making this change?_

We are launching advanced alerting system and we want to make sure when users click on "helicone.ai/alerts" they get redirected to the application domain "us.helicone.ai/alerts".

## Component/Service
What part of Helicone does this affect?
- [x] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [x] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Testing
- [ ] Added/updated unit tests
- [ ] Added/updated integration tests  
- [ ] Tested locally
- [ ] Verified in staging environment
- [ ] E2E tests pass (if applicable)
- [x] No tests exist for this project

## Technical Considerations
- [ ] Database migrations included (if needed)
- [ ] API changes documented
- [ ] Breaking changes noted
- [ ] Performance impact assessed
- [ ] Security implications reviewed

## Dependencies
- [x] No external dependencies added
- [ ] Dependencies added and documented
- [ ] Environment variables added/modified

## Deployment Notes
- [x] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed
