### PR TITLE
feat(api): add GET /v1/request/{requestId}/inputs endpoint

### DIFF
--- a/bifrost/lib/clients/jawnTypes/private.ts
+++ b/bifrost/lib/clients/jawnTypes/private.ts
@@ -298,6 +298,9 @@ export interface paths {
   "/v1/request/{requestId}": {
     get: operations["GetRequestById"];
   };
+  "/v1/request/{requestId}/inputs": {
+    get: operations["GetRequestInputs"];
+  };
   "/v1/request/query-ids": {
     post: operations["GetRequestsByIds"];
   };
@@ -2267,6 +2270,17 @@ Json: JsonObject;
       error: null;
     };
     "Result_HeliconeRequest.string_": components["schemas"]["ResultSuccess_HeliconeRequest_"] | components["schemas"]["ResultError_string_"];
+    "ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_": {
+      data: ({
+        environment: string | null;
+        version_id: string;
+        prompt_id: string;
+        inputs: components["schemas"]["Record_string.any_"];
+      }) | null;
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_": components["schemas"]["ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_"] | components["schemas"]["ResultError_string_"];
     HeliconeRequestAsset: {
       assetUrl: string;
     };
@@ -18617,6 +18631,21 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["Result_HeliconeRequest.string_"];
+        };
+      };
+    };
+  };
+  GetRequestInputs: {
+    parameters: {
+      path: {
+        requestId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_"];
         };
       };
     };

--- a/bifrost/lib/clients/jawnTypes/public.ts
+++ b/bifrost/lib/clients/jawnTypes/public.ts
@@ -355,6 +355,9 @@ export interface paths {
   "/v1/request/{requestId}": {
     get: operations["GetRequestById"];
   };
+  "/v1/request/{requestId}/inputs": {
+    get: operations["GetRequestInputs"];
+  };
   "/v1/request/query-ids": {
     post: operations["GetRequestsByIds"];
   };
@@ -2343,6 +2346,17 @@ Json: JsonObject;
       error: null;
     };
     "Result_HeliconeRequest.string_": components["schemas"]["ResultSuccess_HeliconeRequest_"] | components["schemas"]["ResultError_string_"];
+    "ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_": {
+      data: ({
+        environment: string | null;
+        version_id: string;
+        prompt_id: string;
+        inputs: components["schemas"]["Record_string.any_"];
+      }) | null;
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_": components["schemas"]["ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_"] | components["schemas"]["ResultError_string_"];
     HeliconeRequestAsset: {
       assetUrl: string;
     };
@@ -6930,6 +6944,21 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["Result_HeliconeRequest.string_"];
+        };
+      };
+    };
+  };
+  GetRequestInputs: {
+    parameters: {
+      path: {
+        requestId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_"];
         };
       };
     };

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5769,6 +5769,58 @@
 					}
 				]
 			},
+			"ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_": {
+				"properties": {
+					"data": {
+						"properties": {
+							"environment": {
+								"type": "string",
+								"nullable": true
+							},
+							"version_id": {
+								"type": "string"
+							},
+							"prompt_id": {
+								"type": "string"
+							},
+							"inputs": {
+								"$ref": "#/components/schemas/Record_string.any_"
+							}
+						},
+						"required": [
+							"environment",
+							"version_id",
+							"prompt_id",
+							"inputs"
+						],
+						"type": "object",
+						"nullable": true
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
 			"HeliconeRequestAsset": {
 				"properties": {
 					"assetUrl": {
@@ -20423,6 +20475,41 @@
 						"schema": {
 							"default": false,
 							"type": "boolean"
+						}
+					}
+				]
+			}
+		},
+		"/v1/request/{requestId}/inputs": {
+			"get": {
+				"operationId": "GetRequestInputs",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Request"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "requestId",
+						"required": true,
+						"schema": {
+							"type": "string"
 						}
 					}
 				]

--- a/helicone-mcp/src/types/public.ts
+++ b/helicone-mcp/src/types/public.ts
@@ -355,6 +355,9 @@ export interface paths {
   "/v1/request/{requestId}": {
     get: operations["GetRequestById"];
   };
+  "/v1/request/{requestId}/inputs": {
+    get: operations["GetRequestInputs"];
+  };
   "/v1/request/query-ids": {
     post: operations["GetRequestsByIds"];
   };
@@ -2343,6 +2346,17 @@ Json: JsonObject;
       error: null;
     };
     "Result_HeliconeRequest.string_": components["schemas"]["ResultSuccess_HeliconeRequest_"] | components["schemas"]["ResultError_string_"];
+    "ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_": {
+      data: ({
+        environment: string | null;
+        version_id: string;
+        prompt_id: string;
+        inputs: components["schemas"]["Record_string.any_"];
+      }) | null;
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_": components["schemas"]["ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_"] | components["schemas"]["ResultError_string_"];
     HeliconeRequestAsset: {
       assetUrl: string;
     };
@@ -6930,6 +6944,21 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["Result_HeliconeRequest.string_"];
+        };
+      };
+    };
+  };
+  GetRequestInputs: {
+    parameters: {
+      path: {
+        requestId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_"];
         };
       };
     };

