### PR TITLE
fix(cost): add dated model ID for Claude Sonnet 4.6

### DIFF
--- a/packages/cost/providers/anthropic/index.ts
+++ b/packages/cost/providers/anthropic/index.ts
@@ -219,6 +219,20 @@ export const costs: ModelRow[] = [
   {
     model: {
       operator: "equals",
+      value: "claude-sonnet-4-6-20260217",
+    },
+    cost: {
+      prompt_token: 0.000003, // $3 / MTok
+      completion_token: 0.000015, // $15 / MTok
+      prompt_cache_write_token: 0.00000375, // 5m cache write: $3.75 / MTok
+      prompt_cache_read_token: 0.0000003, // Cache hits/refreshes: $0.30 / MTok
+      prompt_cache_creation_5m: 0.00000375, // $3.75 / MTok
+      prompt_cache_creation_1h: 0.000006, // $6 / MTok
+    },
+  },
+  {
+    model: {
+      operator: "equals",
       value: "claude-opus-4-20250514",
     },
     cost: {

--- a/packages/cost/unified/models.ts
+++ b/packages/cost/unified/models.ts
@@ -337,6 +337,10 @@ export const modelMapping: CreatorModelMapping = {
           modelString: "claude-sonnet-4-6",
         },
         {
+          provider: "ANTHROPIC",
+          modelString: "claude-sonnet-4-6-20260217",
+        },
+        {
           provider: "BEDROCK",
           modelString: "anthropic.claude-sonnet-4-6-20260217-v1:0",
         },


### PR DESCRIPTION
## Summary
- Fixes $0 cost calculations for Claude Sonnet 4.6

## Problem
PR #5579 added pricing for `claude-sonnet-4-6` but the Anthropic API returns the dated version `claude-sonnet-4-6-20260217`. The cost lookup uses exact string matching, so it failed to find the model.

## Changes
- Added `claude-sonnet-4-6-20260217` to legacy cost lookup
- Added dated version to unified models mapping

## Testing
All cost tests pass.

## Priority
**HIGH** - Blocking customer from going live (ref: Arpit's Slack message)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)