### PR TITLE
feat(cost): add Gemini 3.1 Pro Preview model support

### DIFF
--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -2752,6 +2752,101 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
       ],
     },
   },
+  "google/gemini-3.1-pro": {
+    "gemini-3.1-pro-preview:google-ai-studio": {
+      "context": 1048576,
+      "crossRegion": false,
+      "maxTokens": 65536,
+      "modelId": "gemini-3.1-pro-preview",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p",
+      ],
+      "provider": "google-ai-studio",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+    "gemini-3.1-pro-preview:helicone": {
+      "context": 1048576,
+      "crossRegion": false,
+      "maxTokens": 65536,
+      "modelId": "pa/gemini-3.1-pro-preview",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p",
+      ],
+      "provider": "helicone",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+    "gemini-3.1-pro-preview:openrouter": {
+      "context": 1048576,
+      "crossRegion": false,
+      "maxTokens": 65536,
+      "modelId": "google/gemini-3.1-pro-preview",
+      "parameters": [
+        "max_tokens",
+        "response_format",
+        "seed",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p",
+      ],
+      "provider": "openrouter",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+    "gemini-3.1-pro-preview:vertex": {
+      "context": 1048576,
+      "crossRegion": true,
+      "maxTokens": 65536,
+      "modelId": "gemini-3.1-pro-preview",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p",
+      ],
+      "provider": "vertex",
+      "ptbEnabled": true,
+      "regions": [
+        "global",
+      ],
+    },
+  },
   "google/gemma": {
     "gemma2-9b-it:chutes": {
       "context": 8192,
@@ -7129,6 +7224,12 @@ exports[`Registry Snapshots model coverage snapshot 1`] = `
     "openrouter",
     "vertex",
   ],
+  "google/gemini-3.1-pro": [
+    "google-ai-studio",
+    "helicone",
+    "openrouter",
+    "vertex",
+  ],
   "google/gemma": [
     "chutes",
     "openrouter",
@@ -8798,6 +8899,64 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
       },
     ],
   },
+  "google/gemini-3.1-pro": {
+    "google-ai-studio": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+        },
+        "cacheStoragePerHour": 0.0000045,
+        "input": 0.000002,
+        "output": 0.000012,
+        "threshold": 0,
+      },
+      {
+        "input": 0.000004,
+        "output": 0.000018,
+        "threshold": 200000,
+      },
+    ],
+    "helicone": [
+      {
+        "input": 0.000002,
+        "output": 0.000012,
+        "threshold": 0,
+      },
+      {
+        "input": 0.000004,
+        "output": 0.000018,
+        "threshold": 200000,
+      },
+    ],
+    "openrouter": [
+      {
+        "input": 0.00000211,
+        "output": 0.00001266,
+        "threshold": 0,
+      },
+      {
+        "input": 0.00000422,
+        "output": 0.00001899,
+        "threshold": 200000,
+      },
+    ],
+    "vertex": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+        },
+        "cacheStoragePerHour": 0.0000045,
+        "input": 0.000002,
+        "output": 0.000012,
+        "threshold": 0,
+      },
+      {
+        "input": 0.000004,
+        "output": 0.000018,
+        "threshold": 200000,
+      },
+    ],
+  },
   "google/gemma": {
     "chutes": [
       {
@@ -9716,6 +9875,15 @@ exports[`Registry Snapshots verify registry state 1`] = `
       ],
     },
     {
+      "model": "gemini-3.1-pro-preview",
+      "providers": [
+        "google-ai-studio",
+        "helicone",
+        "openrouter",
+        "vertex",
+      ],
+    },
+    {
       "model": "gemma-3-12b-it",
       "providers": [
         "deepinfra",
@@ -10336,7 +10504,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "fireworks",
     },
     {
-      "modelCount": 7,
+      "modelCount": 8,
       "provider": "google-ai-studio",
     },
     {
@@ -10344,7 +10512,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "groq",
     },
     {
-      "modelCount": 50,
+      "modelCount": 51,
       "provider": "helicone",
     },
     {
@@ -10364,7 +10532,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "openai",
     },
     {
-      "modelCount": 68,
+      "modelCount": 69,
       "provider": "openrouter",
     },
     {
@@ -10372,7 +10540,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "perplexity",
     },
     {
-      "modelCount": 21,
+      "modelCount": 22,
       "provider": "vertex",
     },
     {
@@ -10411,6 +10579,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
     "gemini-3-flash-preview",
     "gemini-3-pro-image-preview",
     "gemini-3-pro-preview",
+    "gemini-3.1-pro-preview",
     "gemma-3-12b-it",
     "gemma2-9b-it",
     "glm-4.6",
@@ -10495,9 +10664,9 @@ exports[`Registry Snapshots verify registry state 1`] = `
     "claude-3.5-haiku:anthropic:*",
   ],
   "totalArchivedConfigs": 0,
-  "totalEndpoints": 314,
-  "totalModelProviderConfigs": 314,
-  "totalModelsWithPtb": 104,
+  "totalEndpoints": 318,
+  "totalModelProviderConfigs": 318,
+  "totalModelsWithPtb": 105,
   "totalProviders": 21,
 }
 `;

--- a/packages/cost/models/authors/google/gemini-3.1-pro/endpoints.ts
+++ b/packages/cost/models/authors/google/gemini-3.1-pro/endpoints.ts
@@ -1,0 +1,166 @@
+import { ModelProviderName } from "../../../providers";
+import type { ModelProviderConfig } from "../../../types";
+import { Gemini31ProPreviewModelName } from "./model";
+
+export const endpoints = {
+  "gemini-3.1-pro-preview:google-ai-studio": {
+    providerModelId: "gemini-3.1-pro-preview",
+    provider: "google-ai-studio",
+    author: "google",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000002, // $2/1M tokens
+        output: 0.000012, // $12/1M tokens
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.2/1M = 10% of input
+        },
+        cacheStoragePerHour: 0.0000045, // $4.50/1M tokens per hour
+      },
+      {
+        threshold: 200000,
+        input: 0.000004, // $4/1M tokens (over 200K context)
+        output: 0.000018, // $18/1M tokens (over 200K context)
+      },
+    ],
+    contextLength: 1_048_576,
+    maxCompletionTokens: 65_536,
+    supportedParameters: [
+      "include_reasoning",
+      "max_tokens",
+      "reasoning",
+      "response_format",
+      "seed",
+      "stop",
+      "structured_outputs",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_p",
+    ],
+    rateLimits: {
+      rpm: 2_000,
+      tpm: 8_000_000,
+    },
+    ptbEnabled: true,
+    responseFormat: "GOOGLE",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+  "gemini-3.1-pro-preview:vertex": {
+    providerModelId: "gemini-3.1-pro-preview",
+    provider: "vertex",
+    author: "google",
+    crossRegion: true,
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000002, // $2/1M tokens
+        output: 0.000012, // $12/1M tokens
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.2/1M = 10% of input
+        },
+        cacheStoragePerHour: 0.0000045, // $4.50/1M tokens per hour
+      },
+      {
+        threshold: 200000,
+        input: 0.000004, // $4/1M tokens (over 200K context)
+        output: 0.000018, // $18/1M tokens (over 200K context)
+      },
+    ],
+    contextLength: 1_048_576,
+    maxCompletionTokens: 65_536,
+    supportedParameters: [
+      "include_reasoning",
+      "max_tokens",
+      "reasoning",
+      "response_format",
+      "seed",
+      "stop",
+      "structured_outputs",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_p",
+    ],
+    responseFormat: "GOOGLE",
+    ptbEnabled: true,
+    endpointConfigs: {
+      global: {
+        providerModelId: "gemini-3.1-pro-preview",
+      },
+    },
+  },
+  "gemini-3.1-pro-preview:openrouter": {
+    provider: "openrouter",
+    author: "google",
+    providerModelId: "google/gemini-3.1-pro-preview",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.00000211, // $2.11/1M - $2.00/1M * 1.055
+        output: 0.00001266, // $12.66/1M - $12.00/1M * 1.055
+      },
+      {
+        threshold: 200000,
+        input: 0.00000422, // $4.22/1M - $4.00/1M * 1.055
+        output: 0.00001899, // $18.99/1M - $18.00/1M * 1.055
+      },
+    ],
+    contextLength: 1_048_576,
+    maxCompletionTokens: 65_536,
+    supportedParameters: [
+      "max_tokens",
+      "response_format",
+      "seed",
+      "stop",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_p",
+    ],
+    ptbEnabled: true,
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+  "gemini-3.1-pro-preview:helicone": {
+    provider: "helicone",
+    author: "google",
+    providerModelId: "pa/gemini-3.1-pro-preview",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000002, // $2/1M tokens
+        output: 0.000012, // $12/1M tokens
+      },
+      {
+        threshold: 200000,
+        input: 0.000004, // $4/1M tokens (over 200K context)
+        output: 0.000018, // $18/1M tokens (over 200K context)
+      },
+    ],
+    contextLength: 1_048_576,
+    maxCompletionTokens: 65_536,
+    supportedParameters: [
+      "include_reasoning",
+      "max_tokens",
+      "reasoning",
+      "response_format",
+      "seed",
+      "stop",
+      "structured_outputs",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_p",
+    ],
+    ptbEnabled: true,
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+} satisfies Partial<
+  Record<`${Gemini31ProPreviewModelName}:${ModelProviderName}`, ModelProviderConfig>
+>;