--- a/valhalla/jawn/src/controllers/public/requestController.ts
+++ b/valhalla/jawn/src/controllers/public/requestController.ts
@@ -179,6 +179,31 @@ export class RequestController extends Controller {
     return returnRequest;
   }
 
+  @Get("/{requestId}/inputs")
+  public async getRequestInputs(
+    @Request() request: JawnAuthenticatedRequest,
+    @Path() requestId: string
+  ): Promise<
+    Result<
+      {
+        inputs: Record<string, any>;
+        prompt_id: string;
+        version_id: string;
+        environment: string | null;
+      } | null,
+      string
+    >
+  > {
+    const reqManager = new RequestManager(request.authParams);
+    const result = await reqManager.getRequestInputs(requestId);
+    if (result.error) {
+      this.setStatus(500);
+    } else {
+      this.setStatus(200);
+    }
+    return result;
+  }
+
   @Post("/query-ids")
   public async getRequestsByIds(
     @Body() requestBody: { requestIds: string[] },

--- a/valhalla/jawn/src/tsoa-build/private/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/private/routes.ts
@@ -1433,6 +1433,20 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_HeliconeRequest_"},{"ref":"ResultError_string_"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_": {
+        "dataType": "refObject",
+        "properties": {
+            "data": {"dataType":"union","subSchemas":[{"dataType":"nestedObjectLiteral","nestedProperties":{"environment":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"version_id":{"dataType":"string","required":true},"prompt_id":{"dataType":"string","required":true},"inputs":{"ref":"Record_string.any_","required":true}}},{"dataType":"enum","enums":[null]}],"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_"},{"ref":"ResultError_string_"}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "HeliconeRequestAsset": {
         "dataType": "refObject",
         "properties": {
@@ -18694,6 +18708,38 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'getRequestById',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsRequestController_getRequestInputs: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                requestId: {"in":"path","name":"requestId","required":true,"dataType":"string"},
+        };
+        app.get('/v1/request/:requestId/inputs',
+            authenticateMiddleware([{"api_key":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(RequestController)),
+            ...(fetchMiddlewares<RequestHandler>(RequestController.prototype.getRequestInputs)),
+
+            async function RequestController_getRequestInputs(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsRequestController_getRequestInputs, request, response });
+
+                const controller = new RequestController();
+
+              await templateService.apiHandler({
+                methodName: 'getRequestInputs',
                 controller,
                 response,
                 next,

--- a/valhalla/jawn/src/tsoa-build/private/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/private/swagger.json
@@ -5626,6 +5626,58 @@
 					}
 				]
 			},
+			"ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_": {
+				"properties": {
+					"data": {
+						"properties": {
+							"environment": {
+								"type": "string",
+								"nullable": true
+							},
+							"version_id": {
+								"type": "string"
+							},
+							"prompt_id": {
+								"type": "string"
+							},
+							"inputs": {
+								"$ref": "#/components/schemas/Record_string.any_"
+							}
+						},
+						"required": [
+							"environment",
+							"version_id",
+							"prompt_id",
+							"inputs"
+						],
+						"type": "object",
+						"nullable": true
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
 			"HeliconeRequestAsset": {
 				"properties": {
 					"assetUrl": {
@@ -55078,6 +55130,41 @@
 						"schema": {
 							"default": false,
 							"type": "boolean"
+						}
+					}
+				]
+			}
+		},
+		"/v1/request/{requestId}/inputs": {
+			"get": {
+				"operationId": "GetRequestInputs",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Request"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "requestId",
+						"required": true,
+						"schema": {
+							"type": "string"
 						}
 					}
 				]

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -1797,6 +1797,20 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess_HeliconeRequest_"},{"ref":"ResultError_string_"}],"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_": {
+        "dataType": "refObject",
+        "properties": {
+            "data": {"dataType":"union","subSchemas":[{"dataType":"nestedObjectLiteral","nestedProperties":{"environment":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"version_id":{"dataType":"string","required":true},"prompt_id":{"dataType":"string","required":true},"inputs":{"ref":"Record_string.any_","required":true}}},{"dataType":"enum","enums":[null]}],"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"ref":"ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_"},{"ref":"ResultError_string_"}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "HeliconeRequestAsset": {
         "dataType": "refObject",
         "properties": {
@@ -8955,6 +8969,38 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'getRequestById',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsRequestController_getRequestInputs: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                requestId: {"in":"path","name":"requestId","required":true,"dataType":"string"},
+        };
+        app.get('/v1/request/:requestId/inputs',
+            authenticateMiddleware([{"api_key":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(RequestController)),
+            ...(fetchMiddlewares<RequestHandler>(RequestController.prototype.getRequestInputs)),
+
+            async function RequestController_getRequestInputs(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsRequestController_getRequestInputs, request, response });
+
+                const controller = new RequestController();
+
+              await templateService.apiHandler({
+                methodName: 'getRequestInputs',
                 controller,
                 response,
                 next,

--- a/valhalla/jawn/src/tsoa-build/public/swagger.json
+++ b/valhalla/jawn/src/tsoa-build/public/swagger.json
@@ -5769,6 +5769,58 @@
 					}
 				]
 			},
+			"ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_": {
+				"properties": {
+					"data": {
+						"properties": {
+							"environment": {
+								"type": "string",
+								"nullable": true
+							},
+							"version_id": {
+								"type": "string"
+							},
+							"prompt_id": {
+								"type": "string"
+							},
+							"inputs": {
+								"$ref": "#/components/schemas/Record_string.any_"
+							}
+						},
+						"required": [
+							"environment",
+							"version_id",
+							"prompt_id",
+							"inputs"
+						],
+						"type": "object",
+						"nullable": true
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"data",
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_": {
+				"anyOf": [
+					{
+						"$ref": "#/components/schemas/ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_"
+					},
+					{
+						"$ref": "#/components/schemas/ResultError_string_"
+					}
+				]
+			},
 			"HeliconeRequestAsset": {
 				"properties": {
 					"assetUrl": {
@@ -20423,6 +20475,41 @@
 						"schema": {
 							"default": false,
 							"type": "boolean"
+						}
+					}
+				]
+			}
+		},
+		"/v1/request/{requestId}/inputs": {
+			"get": {
+				"operationId": "GetRequestInputs",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Request"
+				],
+				"security": [
+					{
+						"api_key": []
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "requestId",
+						"required": true,
+						"schema": {
+							"type": "string"
 						}
 					}
 				]

--- a/web/lib/clients/jawnTypes/private.ts
+++ b/web/lib/clients/jawnTypes/private.ts
@@ -298,6 +298,9 @@ export interface paths {
   "/v1/request/{requestId}": {
     get: operations["GetRequestById"];
   };
+  "/v1/request/{requestId}/inputs": {
+    get: operations["GetRequestInputs"];
+  };
   "/v1/request/query-ids": {
     post: operations["GetRequestsByIds"];
   };
@@ -2267,6 +2270,17 @@ Json: JsonObject;
       error: null;
     };
     "Result_HeliconeRequest.string_": components["schemas"]["ResultSuccess_HeliconeRequest_"] | components["schemas"]["ResultError_string_"];
+    "ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_": {
+      data: ({
+        environment: string | null;
+        version_id: string;
+        prompt_id: string;
+        inputs: components["schemas"]["Record_string.any_"];
+      }) | null;
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_": components["schemas"]["ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_"] | components["schemas"]["ResultError_string_"];
     HeliconeRequestAsset: {
       assetUrl: string;
     };
@@ -18617,6 +18631,21 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["Result_HeliconeRequest.string_"];
+        };
+      };
+    };
+  };
+  GetRequestInputs: {
+    parameters: {
+      path: {
+        requestId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_"];
         };
       };
     };

--- a/web/lib/clients/jawnTypes/public.ts
+++ b/web/lib/clients/jawnTypes/public.ts
@@ -355,6 +355,9 @@ export interface paths {
   "/v1/request/{requestId}": {
     get: operations["GetRequestById"];
   };
+  "/v1/request/{requestId}/inputs": {
+    get: operations["GetRequestInputs"];
+  };
   "/v1/request/query-ids": {
     post: operations["GetRequestsByIds"];
   };
@@ -2343,6 +2346,17 @@ Json: JsonObject;
       error: null;
     };
     "Result_HeliconeRequest.string_": components["schemas"]["ResultSuccess_HeliconeRequest_"] | components["schemas"]["ResultError_string_"];
+    "ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_": {
+      data: ({
+        environment: string | null;
+        version_id: string;
+        prompt_id: string;
+        inputs: components["schemas"]["Record_string.any_"];
+      }) | null;
+      /** @enum {number|null} */
+      error: null;
+    };
+    "Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_": components["schemas"]["ResultSuccess__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null_"] | components["schemas"]["ResultError_string_"];
     HeliconeRequestAsset: {
       assetUrl: string;
     };
@@ -6930,6 +6944,21 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["Result_HeliconeRequest.string_"];
+        };
+      };
+    };
+  };
+  GetRequestInputs: {
+    parameters: {
+      path: {
+        requestId: string;
+      };
+    };
+    responses: {
+      /** @description Ok */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Result__inputs-Record_string.any_--prompt_id-string--version_id-string--environment-string-or-null_-or-null.string_"];
         };
       };
     };


### PR DESCRIPTION
## Summary

Adds a new endpoint `GET /v1/request/{requestId}/inputs` that returns the prompt template inputs (variables) used for a given request.

## Problem

When customers use prompt management through the AI Gateway, the template variables (inputs) are stored in `prompts_2025_inputs` but there's no API to retrieve them by request ID. Customers building testing pipelines want to pull a past request's inputs to replay them against new prompt versions without storing inputs separately on their end.

## Solution

New endpoint: `GET /v1/request/{requestId}/inputs`

**Response (when inputs exist):**
```json
{
  "data": {
    "inputs": {"customer_name": "Sarah", "issue": "refund request"},
    "prompt_id": "customer-support",
    "version_id": "1c7a86c8-...",
    "environment": "production"
  },
  "error": null
}
```

**Response (no inputs for request):**
```json
{"data": null, "error": null}
```

## Implementation

- Added `getRequestInputs` method to `RequestManager` — queries `prompts_2025_inputs` joined with `prompts_2025_versions` for org-level access control
- Added `GET /{requestId}/inputs` route to `RequestController`
- Auto-generated TSOA routes and types

## Testing

Tested locally against a running Helicone stack:
- ✅ Returns correct inputs for requests made through AI Gateway with prompt management
- ✅ Returns null for requests without inputs
- ✅ Returns null for non-existent request IDs
- ✅ Org-scoped — cannot access inputs from other organizations