### PR TITLE
fix: concatenate reasoning field in streaming response consolidation

### DIFF
--- a/worker/src/lib/dbLogger/streamParsers/responseParserHelpers.ts
+++ b/worker/src/lib/dbLogger/streamParsers/responseParserHelpers.ts
@@ -54,6 +54,10 @@ export function consolidateTextFields(responseBody: any[]): any {
                   content: c.delta.content
                     ? c.delta.content + (cur.choices[i].delta.content ?? "")
                     : cur.choices[i].delta.content,
+                  reasoning: c.delta.reasoning
+                    ? c.delta.reasoning +
+                      (cur.choices[i].delta.reasoning ?? "")
+                    : cur.choices[i].delta.reasoning,
                   function_call: c.delta.function_call
                     ? recursivelyConsolidate(
                         c.delta.function_call,


### PR DESCRIPTION
## Problem

`consolidateTextFields()` in `responseParserHelpers.ts` only concatenates `content` and `function_call` from streaming deltas, but ignores `reasoning`. This means reasoning tokens from providers like Gemini 2.5 (with thinking/reasoning enabled) get last-chunk-wins behavior instead of proper concatenation when stored.

## Fix

Add `reasoning` field handling alongside `content` in the delta consolidation logic — same pattern, same null-safety.

## Testing

- Tested locally with Gemini 2.5 Flash streaming + `reasoning_effort: high`
- Verified reasoning tokens are properly concatenated in stored response body
- 4-line change, follows existing pattern exactly