### PR TITLE
Fix unspecified issue

### DIFF
--- a/valhalla/jawn/src/controllers/public/heliconeDatasetController.ts
+++ b/valhalla/jawn/src/controllers/public/heliconeDatasetController.ts
@@ -67,17 +67,17 @@ export class HeliconeDatasetController extends Controller {
   > {
     const datasetManager = new DatasetManager(request.authParams);
 
-    const result = await datasetManager.addDataset({
-      ...requestBody,
-      datasetType: "helicone",
+    const result = await datasetManager.helicone.createDatasetWithRequests({
+      name: requestBody.datasetName,
+      requestIds: requestBody.requestIds,
+      meta: requestBody.meta,
     });
-    // const result = await promptManager.getPrompts(requestBody);
     if (result.error || !result.data) {
       console.log(result.error);
       this.setStatus(500);
       return err(result.error ?? "");
     } else {
-      this.setStatus(200); // set return status 201
+      this.setStatus(200);
       return ok({
         datasetId: result.data,
       });


### PR DESCRIPTION
… creation

The addDataset method in DatasetManager was deprecated and returned an error because it relied on the deleted prompt_input_record table. This fix:

- Adds createDataset and createDatasetWithRequests methods to HeliconeDatasetManager
- Updates HeliconeDatasetController to use the new methods
- Properly creates helicone_dataset entries and adds request rows

Fixes the "addDataset is deprecated" error when creating datasets from the UI.

## Ticket
Link to the ticket(s) this pull request addresses.

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Testing
- [ ] Added/updated unit tests
- [ ] Added/updated integration tests  
- [ ] Tested locally
- [ ] Verified in staging environment
- [ ] E2E tests pass (if applicable)

## Technical Considerations
- [ ] Database migrations included (if needed)
- [ ] API changes documented
- [ ] Breaking changes noted
- [ ] Performance impact assessed
- [ ] Security implications reviewed

## Dependencies
- [ ] No external dependencies added
- [ ] Dependencies added and documented
- [ ] Environment variables added/modified

## Deployment Notes
- [ ] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Context
Why are you making this change?

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
|                      |                   |

## Misc. Review Notes
