### PR TITLE
fix: alert filter validation for property conditions

### DIFF
--- a/web/filterAST/components/FilterConditionNode.tsx
+++ b/web/filterAST/components/FilterConditionNode.tsx
@@ -199,15 +199,17 @@ export const FilterConditionNode: React.FC<FilterConditionNodeProps> = ({
     })();
 
     // Create updated condition with new field and default operator
+    const needsKey = filterDef.subType === "property" || filterDef.subType === "score";
     const updated: ConditionExpression = {
       ...condition,
       field: {
-        column: fieldId as any, // Use 'any' to bypass type checking temporarily
+        column: (filterDef.column ?? fieldId) as any,
         subtype: filterDef.subType,
         table: filterDef.table,
+        ...(needsKey && { key: fieldId, valueMode: "value" as const }),
       },
       operator: defaultOperator,
-      value: defaultValue, // Reset value since field changed
+      value: defaultValue,
     };
 
     filterStore.updateFilterExpression(path, updated);
@@ -239,8 +241,9 @@ export const FilterConditionNode: React.FC<FilterConditionNodeProps> = ({
     filterStore.removeFilterExpression(path);
   };
 
-  // Find the filter definition for this field
-  const filterDef = filterDefs.find((def) => def.id === condition.field.column);
+  // Find the filter definition - use key for properties/scores, column otherwise
+  const filterDefId = condition.field.key || condition.field.column;
+  const filterDef = filterDefs.find((def) => def.id === filterDefId);
 
   // Get available operators
   const operators = filterDef?.operators || [];
@@ -410,7 +413,7 @@ export const FilterConditionNode: React.FC<FilterConditionNodeProps> = ({
     >
       <SearchableSelect
         options={fieldOptions}
-        value={condition.field.column}
+        value={filterDefId}
         onValueChange={handleFieldChange}
         placeholder="Select field"
         searchPlaceholder="Search field..."

--- a/web/filterAST/filterUIDefinitions/types.ts
+++ b/web/filterAST/filterUIDefinitions/types.ts
@@ -5,6 +5,7 @@ export interface FilterUIDefinition {
   id: string;
   label: string;
   table: FieldSpec["table"];
+  column?: string; // The actual DB column. Defaults to id if not set.
   type: "string" | "number" | "boolean" | "datetime" | "select" | "searchable";
   subType?: "property" | "score" | "sessions" | "user";
   operators: FilterOperator[];

--- a/web/filterAST/filterUIDefinitions/useFilterUIDefinitions.ts
+++ b/web/filterAST/filterUIDefinitions/useFilterUIDefinitions.ts
@@ -84,6 +84,7 @@ export const useFilterUIDefinitions = () => {
                 property.property.toLowerCase() as keyof typeof KNOWN_HELICONE_PROPERTIES
               ].label
             : property.property,
+        column: "properties",
         type: "searchable",
         operators: ["contains", "not-contains", "eq", "neq", "like", "ilike", "in"],
         onSearch: (searchTerm) => {


### PR DESCRIPTION
## Summary
- Fixed alert filter validation error when filtering by custom properties
- When creating filters on custom properties, the `column` should be `"properties"` with the property name in the `key` field
- Previously the filter was incorrectly setting the property name as the column directly, causing validation errors

## Test plan
- [ ] Create an alert with a property filter (e.g., filter by `product = "mintlify-workflow"`)
- [ ] Verify the alert is created successfully without validation errors
- [ ] Verify existing alerts with property filters still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)