### PR TITLE
Remove left padding from logo in mobile/medium navbar

### DIFF
--- a/bifrost/components/layout/navbar.tsx
+++ b/bifrost/components/layout/navbar.tsx
@@ -151,7 +151,7 @@ const MobileNav = () => {
       <div className="fixed inset-x-0 top-0 z-50 bg-background">
         <MobileHeader
           menuDispatch={[menuOpen, setMenuOpen]}
-          className="pl-2 pr-4"
+          className="pr-4"
         />
       </div>
       {menuOpen && (


### PR DESCRIPTION
Removes the pl-2 class from MobileHeader to fix awkward left padding on the logo at medium screen sizes.

## Ticket
Link to the ticket(s) this pull request addresses.

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [ ] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
|                      |                   |

## Extra Notes
Any additional context, considerations, or notes for reviewers.

## Context
Why are you making this change?

## Screenshots / Demos
