### PR TITLE
fix: forward cachedContent parameter in OpenAI-to-Gemini transformation

### DIFF
--- a/packages/__tests__/llm-mapper/openai-to-google-cached-content.test.ts
+++ b/packages/__tests__/llm-mapper/openai-to-google-cached-content.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "@jest/globals";
+import { toGoogle } from "../../llm-mapper/transform/providers/openai/request/toGoogle";
+
+describe("toGoogle cachedContent transformation", () => {
+  it("should forward cachedContent parameter for Vertex AI format", () => {
+    const openAIRequest = {
+      model: "gemini-2.5-flash",
+      messages: [
+        {
+          role: "user" as const,
+          content: "Analyze the data in the cache.",
+        },
+      ],
+      cachedContent: "projects/my-project/locations/us-central1/cachedContents/abc123",
+    };
+
+    const result = toGoogle(openAIRequest as any);
+
+    expect(result.cachedContent).toBe(
+      "projects/my-project/locations/us-central1/cachedContents/abc123"
+    );
+    expect(result.contents).toHaveLength(1);
+  });
+
+  it("should forward cachedContent parameter for Google AI Studio format", () => {
+    const openAIRequest = {
+      model: "gemini-2.5-flash",
+      messages: [
+        {
+          role: "user" as const,
+          content: "Summarize the cached document.",
+        },
+      ],
+      cachedContent: "cachedContents/xyz789",
+    };
+
+    const result = toGoogle(openAIRequest as any);
+
+    expect(result.cachedContent).toBe("cachedContents/xyz789");
+  });
+
+  it("should not include cachedContent when not provided", () => {
+    const openAIRequest = {
+      model: "gemini-2.5-flash",
+      messages: [
+        {
+          role: "user" as const,
+          content: "Hello world",
+        },
+      ],
+    };
+
+    const result = toGoogle(openAIRequest);
+
+    expect(result.cachedContent).toBeUndefined();
+  });
+
+  it("should not include cachedContent when empty string", () => {
+    const openAIRequest = {
+      model: "gemini-2.5-flash",
+      messages: [
+        {
+          role: "user" as const,
+          content: "Hello world",
+        },
+      ],
+      cachedContent: "",
+    };
+
+    const result = toGoogle(openAIRequest as any);
+
+    expect(result.cachedContent).toBeUndefined();
+  });
+
+  it("should work with cachedContent and other parameters", () => {
+    const openAIRequest = {
+      model: "gemini-2.5-flash",
+      messages: [
+        {
+          role: "system" as const,
+          content: "You are a helpful assistant.",
+        },
+        {
+          role: "user" as const,
+          content: "What's in the cached content?",
+        },
+      ],
+      cachedContent: "projects/test/locations/us-central1/cachedContents/test123",
+      temperature: 0.7,
+      max_tokens: 1024,
+    };
+
+    const result = toGoogle(openAIRequest as any);
+
+    expect(result.cachedContent).toBe(
+      "projects/test/locations/us-central1/cachedContents/test123"
+    );
+    expect(result.system_instruction).toBeDefined();
+    expect(result.generationConfig?.temperature).toBe(0.7);
+    expect(result.generationConfig?.maxOutputTokens).toBe(1024);
+    expect(result.contents).toHaveLength(1); // Only user message, system is separate
+  });
+});

--- a/packages/llm-mapper/transform/providers/openai/request/toGoogle.ts
+++ b/packages/llm-mapper/transform/providers/openai/request/toGoogle.ts
@@ -108,6 +108,14 @@ export function toGoogle(
     }
   }
 
+  // Forward cachedContent parameter for Gemini explicit caching
+  // Supports both Vertex AI format (projects/*/locations/*/cachedContents/*)
+  // and Google AI Studio format (cachedContents/*)
+  const cachedContent = (openAIBody as any).cachedContent;
+  if (typeof cachedContent === "string" && cachedContent.length > 0) {
+    geminiBody.cachedContent = cachedContent;
+  }
+
   return geminiBody;
 }
 

--- a/packages/llm-mapper/transform/types/google.ts
+++ b/packages/llm-mapper/transform/types/google.ts
@@ -76,6 +76,12 @@ export interface GeminiGenerateContentRequest {
   generationConfig?: GeminiGenerationConfig;
   tools?: GeminiTool[];
   toolConfig?: GeminiToolConfig;
+  /**
+   * Reference to a cached content resource.
+   * Format: "projects/{project}/locations/{location}/cachedContents/{cache_id}"
+   * or "cachedContents/{cache_id}" for Google AI Studio
+   */
+  cachedContent?: string;
 }
 
 export type ChatCompletionMessage =


### PR DESCRIPTION
## Summary
- Add `cachedContent` field to `GeminiGenerateContentRequest` interface
- Forward `cachedContent` from OpenAI-format requests to Gemini native format
- Support both Vertex AI format (`projects/*/locations/*/cachedContents/*`) and Google AI Studio format (`cachedContents/*`)

## Problem
When users send requests through the AI Gateway with explicit caching:

```json
{
  "model": "gemini-3-flash-preview/vertex",
  "messages": [{"role": "user", "content": "Analyze the data in the cache."}],
  "cachedContent": "projects/YOUR_PROJECT/locations/us-central1/cachedContents/YOUR_CACHE_ID"
}
```

The `cachedContent` parameter was being **dropped** during the OpenAI-to-Gemini transformation, causing:
1. Gemini not using the cached content
2. Higher token usage (all tokens counted as fresh input)
3. Higher costs (no cache discount applied)

## Solution
The `toGoogle()` transformation function now forwards the `cachedContent` parameter to the native Gemini request format.

## Test plan
- [x] Added 5 tests for cachedContent transformation
- [x] Full packages test suite passes (583 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)