### PR TITLE
fix: extract Anthropic cache_creation_input_tokens without TTL breakdown

### DIFF
--- a/packages/__tests__/cost/usageProcessor.test.ts
+++ b/packages/__tests__/cost/usageProcessor.test.ts
@@ -298,6 +298,81 @@ describe("AnthropicUsageProcessor", () => {
     });
   });
 
+  it("should extract cache_creation_input_tokens without TTL breakdown", async () => {
+    // Test case for older API responses that have cache_creation_input_tokens
+    // but no cache_creation.ephemeral_5m_input_tokens breakdown
+    const mockResponse = {
+      id: "msg_test",
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text: "Hello" }],
+      model: "claude-sonnet-4",
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 500,
+        cache_read_input_tokens: 200,
+        // Note: no cache_creation.ephemeral_5m_input_tokens
+      },
+    };
+
+    const result = await processor.parse({
+      responseBody: JSON.stringify(mockResponse),
+      isStream: false,
+      model: "claude-sonnet-4",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({
+      input: 100,
+      output: 50,
+      cacheDetails: {
+        cachedInput: 200,
+        write5m: 500, // Should fall back to cache_creation_input_tokens
+      },
+    });
+  });
+
+  it("should prefer TTL breakdown over total cache_creation_input_tokens", async () => {
+    // When both total and breakdown are provided, use the breakdown
+    const mockResponse = {
+      id: "msg_test",
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text: "Hello" }],
+      model: "claude-sonnet-4",
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 600, // Total (should be 5m + 1h)
+        cache_read_input_tokens: 200,
+        cache_creation: {
+          ephemeral_5m_input_tokens: 400,
+          ephemeral_1h_input_tokens: 200,
+        },
+      },
+    };
+
+    const result = await processor.parse({
+      responseBody: JSON.stringify(mockResponse),
+      isStream: false,
+      model: "claude-sonnet-4",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({
+      input: 100,
+      output: 50,
+      cacheDetails: {
+        cachedInput: 200,
+        write5m: 400, // Use breakdown, not total
+        write1h: 200,
+      },
+    });
+  });
+
   it("usage processing snapshot", async () => {
     const testCases = [
       {

--- a/packages/cost/usage/anthropicUsageProcessor.ts
+++ b/packages/cost/usage/anthropicUsageProcessor.ts
@@ -104,6 +104,10 @@ export class AnthropicUsageProcessor implements IUsageProcessor {
       const outputTokens = usage.output_tokens ?? 0;
       const cacheReadInputTokens = usage.cache_read_input_tokens ?? 0;
 
+      // Total cache creation tokens (always present when caching occurs)
+      const cacheCreationInputTokens = usage.cache_creation_input_tokens ?? 0;
+
+      // TTL breakdown (may not be present in all API versions/responses)
       const cacheCreation = usage.cache_creation || {};
       const ephemeral5mTokens = cacheCreation.ephemeral_5m_input_tokens ?? 0;
       const ephemeral1hTokens = cacheCreation.ephemeral_1h_input_tokens ?? 0;
@@ -119,13 +123,21 @@ export class AnthropicUsageProcessor implements IUsageProcessor {
 
       if (
         cacheReadInputTokens > 0 ||
+        cacheCreationInputTokens > 0 ||
         ephemeral5mTokens > 0 ||
         ephemeral1hTokens > 0
       ) {
         modelUsage.cacheDetails = { cachedInput: cacheReadInputTokens };
 
+        // Use TTL breakdown if available, otherwise fall back to total cache creation tokens
+        // This handles cases where cache_creation_input_tokens is set but TTL breakdown is not
+        const ttlBreakdownTotal = ephemeral5mTokens + ephemeral1hTokens;
+
         if (ephemeral5mTokens > 0) {
           modelUsage.cacheDetails.write5m = ephemeral5mTokens;
+        } else if (cacheCreationInputTokens > 0 && ttlBreakdownTotal === 0) {
+          // No TTL breakdown provided, use total cache creation tokens as 5m (default TTL)
+          modelUsage.cacheDetails.write5m = cacheCreationInputTokens;
         }
 
         if (ephemeral1hTokens > 0) {

--- a/packages/llm-mapper/transform/providers/anthropic/response/toOpenai.ts
+++ b/packages/llm-mapper/transform/providers/anthropic/response/toOpenai.ts
@@ -69,7 +69,7 @@ export function toOpenAI(response: AnthropicResponseBody): OpenAIResponseBody {
             cache_write_details: {
               write_5m_tokens:
                 anthropicUsage.cache_creation?.ephemeral_5m_input_tokens ??
-                cachedTokens ??
+                cacheWriteTokens ??
                 0,
               write_1h_tokens:
                 anthropicUsage.cache_creation?.ephemeral_1h_input_tokens ?? 0,


### PR DESCRIPTION
## Summary

Fixes Anthropic prompt caching issue where cache write tokens were not being extracted when the TTL breakdown was not provided.

**Root cause**: The `AnthropicUsageProcessor` was only looking at `cache_creation.ephemeral_5m_input_tokens` and `cache_creation.ephemeral_1h_input_tokens`, completely ignoring the main `cache_creation_input_tokens` field. When Anthropic's API returns the total without the TTL breakdown (older API responses, certain scenarios), the cache write tokens were lost.

**Impact**:
- Incorrect cost calculations (undercharging for cache writes)
- Missing cache write data in the dashboard
- "cache read without cache creation" display issues reported by customers

## Changes

1. **`packages/cost/usage/anthropicUsageProcessor.ts`**: Now extracts `cache_creation_input_tokens` and uses it as fallback when TTL breakdown is not available

2. **`packages/llm-mapper/transform/providers/anthropic/response/toOpenai.ts`**: Fixed fallback from `cachedTokens` (read) to `cacheWriteTokens` (write) in non-streaming transformation

3. Added 2 new test cases to verify the fix

## Test plan

- [x] All 585 existing tests pass
- [x] New test case: extracts cache_creation_input_tokens when TTL breakdown is missing
- [x] New test case: prefers TTL breakdown over total when both are provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)