### PR TITLE
fix: Remove ARRAY JOIN from property queries to fix cost calculation discrepancy

### DIFF
--- a/web/lib/api/property/averageLatency.ts
+++ b/web/lib/api/property/averageLatency.ts
@@ -1,8 +1,9 @@
 import { FilterNode } from "@helicone-package/filters/filterDefs";
 import { timeFilterToFilterNode } from "@helicone-package/filters/helpers";
-import { buildFilterWithAuthClickHousePropertiesV2 } from "@helicone-package/filters/filters";
+import { buildFilterWithAuthClickHouse } from "@helicone-package/filters/filters";
 import { Result, resultMap } from "@/packages/common/result";
 import { dbQueryClickhouse } from "../db/dbExecute";
+import { transformSearchPropertiesToPropertyKey } from "./propertyFilterHelpers";
 
 export async function getAverageLatency(
   filter: FilterNode,
@@ -10,25 +11,31 @@ export async function getAverageLatency(
     start: Date;
     end: Date;
   },
-  org_id: string,
+  org_id: string
 ): Promise<Result<number, string>> {
-  const { filter: filterString, argsAcc } =
-    await buildFilterWithAuthClickHousePropertiesV2({
+  // Transform search_properties to property_key to avoid ARRAY JOIN
+  const transformedFilter = transformSearchPropertiesToPropertyKey({
+    left: timeFilterToFilterNode(timeFilter, "request_response_rmt"),
+    right: filter,
+    operator: "and",
+  });
+
+  const { filter: filterString, argsAcc } = await buildFilterWithAuthClickHouse(
+    {
       org_id,
-      filter: {
-        left: timeFilterToFilterNode(timeFilter, "request_response_rmt"),
-        right: filter,
-        operator: "and",
-      },
+      filter: transformedFilter,
       argsAcc: [],
-    });
+    }
+  );
+
+  // Query without ARRAY JOIN - uses property_key filter which generates
+  // has(mapKeys(properties), 'key') instead of requiring ARRAY JOIN
   const query = `
   WITH total_count AS (
-    SELECT 
+    SELECT
       count(*) as count,
       sum(request_response_rmt.latency) as total_latency
     FROM request_response_rmt
-    ARRAY JOIN mapKeys(properties) AS key
     WHERE (
       (${filterString})
     )

--- a/web/lib/api/property/propertyFilterHelpers.ts
+++ b/web/lib/api/property/propertyFilterHelpers.ts
@@ -1,0 +1,56 @@
+import {
+  FilterBranch,
+  FilterLeaf,
+  FilterNode,
+} from "@helicone-package/filters/filterDefs";
+
+/**
+ * Transforms search_properties filters to property_key filters.
+ * This allows queries to work without ARRAY JOIN.
+ *
+ * search_properties: { "prop_name": { equals: "prop_name" } }
+ * becomes: property_key: { equals: "prop_name" }
+ *
+ * The search_properties filter requires ARRAY JOIN to create a `key` column,
+ * while property_key uses has(mapKeys(properties), 'key') which doesn't need ARRAY JOIN.
+ */
+export function transformSearchPropertiesToPropertyKey(
+  filter: FilterNode
+): FilterNode {
+  if (filter === "all") {
+    return filter;
+  }
+
+  // Check if it's a leaf node with search_properties
+  if ("request_response_rmt" in filter) {
+    const leaf = filter as FilterLeaf;
+    const rmt = leaf.request_response_rmt;
+    if (rmt && "search_properties" in rmt && rmt.search_properties) {
+      // Extract the property key from search_properties
+      const propKey = Object.keys(rmt.search_properties)[0];
+      if (propKey) {
+        // Transform to property_key filter
+        return {
+          request_response_rmt: {
+            property_key: {
+              equals: propKey,
+            },
+          },
+        } as FilterLeaf;
+      }
+    }
+    return filter;
+  }
+
+  // Check if it's a branch node
+  if ("left" in filter && "right" in filter && "operator" in filter) {
+    const branch = filter as FilterBranch;
+    return {
+      left: transformSearchPropertiesToPropertyKey(branch.left),
+      right: transformSearchPropertiesToPropertyKey(branch.right),
+      operator: branch.operator,
+    };
+  }
+
+  return filter;
+}


### PR DESCRIPTION
## Summary
- Fixes cost calculation discrepancies between dashboard and properties page (ENG-3213)
- Removes ARRAY JOIN from property queries (`totalCost`, `totalRequests`, `averageLatency`)
- Adds `transformSearchPropertiesToPropertyKey()` helper to convert `search_properties` filters to `property_key` filters
- Uses `has(mapKeys(properties), 'key')` instead of ARRAY JOIN + key column

## Context
The property page queries were using `ARRAY JOIN mapKeys(properties) AS key` which required the `search_properties` filter. This change aligns the property queries with the dashboard query pattern by:

1. Transforming `search_properties` filters to `property_key` filters
2. Removing ARRAY JOIN from the SQL queries
3. Using the `has()` function to check property existence

## Test plan
- [ ] Verify property page total cost matches expected values
- [ ] Verify property page total requests count is correct
- [ ] Verify property page average latency is correct
- [ ] Compare dashboard totals with property page totals for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)