### PR TITLE
fix(worker): resolve 'Body has already been used' error on retry

### DIFF
--- a/worker/src/lib/clients/ProviderClient.ts
+++ b/worker/src/lib/clients/ProviderClient.ts
@@ -187,12 +187,30 @@ export async function callProviderWithRetry(
 ): Promise<Response> {
   let lastResponse;
 
+  // Convert ReadableStream body to string before retry loop to allow reuse across retries.
+  // ReadableStream bodies can only be consumed once, so we need to read them into a string
+  // that can be safely reused for each retry attempt.
+  let retryableBody = callProps.body;
+  if (retryableBody instanceof ReadableStream) {
+    const reader = retryableBody.getReader();
+    const chunks: Uint8Array[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) chunks.push(value);
+    }
+    const decoder = new TextDecoder();
+    retryableBody = chunks.map((chunk) => decoder.decode(chunk)).join("");
+  }
+
+  const retryableCallProps = { ...callProps, body: retryableBody };
+
   try {
     // Use async-retry to call the forwardRequestToOpenAi function with exponential backoff
     await retry(
       async (bail, attempt) => {
         try {
-          const res = await callProvider(callProps);
+          const res = await callProvider(retryableCallProps);
 
           lastResponse = res;
           // Throw an error if the status code is 429 or 5xx


### PR DESCRIPTION
## Summary
- Fixes "Body has already been used" 500 errors that occurred when server-side retries were triggered (for 429 or 5xx responses from providers)
- Converts `ReadableStream` body to string before the retry loop so it can be safely reused

## Problem
When `callProviderWithRetry()` retried requests after receiving 429 or 5xx responses from providers, the retry would fail with "Body has already been used" errors. This happened because:

1. The `body` in `callProps` could be a `ReadableStream` (when `RequestBodyBuffer_Remote` is used for large requests)
2. `ReadableStream` bodies can only be consumed once by `fetch()`
3. The first retry attempt consumed the stream, making it unusable for subsequent attempts

## Solution
Convert any `ReadableStream` body to a string at the start of `callProviderWithRetry()` before entering the retry loop. Strings can be safely reused across multiple `fetch()` calls.

## Test plan
- [x] TypeScript check passes
- [x] All 1421 worker tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)