### PR TITLE
fix: Prompt editor deletes content below truncation in long prompts

### DIFF
--- a/web/components/templates/prompts/id/promptChatRow.tsx
+++ b/web/components/templates/prompts/id/promptChatRow.tsx
@@ -376,23 +376,24 @@ const PromptChatRow = (props: PromptChatRowProps) => {
       );
       const text = textMessage?.text || "";
       const isMinimized = minimize && text.length > 100;
-      const displayText = isMinimized ? `${text.substring(0, 100)}...` : text;
       const isStatic = text.includes("<helicone-prompt-static>");
+      // Always use full text to avoid truncation bugs - use CSS for visual truncation
+      const displayText = isStatic
+        ? text.replace(
+            /<helicone-prompt-static>(.*?)<\/helicone-prompt-static>/g,
+            "$1",
+          )
+        : text;
 
       return (
         <div className="flex flex-col space-y-4 whitespace-pre-wrap">
-          <RenderWithPrettyInputKeys
-            text={removeLeadingWhitespace(
-              isStatic
-                ? displayText.replace(
-                    /<helicone-prompt-static>(.*?)<\/helicone-prompt-static>/g,
-                    "$1",
-                  )
-                : displayText,
-            )}
-            selectedProperties={selectedProperties}
-            playgroundMode={playgroundMode}
-          />
+          <div className={isMinimized ? "line-clamp-3" : ""}>
+            <RenderWithPrettyInputKeys
+              text={removeLeadingWhitespace(displayText)}
+              selectedProperties={selectedProperties}
+              playgroundMode={playgroundMode}
+            />
+          </div>
           {hasImage(content) && (
             <div className="flex flex-wrap items-center border-t border-slate-300 pt-4 dark:border-slate-700">
               {content
@@ -480,17 +481,16 @@ const PromptChatRow = (props: PromptChatRowProps) => {
     } else {
       const contentString = enforceString(content) || "";
       const isMinimized = minimize && contentString.length > 100;
-      const displayText = isMinimized
-        ? `${contentString.substring(0, 100)}...`
-        : contentString;
 
       return (
         <div className="flex flex-col space-y-4 whitespace-pre-wrap">
-          <RenderWithPrettyInputKeys
-            text={displayText}
-            selectedProperties={selectedProperties}
-            playgroundMode={playgroundMode}
-          />
+          <div className={isMinimized ? "line-clamp-3" : ""}>
+            <RenderWithPrettyInputKeys
+              text={contentString}
+              selectedProperties={selectedProperties}
+              playgroundMode={playgroundMode}
+            />
+          </div>
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- Fixes bug where editing long prompts would cause content below the truncation point to be deleted
- The truncation "..." was being treated as actual text instead of a visual indicator
- Replaces string truncation (`substring(0, 100) + "..."`) with CSS-based truncation (`line-clamp-3`)

## Problem
When entering a long system prompt and making edits above the "..." truncation marker, the content below the truncation would be removed and "..." would become part of the actual prompt content.

## Solution
Use CSS `line-clamp-3` class for visual truncation instead of modifying the underlying text. This ensures:
- The full prompt content is always preserved
- Truncation is purely visual
- Editing/saving operations always use the complete content

## Test plan
- [x] TypeScript compiles without errors
- [ ] Manual test: Create a long system prompt (>100 chars), minimize, expand, and verify content is preserved
- [ ] Manual test: Edit a minimized prompt and verify full content is saved

🤖 Generated with [Claude Code](https://claude.ai/code)