### PR TITLE
fix: make worker tests more reliable and skip on unrelated PRs

### DIFF
--- a/.github/workflows/worker-test.yml
+++ b/.github/workflows/worker-test.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "worker/**"
+      - "packages/**"
+      - ".github/workflows/worker-test.yml"
 
 jobs:
   worker-ai-gateway-tests:

--- a/worker/test/ai-gateway/vitest.config.mts
+++ b/worker/test/ai-gateway/vitest.config.mts
@@ -3,8 +3,10 @@ import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
 export default defineWorkersConfig({
   test: {
     retry: 2,
+    testTimeout: 30000, // Increase timeout for Durable Object tests
     poolOptions: {
       workers: {
+        singleWorker: true, // Run tests sequentially to avoid isolated storage conflicts
         wrangler: { configPath: "../../wrangler.toml" },
         miniflare: {
           compatibilityDate: "2025-08-03",


### PR DESCRIPTION
- Add path filters to PR trigger so worker tests only run when worker/packages code changes (not on unrelated PRs)
- Add singleWorker: true to avoid isolated storage conflicts with Durable Objects in parallel test execution
- Increase testTimeout to 30s for Durable Object tests

## Ticket
Link to the ticket(s) this pull request addresses.

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [ ] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
|                      |                   |

## Extra Notes
Any additional context, considerations, or notes for reviewers.

## Context
Why are you making this change?

## Screenshots / Demos
