### PR TITLE
feat: add Helicone gateway endpoint for Claude Sonnet 4.6

### DIFF
--- a/packages/cost/models/authors/anthropic/claude-4.6-sonnet/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-4.6-sonnet/endpoints.ts
@@ -128,6 +128,45 @@ export const endpoints = {
       "us-east-1": {},
     },
   },
+
+  "claude-4.6-sonnet:helicone": {
+    provider: "helicone",
+    author: "anthropic",
+    providerModelId: "pa/claude-sonnet-4-6",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000003, // $3 / MTok
+        output: 0.000015, // $15 / MTok
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.30 / MTok (10% of $3)
+          write5m: 1.25, // $3.75 / MTok (125% of $3)
+          write1h: 2.0, // $6.00 / MTok (200% of $3)
+        },
+      },
+      {
+        threshold: 200000,
+        input: 0.000006, // $6 / MTok
+        output: 0.0000225, // $22.50 / MTok
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 64000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
 } satisfies Partial<
   Record<
     `${ClaudeSonnet46ModelName}:${ModelProviderName}`,


### PR DESCRIPTION
Follow-up to #5579. Adds the `claude-4.6-sonnet:helicone` endpoint with `providerModelId: pa/claude-sonnet-4-6` (confirmed by Novita).

Same pricing structure as the other Sonnet 4.6 endpoints. All tests pass.