### PR TITLE
Fix Bedrock crossRegion check for string values from UI

### DIFF
--- a/packages/__tests__/cost/providers/bedrock.test.ts
+++ b/packages/__tests__/cost/providers/bedrock.test.ts
@@ -34,7 +34,7 @@ describe("BedrockProvider", () => {
       );
     });
 
-    it("should add region prefix for cross-region requests", () => {
+    it("should add region prefix for cross-region requests (boolean true)", () => {
       const url = provider.buildUrl(
         {
           providerModelId: "anthropic.claude-3-haiku-20240307-v1:0",
@@ -46,6 +46,36 @@ describe("BedrockProvider", () => {
 
       expect(url).toBe(
         "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-3-haiku-20240307-v1:0/invoke"
+      );
+    });
+
+    it("should add region prefix for cross-region requests (string 'true' from UI)", () => {
+      const url = provider.buildUrl(
+        {
+          providerModelId: "anthropic.claude-3-haiku-20240307-v1:0",
+          modelConfig: { providerModelId: "anthropic.claude-3-haiku-20240307-v1:0" },
+          userConfig: { region: "us-east-1", crossRegion: "true" },
+        } as any,
+        { isStreaming: false }
+      );
+
+      expect(url).toBe(
+        "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-3-haiku-20240307-v1:0/invoke"
+      );
+    });
+
+    it("should NOT add region prefix when crossRegion is string 'false'", () => {
+      const url = provider.buildUrl(
+        {
+          providerModelId: "anthropic.claude-3-haiku-20240307-v1:0",
+          modelConfig: { providerModelId: "anthropic.claude-3-haiku-20240307-v1:0" },
+          userConfig: { region: "us-east-1", crossRegion: "false" },
+        } as any,
+        { isStreaming: false }
+      );
+
+      expect(url).toBe(
+        "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-haiku-20240307-v1:0/invoke"
       );
     });
 

--- a/packages/cost/models/providers/bedrock.ts
+++ b/packages/cost/models/providers/bedrock.ts
@@ -27,7 +27,9 @@ export class BedrockProvider extends BaseProvider {
     modelProviderConfig: ModelProviderConfig,
     userEndpointConfig: UserEndpointConfig
   ): string {
-    if (userEndpointConfig.crossRegion && userEndpointConfig.region) {
+    // crossRegion can be boolean true or string "true" from the UI
+    const isCrossRegion = userEndpointConfig.crossRegion === true || userEndpointConfig.crossRegion === "true";
+    if (isCrossRegion && userEndpointConfig.region) {
       const regionPrefix = userEndpointConfig.region.split("-")[0];
       return `${regionPrefix}.${modelProviderConfig.providerModelId}`;
     }


### PR DESCRIPTION
## Summary
- Fixes the Bedrock cross-region inference profile feature for BYOK users
- The UI stores `crossRegion` as a string (`"true"`/`"false"`) but the code was checking it as a boolean
- This caused the inference profile prefix (e.g., `us.`) to not be added when users enabled "Cross Region" in the UI

## Root Cause
When a user checks "Cross Region" in the Bedrock provider settings, the config stores:
- `crossRegion: "true"` (string)

But the code was doing:
```typescript
if (userEndpointConfig.crossRegion && userEndpointConfig.region) {
```

Since `"false"` is truthy in JavaScript, this check was incorrect.

## Fix
Now explicitly checks for both boolean `true` and string `"true"`:
```typescript
const isCrossRegion = userEndpointConfig.crossRegion === true || userEndpointConfig.crossRegion === "true";
```

## Test plan
- [x] Added tests for string `"true"` case
- [x] Added tests for string `"false"` case
- [x] All existing tests pass
- [ ] Test in production with Bedrock BYOK after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)