--- a/packages/cost/models/authors/google/gemini-3.1-pro/model.ts
+++ b/packages/cost/models/authors/google/gemini-3.1-pro/model.ts
@@ -1,0 +1,17 @@
+import { ModelConfig } from "../../../types";
+
+export const model = {
+  "gemini-3.1-pro-preview": {
+    name: "Google Gemini 3.1 Pro Preview",
+    author: "google",
+    description:
+      "Gemini 3.1 Pro Preview is Google's latest AI model with significantly improved reasoning capabilities. Achieves 77.1% on ARC-AGI-2 (more than double Gemini 3 Pro). Features advanced coding, complex problem-solving, and multimodal capabilities with a 1M token context window.",
+    contextLength: 1_048_576,
+    maxOutputTokens: 65_536,
+    created: "2026-02-19T00:00:00",
+    modality: { inputs: ["text", "image", "audio", "video"], outputs: ["text"] },
+    tokenizer: "Gemini",
+  },
+} satisfies Record<string, ModelConfig>;
+
+export type Gemini31ProPreviewModelName = keyof typeof model;

--- a/packages/cost/models/authors/google/index.ts
+++ b/packages/cost/models/authors/google/index.ts
@@ -17,6 +17,8 @@ import { model as gemini3FlashPreviewModel } from "./gemini-3-flash-preview/mode
 import { endpoints as gemini3FlashPreviewEndpoints } from "./gemini-3-flash-preview/endpoints";
 import { model as gemini3ProImagePreviewModel } from "./gemini-3-pro-image/model";
 import { endpoints as gemini3ProImagePreviewEndpoints } from "./gemini-3-pro-image/endpoints";
