### PR TITLE
chore: add pre-push hook to prevent direct pushes to main

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,11 @@
+#!/bin/bash
+protected_branch='main'
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+if [ "$current_branch" = "$protected_branch" ]; then
+    echo "🚫 Direct push to main blocked!"
+    echo "Create a feature branch and open a PR instead."
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Adds a husky pre-push hook that blocks direct pushes to the main branch
- Developers will be prompted to create feature branches and open PRs instead
- Helps prevent accidental direct pushes to main

## Test plan
- [x] Hook file created in `.husky/pre-push`
- [x] Hook is executable
- [ ] Test locally by attempting to push from main branch (should be blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)