### PR TITLE
security: fix listener removal bug in WebsocketListeners

### DIFF
--- a/valhalla/jawn/src/controlPlane/WebsocketListeners.ts
+++ b/valhalla/jawn/src/controlPlane/WebsocketListeners.ts
@@ -74,6 +74,8 @@ export class WebsocketListeners {
   }
 
   removeListener(organizationId: string, listener: ConnectedRouterState) {
-    this.listeners.get(organizationId)?.filter((l) => l !== listener);
+    const remaining =
+      this.listeners.get(organizationId)?.filter((l) => l !== listener) ?? [];
+    this.listeners.set(organizationId, remaining);
   }
 }


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

## Ticket
Security finding: Listener Removal Bug in WebsocketListeners

## Component/Service
- [x] Jawn (Backend)

## Type of Change
- [x] Bug fix

## Deployment Notes
- [x] No special deployment steps required

## Context
The `removeListener` method in `WebsocketListeners.ts` (line 77) calls `Array.filter()` but discards the returned array — `filter()` returns a new array and the original array in the `Map` is never updated. This means WebSocket listeners are never actually removed when connections close.

**Security implications:**
1. **Memory leak / DoS vector**: Closed WebSocket connections remain in the listeners Map indefinitely. An attacker who can establish WebSocket connections can exhaust server memory by repeatedly connecting and disconnecting.
2. **Stale auth data in memory**: `ConnectedRouterState` objects containing `AuthParams` persist in memory after the connection is closed.

## Fix Applied
Assigned the filtered result back to the Map using `this.listeners.set()`, matching the existing pattern already used in `addListener` (line 59). When the `organizationId` has no existing listeners, defaults to an empty array via the `?? []` fallback.

## Tests/Linters Ran
- **TypeScript type check** (`npx tsc --noEmit`): Passed with no errors
- **Jest test suite** (`npx jest --detectOpenHandles`): Pre-existing failures unrelated to this change (emoji sanitization tests). Confirmed the same failures exist on `main` — test results are not affected by this fix.

## Contribution Notes
Following the [Contributing Guidelines](CONTRIBUTING_GUIDELINES.md): branched from `main`, code lints, change is minimal and focused on the security fix only.

## Extra Notes
Single-line logical fix. The `filter()` call was already correct in its predicate — only the assignment of the result was missing.