### PR TITLE
fix: propagate NEXT_PUBLIC_HELICONE_JAWN_SERVICE from docker-compose into env.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,8 +151,8 @@ ENV CLICKHOUSE_HOST=http://localhost:8123
 ENV MINIO_ROOT_USER=minioadmin
 ENV MINIO_ROOT_PASSWORD=minioadmin
 
-# Default environment variables for supervisord (can be overridden at runtime with -e)
-# These are read by supervisord.conf using %(ENV_VAR)s syntax
+# Default environment variables (can be overridden at runtime via docker-compose or -e)
+# These are inherited by all supervisord child processes automatically
 ENV NEXT_PUBLIC_HELICONE_JAWN_SERVICE=http://localhost:8585
 ENV S3_ENDPOINT=http://localhost:9080
 ENV S3_ACCESS_KEY=minioadmin
@@ -161,6 +161,11 @@ ENV S3_BUCKET_NAME=request-response-storage
 ENV S3_PROMPT_BUCKET_NAME=prompt-body-storage
 ENV BETTER_AUTH_SECRET=change-me-in-production
 
+# Entrypoint generates __ENV.js from NEXT_PUBLIC_* env vars before starting services
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
 
 # --------------------------------------------------------------------------------------------------------------------

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# Generate __ENV.js from all NEXT_PUBLIC_* environment variables
+# This ensures the frontend has correct runtime values from docker-compose
+# before Next.js starts (defense-in-depth alongside next-runtime-env)
+
+ENV_JS_PATH="/app/web/public/__ENV.js"
+
+# Build JSON object from all NEXT_PUBLIC_* env vars
+JSON="{"
+FIRST=true
+while IFS='=' read -r KEY VALUE; do
+  if [[ "$KEY" == NEXT_PUBLIC_* ]]; then
+    if [ "$FIRST" = true ]; then
+      FIRST=false
+    else
+      JSON+=","
+    fi
+    # Escape backslashes and double quotes in the value
+    ESCAPED_VALUE=$(printf '%s' "$VALUE" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    JSON+="\"$KEY\":\"$ESCAPED_VALUE\""
+  fi
+done < <(env | sort)
+JSON+="}"
+
+echo "window.__ENV = $JSON;" > "$ENV_JS_PATH"
+echo "Generated $ENV_JS_PATH with NEXT_PUBLIC_* environment variables"
+
+# Execute the original command (supervisord)
+exec "$@"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -40,8 +40,9 @@ stdout_logfile=/var/log/supervisor/jawn.out.log
 stdout_logfile_maxbytes=50MB
 stderr_logfile_maxbytes=50MB
 user=root
-; S3_ENDPOINT and BETTER_AUTH_SECRET can be overridden via Docker env vars for remote deployments
-environment=S3_ACCESS_KEY="%(ENV_S3_ACCESS_KEY)s",S3_SECRET_KEY="%(ENV_S3_SECRET_KEY)s",S3_ENDPOINT="%(ENV_S3_ENDPOINT)s",S3_PROMPT_BUCKET_NAME="%(ENV_S3_PROMPT_BUCKET_NAME)s",S3_BUCKET_NAME="%(ENV_S3_BUCKET_NAME)s",KAFKA_CREDS='{"KAFKA_ENABLED": "false", "UPSTASH_KAFKA_BROKER": "localhost:9092", "UPSTASH_KAFKA_URL": "http://localhost:9092", "LOCAL_KAFKA": true}',OPENROUTER_WORKER_URL="http://localhost:8788",OPENAI_API_KEY="sk-...",OPENROUTER_API_KEY="sk-....",PROVIDER_KEYS='{ "DEMO_OPENAI_API_KEY": "sk-..." }',CSB_API_KEY="sk-...",TOGETHER_API_KEY="sk-...",STRIPE_SECRET_KEY="sk_dummy_key_12345678901234567890123456789012345678901234567890",NEXT_PUBLIC_BETTER_AUTH="true",BETTER_AUTH_SECRET="%(ENV_BETTER_AUTH_SECRET)s",DATABASE_URL="http://localhost:8123",SUPABASE_DATABASE_URL="postgresql://postgres:password@localhost:5432/helicone_test",HELICONE_WORKER_URL="http://localhost:8585/v1/gateway/oai",NODE_ENV="development",LOG_LEVEL="debug"
+; S3_*, BETTER_AUTH_SECRET, and NEXT_PUBLIC_* vars are inherited from Docker env (set in Dockerfile/docker-compose)
+; Do NOT re-declare them here with %(ENV_...)s — that can override docker-compose values with Dockerfile defaults
+environment=KAFKA_CREDS='{"KAFKA_ENABLED": "false", "UPSTASH_KAFKA_BROKER": "localhost:9092", "UPSTASH_KAFKA_URL": "http://localhost:9092", "LOCAL_KAFKA": true}',OPENROUTER_WORKER_URL="http://localhost:8788",OPENAI_API_KEY="sk-...",OPENROUTER_API_KEY="sk-....",PROVIDER_KEYS='{ "DEMO_OPENAI_API_KEY": "sk-..." }',CSB_API_KEY="sk-...",TOGETHER_API_KEY="sk-...",STRIPE_SECRET_KEY="sk_dummy_key_12345678901234567890123456789012345678901234567890",NEXT_PUBLIC_BETTER_AUTH="true",DATABASE_URL="http://localhost:8123",SUPABASE_DATABASE_URL="postgresql://postgres:password@localhost:5432/helicone_test",HELICONE_WORKER_URL="http://localhost:8585/v1/gateway/oai",NODE_ENV="development",LOG_LEVEL="debug"
 
 [program:web]
 command=yarn start
@@ -51,8 +52,9 @@ autorestart=true
 stderr_logfile=/var/log/supervisor/web.err.log
 stdout_logfile=/var/log/supervisor/web.out.log
 user=root
-; NEXT_PUBLIC_HELICONE_JAWN_SERVICE must be set to public URL for remote deployments (browser connects to this)
-environment=VERCEL="1",VERCEL_ENV="development",NEXT_PUBLIC_SLACK_CLIENT_ID="1234567890",SLACK_CLIENT_SECRET="1234567890",NEXT_PUBLIC_BASE_PATH="https://oai.helicone.ai/v1",NEXT_PUBLIC_HELICONE_JAWN_SERVICE="%(ENV_NEXT_PUBLIC_HELICONE_JAWN_SERVICE)s",DATABASE_URL="postgresql://postgres:password@localhost:5432/helicone_test",BETTER_AUTH_SECRET="%(ENV_BETTER_AUTH_SECRET)s",NEXT_PUBLIC_BETTER_AUTH="true"
+; NEXT_PUBLIC_HELICONE_JAWN_SERVICE and BETTER_AUTH_SECRET are inherited from Docker env (set in Dockerfile/docker-compose)
+; Do NOT re-declare them here with %(ENV_...)s — that can override docker-compose values with Dockerfile defaults
+environment=VERCEL="1",VERCEL_ENV="development",NEXT_PUBLIC_SLACK_CLIENT_ID="1234567890",SLACK_CLIENT_SECRET="1234567890",NEXT_PUBLIC_BASE_PATH="https://oai.helicone.ai/v1",DATABASE_URL="postgresql://postgres:password@localhost:5432/helicone_test",NEXT_PUBLIC_BETTER_AUTH="true"
 
 [program:flyway-migrate]
 command=/bin/bash -c "until pg_isready -U postgres; do echo 'Waiting for PostgreSQL...'; sleep 2; done && flyway migrate"


### PR DESCRIPTION
## Summary
- Removed `%(ENV_...)s` variable re-declarations from `supervisord.conf` for both the **web** and **jawn** programs — these vars (`NEXT_PUBLIC_HELICONE_JAWN_SERVICE`, `BETTER_AUTH_SECRET`, `S3_*`) are already set as `ENV` defaults in the Dockerfile and are automatically inherited by supervisord child processes
- Added `docker-entrypoint.sh` that generates `__ENV.js` from all `NEXT_PUBLIC_*` container env vars before supervisord starts, as defense-in-depth

### Root cause
The supervisord `environment` directive for the web program was re-declaring `NEXT_PUBLIC_HELICONE_JAWN_SERVICE` using `%(ENV_...)s` interpolation. This **overrode** the value inherited from the Docker container environment, preventing docker-compose `environment` overrides from reaching the Next.js process. Other `NEXT_PUBLIC_*` vars (like `NEXT_PUBLIC_APP_URL`) worked correctly because they were NOT re-declared in the supervisord directive — they were simply inherited from the container env.

### Files changed
| File | Change |
|------|--------|
| `supervisord.conf` | Remove redundant `%(ENV_...)s` vars from web and jawn environment directives |
| `Dockerfile` | Add entrypoint script to generate `__ENV.js` before services start |
| `docker-entrypoint.sh` | New entrypoint that reads all `NEXT_PUBLIC_*` env vars and writes `public/__ENV.js` |

## Test plan
- [ ] Build Docker image: `docker build -t helicone-test .`
- [ ] Run with custom `NEXT_PUBLIC_HELICONE_JAWN_SERVICE`:
  ```
  docker run -e NEXT_PUBLIC_HELICONE_JAWN_SERVICE=https://custom-jawn.example.com -p 3000:3000 helicone-test
  ```
- [ ] Verify `curl http://localhost:3000/__ENV.js` contains `https://custom-jawn.example.com`
- [ ] Verify frontend API calls go to the custom URL, not `http://localhost:8585`
- [ ] Verify default behavior still works without docker-compose overrides

Closes #5551