### PR TITLE
fix(mcp): handle JSON-serialized object parameters from MCP clients

### DIFF
--- a/helicone-mcp/package.json
+++ b/helicone-mcp/package.json
@@ -19,6 +19,7 @@
 		"dev": "tsx src/index.ts",
 		"format": "biome format --write",
 		"lint:fix": "biome lint --fix",
+		"test": "vitest run",
 		"type-check": "tsc --noEmit",
 		"flatten-types": "tsx flatten-types.ts",
 		"generate-zod": "npm run flatten-types && ts-to-zod src/types/flat.ts src/types/generated-zod.ts && npm run build"
@@ -45,8 +46,9 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.2.5",
 		"@types/node": "^24.9.2",
+		"tsx": "^4.7.0",
 		"typescript": "5.9.3",
-		"tsx": "^4.7.0"
+		"vitest": "^4.0.18"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/helicone-mcp/src/__tests__/json-preprocess.test.ts
+++ b/helicone-mcp/src/__tests__/json-preprocess.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { jsonPreprocess } from "../lib/json-preprocess.js";
+
+describe("jsonPreprocess", () => {
+	const objectSchema = z.object({
+		name: z.string(),
+		value: z.number(),
+	});
+
+	it("passes through native objects unchanged", () => {
+		const schema = jsonPreprocess(objectSchema);
+		const result = schema.parse({ name: "test", value: 42 });
+		expect(result).toEqual({ name: "test", value: 42 });
+	});
+
+	it("parses a JSON string into an object before validation", () => {
+		const schema = jsonPreprocess(objectSchema);
+		const result = schema.parse('{"name": "test", "value": 42}');
+		expect(result).toEqual({ name: "test", value: 42 });
+	});
+
+	it("rejects a parsed JSON string that doesn't match the schema", () => {
+		const schema = jsonPreprocess(objectSchema);
+		expect(() => schema.parse('{"name": 123}')).toThrow();
+	});
+
+	it("preserves the 'all' literal string without parsing", () => {
+		const unionSchema = z.union([objectSchema, z.literal("all")]);
+		const schema = jsonPreprocess(unionSchema);
+		const result = schema.parse("all");
+		expect(result).toBe("all");
+	});
+
+	it("passes through invalid JSON strings for the schema to reject", () => {
+		const schema = jsonPreprocess(objectSchema);
+		expect(() => schema.parse("not valid json")).toThrow();
+	});
+
+	it("passes through non-string values (numbers, booleans, null)", () => {
+		const numberSchema = jsonPreprocess(z.number());
+		expect(numberSchema.parse(42)).toBe(42);
+
+		const boolSchema = jsonPreprocess(z.boolean());
+		expect(boolSchema.parse(true)).toBe(true);
+	});
+
+	it("works with nested filter schemas", () => {
+		const filterSchema = z.union([
+			z.object({
+				request_response_rmt: z.object({
+					request_id: z.object({
+						equals: z.string(),
+					}).optional(),
+				}).optional(),
+			}),
+			z.literal("all"),
+		]);
+
+		const schema = jsonPreprocess(filterSchema);
+
+		// JSON string with nested filter
+		const jsonInput = '{"request_response_rmt": {"request_id": {"equals": "abc-123"}}}';
+		const result = schema.parse(jsonInput);
+		expect(result).toEqual({
+			request_response_rmt: {
+				request_id: { equals: "abc-123" },
+			},
+		});
+
+		// "all" literal still works
+		expect(schema.parse("all")).toBe("all");
+
+		// Native object still works
+		const nativeResult = schema.parse({ request_response_rmt: { request_id: { equals: "xyz" } } });
+		expect(nativeResult).toEqual({ request_response_rmt: { request_id: { equals: "xyz" } } });
+	});
+
+	it("works with sort schemas", () => {
+		const sortSchema = z.object({
+			created_at: z.union([z.literal("asc"), z.literal("desc")]).optional(),
+		});
+
+		const schema = jsonPreprocess(sortSchema);
+		const result = schema.parse('{"created_at": "desc"}');
+		expect(result).toEqual({ created_at: "desc" });
+	});
+});

--- a/helicone-mcp/src/index.ts
+++ b/helicone-mcp/src/index.ts
@@ -5,6 +5,21 @@ import { z } from "zod";
 import { fetchRequests, fetchSessions, useAiGateway } from "./lib/helicone-client.js";
 import { requestFilterNodeSchema, sortLeafRequestSchema, sessionFilterNodeSchema } from "./types/generated-zod.js";
 
