### PR TITLE
Change 3-day rollup from daily to hourly

### DIFF
--- a/web/lib/timeCalculations/time.ts
+++ b/web/lib/timeCalculations/time.ts
@@ -98,7 +98,8 @@ export const getTimeInterval = ({
 
   if (diff < 1000 * 60 * 60 * 2) {
     return "min";
-  } else if (diff < 1000 * 60 * 60 * 24 * 2) {
+  } else if (diff < 1000 * 60 * 60 * 24 * 3) {
+    // Use hourly granularity for ranges up to 3 days
     return "hour";
   } else {
     return "day";


### PR DESCRIPTION
Previously, any time range >= 2 days would use daily granularity. This change updates the threshold to 3 days so that the "3d" quick select option now shows hourly data instead of daily rollup.

## Ticket
Link to the ticket(s) this pull request addresses.

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Testing
- [ ] Added/updated unit tests
- [ ] Added/updated integration tests  
- [ ] Tested locally
- [ ] Verified in staging environment
- [ ] E2E tests pass (if applicable)

## Technical Considerations
- [ ] Database migrations included (if needed)
- [ ] API changes documented
- [ ] Breaking changes noted
- [ ] Performance impact assessed
- [ ] Security implications reviewed

## Dependencies
- [ ] No external dependencies added
- [ ] Dependencies added and documented
- [ ] Environment variables added/modified

## Deployment Notes
- [ ] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Context
Why are you making this change?

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
|                      |                   |

## Misc. Review Notes
