### PR TITLE
fix: strip models/ prefix from Google Gemini model names for correct cost calculation

### DIFF
--- a/valhalla/jawn/src/lib/handlers/ResponseBodyHandler.ts
+++ b/valhalla/jawn/src/lib/handlers/ResponseBodyHandler.ts
@@ -201,10 +201,11 @@ export class ResponseBodyHandler extends AbstractLogHandler {
           } else if (parsedUsage.data) {
             context.usage = parsedUsage.data ?? null;
 
-            const providerModelId =
+            const providerModelId = (
               context.message.heliconeMeta.providerModelId ??
               (!isAIGateway ? context.processedLog.model : "") ??
-              "";
+              ""
+            ).replace(/^models\//, "");
 
             const breakdown = modelCostBreakdownFromRegistry({
               modelUsage: parsedUsage.data,

--- a/valhalla/jawn/src/utils/modelMapper.ts
+++ b/valhalla/jawn/src/utils/modelMapper.ts
@@ -6,7 +6,9 @@ export function getModelFromRequest(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (requestBody && (requestBody as any).model) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (requestBody as any).model;
+    const model = (requestBody as any).model;
+    // Strip Google's "models/" prefix for consistent cost registry lookups
+    return typeof model === "string" ? model.replace(/^models\//, "") : model;
   }
 
   if (targetUrl && targetUrl.toLowerCase().includes("firecrawl")) {
@@ -53,13 +55,14 @@ function getModelFromPath(path: string) {
 }
 
 export function getModelFromResponse(responseBody: any) {
-  return (
+  const model =
     responseBody?.model ??
     responseBody?.body?.model ??
     responseBody?.body?.modelVersion ??
     responseBody?.providerMetadata?.gateway?.routing?.originalModelId ??
-    null
-  );
+    null;
+  // Strip Google's "models/" prefix for consistent cost registry lookups
+  return typeof model === "string" ? model.replace(/^models\//, "") : model;
 }
 
 export function calculateModel(


### PR DESCRIPTION
## Problem

Google's Gemini API returns model names with a `models/` prefix in the request body (e.g., `models/gemini-3-pro-preview`). The new cost registry performs exact match lookups expecting bare model names like `gemini-3-pro-preview`, so these lookups fail.

When the registry lookup fails, cost calculation falls back to the legacy pricing system, which lacks `prompt_cache_write_token` pricing. This causes cache write tokens to be incorrectly charged at the standard input token rate ($2/1M) instead of using the registry's `cacheMultipliers`.

## Fix

Strip the `models/` prefix from Google model names in three locations:

1. **`modelMapper.ts` → `getModelFromRequest()`** — normalizes the model name extracted from the request body
2. **`modelMapper.ts` → `getModelFromResponse()`** — normalizes the model name extracted from the response (including `modelVersion`)
3. **`ResponseBodyHandler.ts`** — normalizes `providerModelId` before passing to `modelCostBreakdownFromRegistry()`

This ensures the cost registry always receives clean model names for lookup, enabling correct cache token pricing via the new registry system.

## Context

Reported by a customer experiencing incorrect cache pricing for Google Gemini models. Cache write tokens were being charged at the input rate instead of at the correct cache write rate defined in the cost registry.