### PR TITLE
Disable promotion codes in Stripe checkout

### DIFF
--- a/valhalla/jawn/src/managers/stripe/StripeManager.ts
+++ b/valhalla/jawn/src/managers/stripe/StripeManager.ts
@@ -1246,6 +1246,7 @@ WHERE (${builtFilter.filter})`,
           success_url: successUrl,
           cancel_url: cancelUrl,
           mode: "payment",
+          allow_promotion_codes: false,
           line_items: [
             {
               price_data: {


### PR DESCRIPTION
Add allow_promotion_codes: false to the Stripe checkout session creation in createCloudGatewayCheckoutSession to prevent coupon usage for credits purchases.

## Ticket
Link to the ticket(s) this pull request addresses.

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [ ] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
|                      |                   |

## Extra Notes
Any additional context, considerations, or notes for reviewers.

## Context
Why are you making this change?

## Screenshots / Demos