+import { model as gemini31ProPreviewModel } from "./gemini-3.1-pro/model";
+import { endpoints as gemini31ProPreviewEndpoints } from "./gemini-3.1-pro/endpoints";
 import { model as gemma29bModel } from "./gemma/model";
 import { endpoints as gemma29bEndpoints } from "./gemma/endpoints";
 import { model as gemma3Model } from "./gemma-3/model";
@@ -31,6 +33,7 @@ export const googleModels = {
   ...gemini3ProPreviewModel,
   ...gemini3FlashPreviewModel,
   ...gemini3ProImagePreviewModel,
+  ...gemini31ProPreviewModel,
   ...gemma29bModel,
   ...gemma3Model,
 } satisfies Record<string, ModelConfig>;
@@ -43,6 +46,7 @@ export const googleEndpointConfig = {
   ...gemini3ProPreviewEndpoints,
   ...gemini3FlashPreviewEndpoints,
   ...gemini3ProImagePreviewEndpoints,
+  ...gemini31ProPreviewEndpoints,
   ...gemma29bEndpoints,
   ...gemma3Endpoints,
 } satisfies Record<string, ModelProviderConfig>;

--- a/packages/cost/providers/google/index.ts
+++ b/packages/cost/providers/google/index.ts
@@ -244,6 +244,17 @@ export const costs: ModelRow[] = [
   {
     model: {
       operator: "includes",
+      value: "gemini-3.1-pro-preview",
+    },
+    cost: {
+      prompt_token: 0.000002,
+      completion_token: 0.000012,
+      prompt_cache_read_token: 0.0000002,
+    },
+  },
+  {
+    model: {
+      operator: "includes",
       value: "gemini-3-flash-preview",
     },
     cost: {

--- a/packages/cost/unified/models.ts
+++ b/packages/cost/unified/models.ts
@@ -478,6 +478,30 @@ export const modelMapping: CreatorModelMapping = {
         },
       ],
     },
+    "Gemini 3.1 Pro Preview": {
+      defaultTokenCost: {
+        input: 0,
+        output: 0,
+      },
+      defaultParameters: {
+        stop: [],
+        response_format: true,
+      },
+      providers: [
+        {
+          provider: "GOOGLE_GEMINI",
+          modelString: "gemini-3.1-pro-preview",
+        },
+        {
+          provider: "GOOGLE_VERTEXAI",
+          modelString: "gemini-3.1-pro-preview",
+        },
+        {
+          provider: "OPENROUTER",
+          modelString: "google/gemini-3.1-pro-preview",
+        },
+      ],
+    },
   },
   Meta: {
     "Llama 3.3 70B Instruct": {


### PR DESCRIPTION
## Summary
Add Google Gemini 3.1 Pro Preview (released today, Feb 19, 2026) — Google's new SOTA model with 77.1% on ARC-AGI-2 (2x+ over Gemini 3 Pro).

## Pricing (same as Gemini 3 Pro)
- **≤ 200K tokens:** $2/MTok input, $12/MTok output
- **> 200K tokens:** $4/MTok input, $18/MTok output
- Cache read: $0.20/MTok, Cache storage: $4.50/MTok/hr

## Model Details
- Context window: 1M tokens
- Max output: 64K tokens
- API model name: `gemini-3.1-pro-preview`
- Providers: Google AI Studio, Vertex AI, OpenRouter, Helicone

## Changes
- New: `packages/cost/models/authors/google/gemini-3.1-pro/` (model.ts + endpoints.ts)
- Modified: Google author index, legacy provider costs, unified models
- Updated: registry snapshots

All tests pass locally including snapshot tests.