### PR TITLE
fix: update registry snapshots for Sonnet 4.6 helicone endpoint

### DIFF
--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -1104,6 +1104,26 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
         "us-east-1",
       ],
     },
+    "claude-4.6-sonnet:helicone": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 64000,
+      "modelId": "pa/claude-sonnet-4-6",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "helicone",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
     "claude-4.6-sonnet:vertex": {
       "context": 1000000,
       "crossRegion": true,
@@ -6977,6 +6997,7 @@ exports[`Registry Snapshots model coverage snapshot 1`] = `
   "anthropic/claude-4.6-sonnet": [
     "anthropic",
     "bedrock",
+    "helicone",
     "vertex",
   ],
   "anthropic/claude-haiku-4-5-20251001": [
@@ -7855,6 +7876,23 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
         "output": 0.000015,
         "threshold": 0,
         "web_search": 0.01,
+      },
+      {
+        "input": 0.000006,
+        "output": 0.0000225,
+        "threshold": 200000,
+      },
+    ],
+    "helicone": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write1h": 2,
+          "write5m": 1.25,
+        },
+        "input": 0.000003,
+        "output": 0.000015,
+        "threshold": 0,
       },
       {
         "input": 0.000006,
@@ -9463,6 +9501,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "providers": [
         "anthropic",
         "bedrock",
+        "helicone",
         "vertex",
       ],
     },
@@ -10272,7 +10311,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "groq",
     },
     {
-      "modelCount": 48,
+      "modelCount": 49,
       "provider": "helicone",
     },
     {
@@ -10423,8 +10462,8 @@ exports[`Registry Snapshots verify registry state 1`] = `
     "claude-3.5-haiku:anthropic:*",
   ],
   "totalArchivedConfigs": 0,
-  "totalEndpoints": 312,
-  "totalModelProviderConfigs": 312,
+  "totalEndpoints": 313,
+  "totalModelProviderConfigs": 313,
   "totalModelsWithPtb": 104,
   "totalProviders": 21,
 }


### PR DESCRIPTION
The Packages Jest Tests are failing because the registry snapshot doesn't include the new `claude-4.6-sonnet:helicone` endpoint added in #5581.

This just runs `--updateSnapshot` to regenerate the snapshots. 4 snapshots updated.

The E2E failure is unrelated (Docker/Wrangler image inspection error).