### PR TITLE
Add User-Agent header to Anthropic API requests

### DIFF
--- a/packages/__tests__/cost/providers/anthropic.test.ts
+++ b/packages/__tests__/cost/providers/anthropic.test.ts
@@ -52,6 +52,15 @@ describe("AnthropicProvider", () => {
       expect(result.headers["x-api-key"]).toBe("test-api-key");
       expect(result.headers["anthropic-beta"]).toBe("context-management-2025-06-27");
     });
+
+    it("should include User-Agent header set to helicone", () => {
+      const result = provider.authenticate(
+        { apiKey: "test-api-key" },
+        { providerModelId: "claude-3-haiku" } as any
+      );
+
+      expect(result.headers["User-Agent"]).toBe("helicone");
+    });
   });
 
   describe("provider metadata", () => {

--- a/packages/cost/models/providers/anthropic.ts
+++ b/packages/cost/models/providers/anthropic.ts
@@ -35,6 +35,7 @@ export class AnthropicProvider extends BaseProvider {
       enabledBetaHeaders.push("context-1m-2025-08-07");
     }
     headers["anthropic-beta"] = enabledBetaHeaders.join(",");
+    headers["User-Agent"] = "helicone";
     return { headers };
   }
 


### PR DESCRIPTION
## Summary
- Adds a `User-Agent: helicone` header to outgoing Anthropic API requests in the cost calculation provider
- Adds a unit test verifying the header is set correctly

## Component/Service
- Packages

## Type of Change
- New feature

## Deployment Notes
- No special deployment steps required

## Test plan
- [x] Existing package tests pass (573 passed)
- [x] New Anthropic User-Agent header test passes
- [x] Snapshot tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)