### PR TITLE
fix(gateway): preserve Responses tool linkage and structured output format

### DIFF
--- a/packages/__tests__/llm-mapper/openai-chat-to-responses-converters.test.ts
+++ b/packages/__tests__/llm-mapper/openai-chat-to-responses-converters.test.ts
@@ -418,6 +418,70 @@ describe("OpenAI Chat -> Responses converters", () => {
       expect(toolResponse.tool_call_id).toBe(shortId);
     });
 
+    it("prefers call_id over id when mapping function_call items", () => {
+      const req = {
+        model: "gpt-4o-mini",
+        input: [
+          { role: "user", content: "Hello" },
+          {
+            type: "function_call",
+            id: "fc_1234567890abcdefghij1234567890abcdefghij1234567890",
+            call_id: "call_link_1",
+            name: "my_func",
+            arguments: "{}",
+          },
+          { type: "function_call_output", call_id: "call_link_1", output: "result" },
+        ],
+      } as unknown as ResponsesRequestBody;
+
+      const oai = toChatCompletions(req);
+
+      const assistant = oai.messages?.[1] as any;
+      const toolResponse = oai.messages?.[2] as any;
+
+      expect(assistant.tool_calls?.[0].id).toBe("call_link_1");
+      expect(toolResponse.tool_call_id).toBe("call_link_1");
+    });
+
+    it("maps responses text.format json_schema to chat response_format", () => {
+      const req = {
+        model: "gpt-4o-mini",
+        input: "hello",
+        text: {
+          format: {
+            type: "json_schema",
+            name: "weather_schema",
+            description: "Structured weather response",
+            schema: {
+              type: "object",
+              properties: {
+                temperature: { type: "number" },
+              },
+              required: ["temperature"],
+            },
+            strict: true,
+          },
+        },
+      } as unknown as ResponsesRequestBody;
+
+      const oai = toChatCompletions(req);
+      expect(oai.response_format).toEqual({
+        type: "json_schema",
+        json_schema: {
+          name: "weather_schema",
+          description: "Structured weather response",
+          schema: {
+            type: "object",
+            properties: {
+              temperature: { type: "number" },
+            },
+            required: ["temperature"],
+          },
+          strict: true,
+        },
+      });
+    });
+
     it("maps Responses tools (flattened) to Chat tools (nested)", () => {
       const req = {
         model: "gpt-4o-mini",

--- a/packages/llm-mapper/transform/providers/responses/request/toChatCompletions.ts
+++ b/packages/llm-mapper/transform/providers/responses/request/toChatCompletions.ts
@@ -79,6 +79,37 @@ function convertContentParts(
   });
 }
 
+function mapTextFormatToChatResponseFormat(
+  textFormat: NonNullable<ResponsesRequestBody["text"]>["format"]
+): HeliconeChatCreateParams["response_format"] {
+  if (!textFormat) {
+    return undefined;
+  }
+
+  if (textFormat.type === "json_schema" && "schema" in textFormat) {
+    return {
+      type: "json_schema",
+      json_schema: {
+        name: textFormat.name,
+        description: textFormat.description,
+        schema: textFormat.schema,
+        strict: textFormat.strict,
+      },
+    } as HeliconeChatCreateParams["response_format"];
+  }
+
+  return textFormat as HeliconeChatCreateParams["response_format"];
+}
+
+function resolveFunctionCallLinkId(
+  item: Extract<ResponsesInputItem, { type: "function_call" }>,
+  fallbackId: string
+): string {
+  // `call_id` is the canonical linkage field used by function_call_output.
+  // Prefer it over opaque item `id` to avoid mismatches in multi-turn tool chains.
+  return item.call_id || item.id || fallbackId;
+}
+
 /**
  * Collects consecutive items of a specific type from the input array.
  * Returns the collected items and the index after the last collected item.
@@ -115,7 +146,7 @@ function convertInputToMessages(input: ResponsesRequestBody["input"]) {
       >(input, i, "function_call");
 
       const toolCalls = functionCalls.map((fc, idx) => ({
-        id: truncateToolCallId(fc.id || fc.call_id || `call_${i + idx}`),
+        id: truncateToolCallId(resolveFunctionCallLinkId(fc, `call_${i + idx}`)),
         type: "function" as const,
         function: {
           name: fc.name,
@@ -267,6 +298,10 @@ export function toChatCompletions(
     reasoning_effort = body.reasoning.effort === "minimal" ? "low" : body.reasoning.effort;
   }
 
+  const responseFormat =
+    body.response_format ??
+    mapTextFormatToChatResponseFormat(body.text?.format);
+
   const heliconeBody: HeliconeChatCreateParams = {
     model: body.model,
     messages,
@@ -285,7 +320,7 @@ export function toChatCompletions(
     logit_bias: body.logit_bias,
     logprobs: body.logprobs,
     top_logprobs: body.top_logprobs,
-    response_format: body.response_format,
+    response_format: responseFormat,
     seed: body.seed,
     user: body.user,
     service_tier: body.service_tier,


### PR DESCRIPTION
## Summary
This PR fixes two Responses API mapping issues in the gateway conversion layer:

1. `function_call` linkage now prefers `call_id` over opaque `id` when constructing Chat Completions `tool_calls[].id`.
2. Responses `text.format` is now mapped to Chat Completions `response_format` (including `json_schema` shape conversion).

## Why
- In multi-turn tool-call chains, `function_call_output` links by `call_id`. Preferring `id` could create mismatches and orphaned tool outputs.
- Structured output requests that use Responses-native `text.format` (e.g. `responses.parse`) were not propagated into chat `response_format`, causing unconstrained plain-text output in provider-mapped flows.

## Changes
- Added `resolveFunctionCallLinkId()` and switched tool-call ID selection to use `call_id` first.
- Added `mapTextFormatToChatResponseFormat()` to convert Responses `text.format` into Chat `response_format`, including `json_schema` mapping to `{ type: "json_schema", json_schema: { ... } }`.
- Added regression tests in `openai-chat-to-responses-converters.test.ts`:
  - prefers `call_id` over `id` for function calls
  - maps Responses `text.format` json_schema into chat `response_format`

## Validation
- `corepack yarn jest --config packages/jest.config.ts packages/__tests__/llm-mapper/openai-chat-to-responses-converters.test.ts`
- `corepack yarn jest --config packages/jest.config.ts packages/__tests__/llm-mapper`
