### PR TITLE
security: fix remaining HIGH findings (H2 remaining, H8, H10)

### DIFF
--- a/valhalla/jawn/src/controllers/private/adminController.ts
+++ b/valhalla/jawn/src/controllers/private/adminController.ts
@@ -208,8 +208,8 @@ export class AdminController extends Controller {
   }> {
     await authCheckThrow(request.authParams.userId);
 
-    const limit = body.limit ?? 10;
-    const minRequests = body.minRequests ?? 1_000_000;
+    const limit = Math.max(1, Math.min(Math.floor(Number(body.limit) || 10), 1000));
+    const minRequests = Math.max(0, Math.floor(Number(body.minRequests) || 1_000_000));
 
     // Fetch top organizations by usage in the past month
     const topOrgsQuery = `

--- a/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
+++ b/valhalla/jawn/src/lib/db/ClickhouseWrapper.ts
@@ -101,7 +101,7 @@ export class ClickhouseClientWrapper {
       }
       return { data: validated.data, error: null };
     } catch (err) {
-      console.error("Error executing Clickhouse query: ", query, parameters);
+      console.error("Error executing Clickhouse query: ", query);
       console.error(err);
       // Extract error message properly - Error objects don't stringify well
       const errorMessage = err instanceof Error ? err.message : String(err);

--- a/valhalla/jawn/src/lib/db/valhalla.ts
+++ b/valhalla/jawn/src/lib/db/valhalla.ts
@@ -109,7 +109,7 @@ class ValhallaDB implements IValhallaDB {
     try {
       client = await this.pool.connect();
     } catch (thrownErr) {
-      console.error("Error in query", query, thrownErr);
+      console.error("Error in query", query);
       return err(JSON.stringify(thrownErr));
     }
 
@@ -118,7 +118,7 @@ class ValhallaDB implements IValhallaDB {
       client.release();
       return ok(result);
     } catch (thrownErr) {
-      console.error("Error in query", query, thrownErr);
+      console.error("Error in query", query);
       client.release();
       return err(JSON.stringify(thrownErr));
     }

--- a/valhalla/jawn/src/lib/shared/db/dbExecute.ts
+++ b/valhalla/jawn/src/lib/shared/db/dbExecute.ts
@@ -85,7 +85,7 @@ export async function dbExecute<T>(
 
     return { data: result, error: null };
   } catch (err) {
-    console.error("Error executing query: ", query, parameters);
+    console.error("Error executing query: ", query);
     console.error(err);
     return { data: null, error: JSON.stringify(err) };
   }

--- a/valhalla/jawn/src/managers/MetricsManager.ts
+++ b/valhalla/jawn/src/managers/MetricsManager.ts
@@ -723,6 +723,8 @@ export class MetricsManager extends BaseManager {
     if (isNaN(offset) || isNaN(limit)) {
       return { data: null, error: "Invalid offset or limit" };
     }
+    offset = Math.max(0, Math.floor(offset));
+    limit = Math.max(1, Math.min(Math.floor(limit), 10000));
 
     const builtFilter = await buildFilterWithAuthClickHouse({
       org_id: this.authParams.organizationId,
@@ -790,6 +792,8 @@ export class MetricsManager extends BaseManager {
     if (isNaN(offset) || isNaN(limit)) {
       return { data: null, error: "Invalid offset or limit" };
     }
+    offset = Math.max(0, Math.floor(offset));
+    limit = Math.max(1, Math.min(Math.floor(limit), 10000));
 
     const builtFilter = await buildFilterWithAuthClickHouse({
       org_id: this.authParams.organizationId,

--- a/valhalla/jawn/src/managers/dataset/HeliconeDatasetManager.ts
+++ b/valhalla/jawn/src/managers/dataset/HeliconeDatasetManager.ts
@@ -108,6 +108,8 @@ export class HeliconeDatasetManager extends BaseManager {
   }
 
   async query(datasetId: string, params: { offset: number; limit: number }) {
+    const limit = Math.max(1, Math.min(Math.floor(Number(params.limit) || 50), 10000));
+    const offset = Math.max(0, Math.floor(Number(params.offset) || 0));
     const query = `
       SELECT 
         hdr.id,
@@ -120,8 +122,8 @@ export class HeliconeDatasetManager extends BaseManager {
       AND hdr.organization_id = $2
       AND hd.deleted_at IS NULL
       ORDER BY hdr.created_at DESC
-      LIMIT ${params.limit}
-      OFFSET ${params.offset}
+      LIMIT ${limit}
+      OFFSET ${offset}
     `;
 
     const result = await dbExecute<HeliconeDatasetRow>(query, [

--- a/valhalla/jawn/src/middleware/auth.ts
+++ b/valhalla/jawn/src/middleware/auth.ts
@@ -68,7 +68,18 @@ export const authMiddleware = async (
   res: Response,
   next: NextFunction
 ) => {
-  if (req.path.startsWith("/v1/public")) {
+  // Public routes — explicitly whitelisted to prevent accidental exposure
+  const PUBLIC_ROUTE_PREFIXES = [
+    "/v1/public/model-registry",
+    "/v1/public/stats",
+    "/v1/public/security",
+    "/v1/public/alert-banner",
+    "/v1/public/status/provider",
+    "/v1/public/pi",
+    "/v1/public/compare",
+    "/v1/public/waitlist",
+  ];
+  if (PUBLIC_ROUTE_PREFIXES.some((prefix) => req.path.startsWith(prefix))) {
     next();
     return;
   }

--- a/worker/src/lib/db/ClickhouseWrapper.ts
+++ b/worker/src/lib/db/ClickhouseWrapper.ts
@@ -94,7 +94,7 @@ export class ClickhouseClientWrapper {
       });
       return { data: await queryResult.json<T[]>(), error: null };
     } catch (err) {
-      console.error("Error executing query: ", query, parameters);
+      console.error("Error executing query: ", query);
       console.error(err);
       return {
         data: null,


### PR DESCRIPTION
## Security Fixes — Batch 3

### H2 (remaining): LIMIT/OFFSET SQL injection hardening
**Files:** adminController, MetricsManager, HeliconeDatasetManager
- Validate and clamp `limit` and `offset` as safe integers before SQL interpolation
- Adds `Math.floor()` + `Math.max()/Math.min()` bounds

### H8: Remove query parameters from error logs
**Files:** dbExecute.ts, ClickhouseWrapper.ts (jawn + worker), valhalla.ts
- Removed `parameters` from `console.error()` calls in catch blocks
- Query text is still logged for debugging, but parameter values (which may contain PII, secrets, or user data) are no longer exposed

### H10: Replace blanket public route auth bypass with whitelist
**File:** `valhalla/jawn/src/middleware/auth.ts`
- Changed `req.path.startsWith('/v1/public')` to explicit whitelist of 8 known public route prefixes
- Prevents future endpoints accidentally added under `/v1/public/` from being unauthenticated

---

All TypeScript compiles clean (only pre-existing Gemini duplicate import errors on main).