### PR TITLE
Fix navbar logo left padding at medium screen sizes

### DIFF
--- a/bifrost/components/layout/navbar.tsx
+++ b/bifrost/components/layout/navbar.tsx
@@ -351,7 +351,7 @@ const NavBar = (props: NavBarProps) => {
       <MobileNav />
 
       <nav
-        className="gap-x-3 mx-auto lg:flex sm:px-16 lg:px-24 2xl:px-40 max-w-[2000px] items-center py-2 hidden justify-between"
+        className="gap-x-3 mx-auto lg:flex lg:px-8 xl:px-16 2xl:px-40 max-w-[2000px] items-center py-2 hidden justify-between"
         aria-label="Global"
       >
         {/* Logo */}


### PR DESCRIPTION
Reduced horizontal padding at lg breakpoint from px-24 (96px) to px-8 (32px) to prevent excessive left padding on the logo at screen sizes right when desktop nav appears (~1024px). Created more gradual padding increase:
- lg: 32px
- xl: 64px
- 2xl: 160px

## Ticket
Link to the ticket(s) this pull request addresses.

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [ ] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
|                      |                   |

## Extra Notes
Any additional context, considerations, or notes for reviewers.

## Context
Why are you making this change?

## Screenshots / Demos
