### PR TITLE
security: fix critical vulnerabilities (C1, C3, C4, C6)

### DIFF
--- a/web/components/templates/auth/authForm.tsx
+++ b/web/components/templates/auth/authForm.tsx
@@ -51,7 +51,15 @@ const AuthForm = (props: AuthFormProps) => {
       const urlParam = fullUrl.substring(startIndex + 4);
       const decodedUrl = decodeURIComponent(urlParam);
 
-      window.location.href = decodedUrl as string;
+      // Validate redirect URL to prevent open redirect attacks
+      try {
+        const redirectUrl = new URL(decodedUrl, window.location.origin);
+        if (redirectUrl.origin === window.location.origin) {
+          window.location.href = redirectUrl.href;
+        }
+      } catch {
+        // Invalid URL, ignore redirect
+      }
     }
   }, [router.query, router.asPath]);
 

--- a/web/pages/api/intercom.ts
+++ b/web/pages/api/intercom.ts
@@ -85,12 +85,17 @@ export default async function handler(
 
     const payload = JSON.stringify(req.body);
 
-    // Debug: Log incoming webhook data
-
-    // Verify webhook signature (temporarily disabled for testing)
-    // if (signature && !verifyIntercomWebhook(payload, signature.replace("sha256=", ""), intercomSecret)) {
-    //   return res.status(401).json({ error: "Invalid signature" });
-    // }
+    // Verify webhook signature
+    if (
+      !signature ||
+      !verifyIntercomWebhook(
+        payload,
+        signature.replace("sha256=", ""),
+        intercomSecret
+      )
+    ) {
+      return res.status(401).json({ error: "Invalid signature" });
+    }
 
     const webhookData = req.body as IntercomWebhookPayload;
     const service = new IntercomSlackService();

--- a/web/pages/api/slack-events.ts
+++ b/web/pages/api/slack-events.ts
@@ -69,11 +69,10 @@ export default async function handler(
 
     const payload = JSON.stringify(req.body);
 
-    // Verify webhook signature (temporarily disabled for testing)
-    if (signature && !verifySlackWebhook(payload, signature, slackSecret)) {
+    // Verify webhook signature
+    if (!signature || !verifySlackWebhook(payload, signature, slackSecret)) {
       return res.status(401).json({ error: "Invalid signature" });
     }
-    // Note: Webhook signature verification is disabled for testing
 
     const eventData = req.body as SlackEventPayload;
     const service = new IntercomSlackService();

--- a/worker/RequestBodyBufferContainer/src/app.ts
+++ b/worker/RequestBodyBufferContainer/src/app.ts
@@ -226,8 +226,10 @@ export function createApp(config: AppConfig, logger: any): FastifyInstance {
     try {
       const bodyJson = JSON.parse(entry.data.toString("utf8"));
 
+      const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
       const applyOverride = (body: any, override: object): object => {
         for (const [key, value] of Object.entries(override)) {
+          if (DANGEROUS_KEYS.has(key)) continue;
           if (typeof value !== "object" || value === null || Array.isArray(value)) {
             body[key] = value;
           } else {

--- a/worker/src/RequestBodyBuffer/RequestBodyBuffer_InMemory.ts
+++ b/worker/src/RequestBodyBuffer/RequestBodyBuffer_InMemory.ts
@@ -50,8 +50,15 @@ export class RequestBodyBuffer_InMemory implements IRequestBodyBuffer {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private static readonly DANGEROUS_KEYS = new Set([
+    "__proto__",
+    "constructor",
+    "prototype",
+  ]);
+
   private applyOverride(body: any, override: object): object {
     for (const [key, value] of Object.entries(override)) {
+      if (RequestBodyBuffer_InMemory.DANGEROUS_KEYS.has(key)) continue;
       if (typeof value !== "object" || value === null || Array.isArray(value)) {
         body[key] = value;
       } else {


### PR DESCRIPTION
## Security Fixes — Batch 1

Fixes 4 critical findings from the security scan report.

### C1: Prototype Pollution in `applyOverride()`
**Files:** `RequestBodyBuffer_InMemory.ts`, `RequestBodyBufferContainer/app.ts`
**Fix:** Block `__proto__`, `constructor`, and `prototype` keys in the recursive override function. Prevents attackers from polluting Object.prototype via request body overrides.

### C3: Disabled Intercom Webhook Signature Verification
**File:** `web/pages/api/intercom.ts`
**Fix:** Re-enabled signature verification that was commented out for testing. Now rejects requests with missing or invalid signatures (401).

### C4: Slack Webhook Signature Bypass
**File:** `web/pages/api/slack-events.ts`
**Fix:** Changed `if (signature && ...)` to `if (!signature || ...)` so requests without a signature header are rejected instead of accepted.

### C6: Open Redirect in Auth Form
**File:** `web/components/templates/auth/authForm.tsx`
**Fix:** Validates redirect URL origin matches `window.location.origin` before redirecting. Prevents phishing via crafted login URLs like `/signin?url=https://evil.com`.

---

All changes are minimal and surgical. Worker TypeScript compiles clean.