### PR TITLE
feat: better error messages + property value index

### DIFF
--- a/clickhouse/migrations/schema_79_property_value_index.sql
+++ b/clickhouse/migrations/schema_79_property_value_index.sql
@@ -1,0 +1,6 @@
+-- Add bloom filter index on property values for faster filtering
+ALTER TABLE request_response_rmt
+ADD INDEX idx_properties_value mapValues(properties) TYPE bloom_filter(0.01) GRANULARITY 1;
+
+-- Materialize the index for existing data
+ALTER TABLE request_response_rmt MATERIALIZE INDEX idx_properties_value;


### PR DESCRIPTION
- Surface user-friendly error messages for ClickHouse errors (timeout, memory, row limits) instead of generic "Internal Server Error"
- Add bloom filter index on mapValues(properties) for faster property filtering

## Ticket
Link to the ticket(s) this pull request addresses.

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [ ] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
|                      |                   |

## Extra Notes
Any additional context, considerations, or notes for reviewers.

## Context
Why are you making this change?

## Screenshots / Demos
