### PR TITLE
fix: freeze yarn lockfile in jawn docker build

### DIFF
--- a/valhalla/dockerfile
+++ b/valhalla/dockerfile
@@ -195,6 +195,7 @@ WORKDIR /usr/src/app
 COPY ./shared ./shared
 COPY ./packages ./packages
 COPY ./package.json ./package.json
+COPY ./yarn.lock ./yarn.lock
 
 
 WORKDIR /usr/src/app/valhalla/jawn
@@ -206,7 +207,7 @@ RUN find /usr/src/app/valhalla/jawn -name ".env.*" -exec rm {} \;
 #yarn workspace jawn serve
 ENV PORT=8585
 
-RUN yarn
+RUN yarn --frozen-lockfile
 
 RUN yarn build
 COPY ./valhalla/prompt_security/main.py /usr/src/app/valhalla/prompt_security/main.py


### PR DESCRIPTION
Repurposed this PR (original GLM playground work popped — commit `44121e5` still in history) to land an urgent docker build fix.

## Problem
The jawn dockerfile copied the root `package.json` but **not** `yarn.lock`, so `RUN yarn` did a fresh, unpinned resolution. `better-auth` (`^1.2.7`) recently published past 1.3.6, pulling in `kysely@0.29.2` which requires Node >=22 — breaking the build on the `node:20` base image:

```
error kysely@0.29.2: The engine "node" is incompatible with this module. Expected version ">=22.0.0". Got "20.19.4"
```

## Fix
Copy the root `yarn.lock` into the image and install with `--frozen-lockfile` so Docker builds match the locked versions used locally and in CI. One-file change.