### PR TITLE
fix: extract thoughtsTokenCount for Gemini thinking models

### DIFF
--- a/valhalla/jawn/src/lib/shared/bodyProcessors/__tests__/googleBodyProcessor.test.ts
+++ b/valhalla/jawn/src/lib/shared/bodyProcessors/__tests__/googleBodyProcessor.test.ts
@@ -118,4 +118,58 @@ describe("GoogleBodyProcessor", () => {
       promptCacheReadTokens: 13644,
     });
   });
+
+  it("handles Gemini thinking model responses with thoughtsTokenCount", async () => {
+    const body = {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [
+              {
+                text: "25 * 47 = 1175",
+              },
+            ],
+          },
+          finishReason: "STOP",
+          avgLogprobs: -0.24105726576781206,
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 15,
+        candidatesTokenCount: 359,
+        totalTokenCount: 1035,
+        thoughtsTokenCount: 661,
+        trafficType: "ON_DEMAND",
+        promptTokensDetails: [
+          {
+            modality: "TEXT",
+            tokenCount: 15,
+          },
+        ],
+        candidatesTokensDetails: [
+          {
+            modality: "TEXT",
+            tokenCount: 359,
+          },
+        ],
+      },
+      modelVersion: "gemini-2.5-flash",
+      createTime: "2026-02-24T06:59:17.723195Z",
+      responseId: "RUydafuRLIuolu8P8YbxgAg",
+    };
+
+    const { usage } = await parse(body);
+
+    expect(usage).toEqual({
+      totalTokens: 1035,
+      promptTokens: 15,
+      // thoughts + candidates (661 + 359)
+      completionTokens: 1020,
+      // reasoningTokens should be extracted separately
+      reasoningTokens: 661,
+      heliconeCalculated: false,
+      promptCacheReadTokens: undefined,
+    });
+  });
 });

--- a/valhalla/jawn/src/lib/shared/bodyProcessors/googleBodyProcessor.ts
+++ b/valhalla/jawn/src/lib/shared/bodyProcessors/googleBodyProcessor.ts
@@ -70,19 +70,23 @@ export class GoogleBodyProcessor implements IBodyProcessor {
       ?.promptTokenCount;
     const cachedContentTokens = usageMetadataItem?.usageMetadata
       ?.cachedContentTokenCount;
+    // If there's no caching, return raw promptTokenCount
+    // If there's caching, subtract cached tokens from prompt tokens
     const adjustedPromptTokens =
-      promptTokens !== undefined && cachedContentTokens !== undefined
-        ? promptTokens - cachedContentTokens
+      promptTokens !== undefined
+        ? promptTokens - (cachedContentTokens ?? 0)
         : undefined;
+
+    const thoughtsTokenCount = usageMetadataItem?.usageMetadata?.thoughtsTokenCount ?? 0;
+    const candidatesTokenCount = usageMetadataItem?.usageMetadata?.candidatesTokenCount ?? 0;
 
     return ok({
       processedBody: parsedResponseBody,
       usage: {
         totalTokens: usageMetadataItem?.usageMetadata?.totalTokenCount,
         promptTokens: adjustedPromptTokens,
-        completionTokens:
-          (usageMetadataItem?.usageMetadata?.thoughtsTokenCount ?? 0) +
-          (usageMetadataItem?.usageMetadata?.candidatesTokenCount ?? 0),
+        completionTokens: thoughtsTokenCount + candidatesTokenCount,
+        reasoningTokens: thoughtsTokenCount > 0 ? thoughtsTokenCount : undefined,
         heliconeCalculated: false,
         promptCacheReadTokens: cachedContentTokens,
       },

--- a/worker/src/lib/dbLogger/DBLoggable.ts
+++ b/worker/src/lib/dbLogger/DBLoggable.ts
@@ -532,6 +532,7 @@ export class DBLoggable {
           promptTokenCount?: number;
           candidatesTokenCount?: number;
           cachedContentTokenCount?: number;
+          thoughtsTokenCount?: number;
         };
       };
       const usageMetadata = response.usageMetadata;
@@ -540,6 +541,7 @@ export class DBLoggable {
         prompt_tokens: usageMetadata?.promptTokenCount,
         completion_tokens: usageMetadata?.candidatesTokenCount,
         prompt_cache_read_tokens: usageMetadata?.cachedContentTokenCount,
+        reasoning_tokens: usageMetadata?.thoughtsTokenCount,
       };
     }
 


### PR DESCRIPTION
## Summary
- Add `reasoning_tokens` extraction from Gemini `usageMetadata.thoughtsTokenCount` in worker's `getDetailedUsage()`
- Add `reasoningTokens` to `GoogleBodyProcessor` output in Jawn
- Fix `promptTokens` calculation when no caching is present (was returning `undefined` instead of raw `promptTokenCount`)

## Problem
Gemini thinking models (2.5 Flash, 3.x Pro) return `thoughtsTokenCount` separately from `candidatesTokenCount`:

```json
"usageMetadata": {
  "promptTokenCount": 15,
  "candidatesTokenCount": 359,
  "totalTokenCount": 1035,
  "thoughtsTokenCount": 661  // This was not being extracted!
}
```

This caused:
1. Token count discrepancies (input + output didn't match total)
2. Incorrect cost calculations (thinking tokens weren't tracked separately)
3. Missing reasoning_tokens in the detailed usage breakdown

## Test plan
- [x] Added test for Gemini thinking model response with `thoughtsTokenCount`
- [x] Existing GoogleBodyProcessor tests pass
- [x] Full packages test suite passes (578 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)