### PR TITLE
fix: add missing helicone endpoint for Claude 4.6 Opus

### DIFF
--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -1020,6 +1020,26 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
         "us-east-1",
       ],
     },
+    "claude-4.6-opus:helicone": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 64000,
+      "modelId": "pa/claude-opus-4-6",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "helicone",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
     "claude-4.6-opus:openrouter": {
       "context": 1000000,
       "crossRegion": false,
@@ -7067,6 +7087,7 @@ exports[`Registry Snapshots model coverage snapshot 1`] = `
   "anthropic/claude-4.6-opus": [
     "anthropic",
     "bedrock",
+    "helicone",
     "openrouter",
     "vertex",
   ],
@@ -7899,6 +7920,19 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
       {
         "cacheMultipliers": {
           "cachedInput": 0.1,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+    "helicone": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write1h": 2,
           "write5m": 1.25,
         },
         "input": 0.000005,
@@ -9625,6 +9659,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "providers": [
         "anthropic",
         "bedrock",
+        "helicone",
         "openrouter",
         "vertex",
       ],
@@ -10452,7 +10487,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "groq",
     },
     {
-      "modelCount": 51,
+      "modelCount": 52,
       "provider": "helicone",
     },
     {
@@ -10604,8 +10639,8 @@ exports[`Registry Snapshots verify registry state 1`] = `
     "claude-3.5-haiku:anthropic:*",
   ],
   "totalArchivedConfigs": 0,
-  "totalEndpoints": 316,
-  "totalModelProviderConfigs": 316,
+  "totalEndpoints": 317,
+  "totalModelProviderConfigs": 317,
   "totalModelsWithPtb": 105,
   "totalProviders": 21,
 }

--- a/packages/cost/models/authors/anthropic/claude-4.6-opus/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-4.6-opus/endpoints.ts
@@ -142,6 +142,40 @@ export const endpoints = {
       "*": {},
     },
   },
+  "claude-4.6-opus:helicone": {
+    provider: "helicone",
+    author: "anthropic",
+    providerModelId: "pa/claude-opus-4-6",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+          write1h: 2.0, // $10 / MTok (200% of $5)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 64000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
 } satisfies Partial<
   Record<`${ClaudeOpus46ModelName}:${ModelProviderName}`, ModelProviderConfig>
 >;


### PR DESCRIPTION
## Summary
- Adds the missing `claude-4.6-opus:helicone` endpoint that was removed in PR #5559 before merge
- Pricing matches the anthropic endpoint: $5/MTok input, $25/MTok output
- Fixes AI gateway routing to OpenRouter instead of Helicone for Claude 4.6 Opus

## Context
The helicone endpoint was originally included in the branch but was removed with commit message "chore: remove helicone provider endpoint (not set up yet)" before the PR was merged.

## Test plan
- [x] Snapshot tests updated and passing
- [x] All package tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)