### PR TITLE
fix: map Responses API text.format to response_format in chat completions conversion

### DIFF
--- a/packages/llm-mapper/transform/providers/responses/request/toChatCompletions.ts
+++ b/packages/llm-mapper/transform/providers/responses/request/toChatCompletions.ts
@@ -285,7 +285,25 @@ export function toChatCompletions(
     logit_bias: body.logit_bias,
     logprobs: body.logprobs,
     top_logprobs: body.top_logprobs,
-    response_format: body.response_format,
+    response_format: body.text?.format
+      ? {
+          type: body.text.format.type,
+          ...(body.text.format.type === "json_schema"
+            ? {
+                json_schema: {
+                  name: body.text.format.name ?? "response",
+                  ...(body.text.format.description
+                    ? { description: body.text.format.description }
+                    : {}),
+                  schema: body.text.format.schema,
+                  ...(body.text.format.strict !== undefined
+                    ? { strict: body.text.format.strict }
+                    : {}),
+                },
+              }
+            : {}),
+        }
+      : body.response_format,
     seed: body.seed,
     user: body.user,
     service_tier: body.service_tier,

--- a/packages/llm-mapper/transform/types/responses.ts
+++ b/packages/llm-mapper/transform/types/responses.ts
@@ -137,6 +137,13 @@ export interface ResponsesRequestBody {
     budget_tokens?: number;
   };
   text?: {
+    format?: {
+      type: string;
+      name?: string;
+      description?: string;
+      schema?: any;
+      strict?: boolean;
+    };
     verbosity?: "low" | "medium" | "high";
   };
   store?: boolean;


### PR DESCRIPTION
## Problem

When using the Responses API (`/v1/responses`) through the AI Gateway with BYOK Azure endpoints, structured output (`text.format` with `json_schema`) is silently dropped. The provider returns plain text instead of structured JSON, breaking `client.responses.parse()` and Pydantic validation.

**Works:** Azure direct, OAI proxy, raw OpenAI
**Fails:** AI Gateway BYOK → Azure

## Root Cause

The `toChatCompletions()` function converts Responses API requests to Chat Completions format for providers that don't natively support the Responses API (like Azure). It was mapping `body.response_format` (Chat Completions field) but ignoring `body.text.format` (where structured output is actually specified in the Responses API).

In the Responses API, structured output is:
```json
{"text": {"format": {"type": "json_schema", "schema": {...}}}}
```

In Chat Completions, it's:
```json
{"response_format": {"type": "json_schema", "json_schema": {"schema": {...}}}}
```

The conversion was missing entirely.

## Fix

- Added `format` field to `ResponsesRequestBody.text` type definition
- Map `body.text.format` → `response_format` in `toChatCompletions()`
- Handles `json_schema` type with name, description, schema, strict
- Falls back to `body.response_format` for backward compatibility

## Files Changed

- `packages/llm-mapper/transform/types/responses.ts` — added `text.format` type
- `packages/llm-mapper/transform/providers/responses/request/toChatCompletions.ts` — mapping logic