### PR TITLE
(fix) Add default reasoning effort to gemini 3 models

### DIFF
--- a/packages/__tests__/llm-mapper/google-reasoning.test.ts
+++ b/packages/__tests__/llm-mapper/google-reasoning.test.ts
@@ -52,6 +52,52 @@ describe("Google Reasoning/Thinking Support", () => {
       });
     });
 
+    it("should default to 'low' reasoning_effort when not specified for Gemini 3 models", () => {
+      const openAIRequest: HeliconeChatCreateParams = {
+        model: "gemini-3-pro-preview",
+        messages: [{ role: "user", content: "What is 2+2?" }],
+        // No reasoning_effort specified - should default to "low" ONLY for Gemini 3+
+      };
+
+      const googleRequest = toGoogle(openAIRequest);
+
+      // Default "low" effort maps to "low" thinkingLevel for Google
+      expect(googleRequest.generationConfig?.thinkingConfig).toEqual({
+        includeThoughts: true,
+        thinkingLevel: "low",
+      });
+    });
+
+    it("should disable thinking by default for Gemini 2.5 models when reasoning_effort not specified", () => {
+      const openAIRequest: HeliconeChatCreateParams = {
+        model: "gemini-2.5-flash",
+        messages: [{ role: "user", content: "Test" }],
+        // No reasoning_effort specified - Gemini 2.5 requires explicit opt-in
+      };
+
+      const googleRequest = toGoogle(openAIRequest);
+
+      // Gemini 2.5 models don't get thinking enabled by default
+      expect(googleRequest.generationConfig?.thinkingConfig).toEqual({
+        thinkingBudget: 0,
+      });
+    });
+
+    it("should disable thinking by default for Gemini 1.5 and older models", () => {
+      const openAIRequest: HeliconeChatCreateParams = {
+        model: "gemini-1.5-pro",
+        messages: [{ role: "user", content: "Hello" }],
+        // No reasoning_effort specified - should disable thinking for older models
+      };
+
+      const googleRequest = toGoogle(openAIRequest);
+
+      // Older models don't get thinking enabled by default
+      expect(googleRequest.generationConfig?.thinkingConfig).toEqual({
+        thinkingBudget: 0,
+      });
+    });
+
     it("should use thinkingBudget=-1 for reasoning_effort on Gemini 2.5 models", () => {
       const openAIRequest: HeliconeChatCreateParams = {
         model: "gemini-2.5-flash",


### PR DESCRIPTION
## Ticket
[[ENG-3831] Fix. Gemini 3 Thinking tokens issue](https://linear.app/helicone/issue/ENG-3831/gemini-thinking-tokens-issue)

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [x] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [x] AI Gateway
- [x] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [x] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Context
_Why are you making this change?_

Gemini 3 models require `reasoning_effort` to be defined when making a Gemini request. Currently, we have our request set as error-first, which means that every request is failing (when the user doesn't pass `reasoning_effort`) until reaching OpenRouter - at which point they have an "always pass" policy so it goes through.
Instead, we want to make sure that other providers are able to go through as well before reaching OpenRouter if that's what the user sets. 