+/**
+ * Wraps a Zod schema with a preprocessing step that parses JSON strings.
+ * Some MCP clients (e.g. Claude Code) serialize complex object parameters
+ * as JSON strings rather than native objects. This ensures validation
+ * still works regardless of how the client sends the data.
+ */
+function jsonPreprocess<T extends z.ZodTypeAny>(schema: T) {
+	return z.preprocess((val) => {
+		if (typeof val === "string" && val !== "all") {
+			try { return JSON.parse(val); } catch { return val; }
+		}
+		return val;
+	}, schema);
+}
+
 const HELICONE_API_KEY = process.env.HELICONE_API_KEY;
 
 if (!HELICONE_API_KEY) {
@@ -21,10 +36,10 @@ server.tool(
 	"query_requests",
 	"Query Helicone requests with filters, pagination, sorting, and optional body content",
 	{
-		filter: requestFilterNodeSchema.optional().describe("Filter criteria for requests"),
+		filter: jsonPreprocess(requestFilterNodeSchema).optional().describe("Filter criteria for requests"),
 		offset: z.number().optional().describe("Pagination offset (default: 0)"),
 		limit: z.number().optional().describe("Maximum number of results to return (default: 100)"),
-		sort: sortLeafRequestSchema.optional().describe("Sort criteria"),
+		sort: jsonPreprocess(sortLeafRequestSchema).optional().describe("Sort criteria"),
 		includeBodies: z.boolean().optional().describe("Fetch and include request/response bodies (default: false). If true, fetches content from signed URLs."),
 	},
 	async (params: any) => {
@@ -70,7 +85,7 @@ server.tool(
 		endTimeUnixMs: z.number().describe("End time for session query (Unix timestamp in milliseconds)"),
 		nameEquals: z.string().optional().describe("Filter sessions by exact name match"),
 		timezoneDifference: z.number().describe("Timezone difference in hours (e.g., -5 for EST)"),
-		filter: sessionFilterNodeSchema.optional().describe("Advanced filter criteria"),
+		filter: jsonPreprocess(sessionFilterNodeSchema).optional().describe("Advanced filter criteria"),
 		offset: z.number().optional().describe("Pagination offset (default: 0)"),
 		limit: z.number().optional().describe("Maximum number of results to return (default: 100)"),
 	},

--- a/helicone-mcp/src/index.ts
+++ b/helicone-mcp/src/index.ts
@@ -4,21 +4,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { fetchRequests, fetchSessions, useAiGateway } from "./lib/helicone-client.js";
 import { requestFilterNodeSchema, sortLeafRequestSchema, sessionFilterNodeSchema } from "./types/generated-zod.js";
-
-/**
- * Wraps a Zod schema with a preprocessing step that parses JSON strings.
- * Some MCP clients (e.g. Claude Code) serialize complex object parameters
- * as JSON strings rather than native objects. This ensures validation
- * still works regardless of how the client sends the data.
- */
-function jsonPreprocess<T extends z.ZodTypeAny>(schema: T) {
-	return z.preprocess((val) => {
-		if (typeof val === "string" && val !== "all") {
-			try { return JSON.parse(val); } catch { return val; }
-		}
-		return val;
-	}, schema);
-}
+import { jsonPreprocess } from "./lib/json-preprocess.js";
 
 const HELICONE_API_KEY = process.env.HELICONE_API_KEY;
 

--- a/helicone-mcp/src/lib/json-preprocess.ts
+++ b/helicone-mcp/src/lib/json-preprocess.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+/**
+ * Wraps a Zod schema with a preprocessing step that parses JSON strings.
+ * Some MCP clients (e.g. Claude Code) serialize complex object parameters
+ * as JSON strings rather than native objects. This ensures validation
+ * still works regardless of how the client sends the data.
+ */
+export function jsonPreprocess<T extends z.ZodTypeAny>(schema: T) {
+	return z.preprocess((val) => {
+		if (typeof val === "string" && val !== "all") {
+			try { return JSON.parse(val); } catch { return val; }
+		}
+		return val;
+	}, schema);
+}


### PR DESCRIPTION
## Summary

Some MCP clients (e.g. Claude Code) serialize complex object parameters as JSON strings rather than native JavaScript objects. This causes Zod validation to reject valid filter/sort values with `invalid_type` errors (`expected: object, received: string`).

This PR adds a `z.preprocess` wrapper that transparently parses JSON strings before Zod validation runs, keeping all existing schema validation intact.

**Affected parameters:**
- `filter` on `query_requests`
- `sort` on `query_requests`
- `filter` on `query_sessions`

Closes #5610