### PR TITLE
feat: translate response_format to Anthropic output_config for structured output

### DIFF
--- a/packages/llm-mapper/transform/providers/openai/request/toAnthropic.ts
+++ b/packages/llm-mapper/transform/providers/openai/request/toAnthropic.ts
@@ -125,6 +125,34 @@ export function toAnthropic(
     throw new Error("Logit bias is not supported");
   }
 
+  // Map response_format to Anthropic's output_config.format
+  // OpenAI uses `response_format: { type: "json_schema", json_schema: { schema, name } }`
+  // Anthropic uses `output_config: { format: { type: "json_schema", json_schema: { schema, name } } }`
+  // Note: Anthropic does not support `strict` (OpenAI-specific), so it is omitted.
+  if (
+    openAIBody.response_format &&
+    typeof openAIBody.response_format === "object" &&
+    "type" in openAIBody.response_format &&
+    openAIBody.response_format.type === "json_schema" &&
+    "json_schema" in openAIBody.response_format
+  ) {
+    const jsonSchema = (openAIBody.response_format as any).json_schema;
+    if (jsonSchema?.schema) {
+      antBody.output_config = {
+        format: {
+          type: "json_schema",
+          json_schema: {
+            schema: jsonSchema.schema,
+            ...(jsonSchema.name && { name: jsonSchema.name }),
+            ...(jsonSchema.description && {
+              description: jsonSchema.description,
+            }),
+          },
+        },
+      };
+    }
+  }
+
   // Map context_editing to Anthropic's context_management
   if (openAIBody.context_editing?.enabled) {
     antBody.context_management = mapContextEditing(openAIBody.context_editing);

--- a/packages/llm-mapper/transform/types/anthropic.ts
+++ b/packages/llm-mapper/transform/types/anthropic.ts
@@ -32,6 +32,22 @@ export interface AnthropicRequestBody {
    * @see https://docs.anthropic.com/en/docs/build-with-claude/context-editing
    */
   context_management?: AnthropicContextManagement;
+  /**
+   * Structured output configuration for JSON schema-constrained responses.
+   * @see https://docs.anthropic.com/en/docs/build-with-claude/structured-output
+   */
+  output_config?: AnthropicOutputConfig;
+}
+
+export interface AnthropicOutputConfig {
+  format: {
+    type: "json_schema";
+    json_schema: {
+      schema: Record<string, unknown>;
+      name?: string;
+      description?: string;
+    };
+  };
 }
 
 export type AnthropicThinkingConfig = {


### PR DESCRIPTION
Fixes #5639

## Problem

When using the AI Gateway with Anthropic models, `response_format: { type: "json_schema" }` is passed through untranslated. Anthropic ignores this OpenAI-specific parameter, so the model returns prose instead of JSON — breaking `Output.object()`, `generateObject()`, and any structured output workflow.

## Solution

Map OpenAI's `response_format` to Anthropic's native [`output_config.format`](https://docs.anthropic.com/en/docs/build-with-claude/structured-output) in `toAnthropic()`.

### Translation

```
OpenAI (input to gateway):
response_format: {
  type: "json_schema",
  json_schema: { schema: {...}, strict: true, name: "response" }
}

Anthropic (output from gateway):
output_config: {
  format: {
    type: "json_schema",
    json_schema: { schema: {...}, name: "response" }
  }
}
```

Note: `strict` is omitted — it's OpenAI-specific and not part of Anthropic's API.

## Changes

- **`packages/llm-mapper/transform/types/anthropic.ts`**: Added `output_config` and `AnthropicOutputConfig` type to `AnthropicRequestBody`
- **`packages/llm-mapper/transform/providers/openai/request/toAnthropic.ts`**: Added `response_format` → `output_config` translation in `toAnthropic()`

## Testing

The fix can be verified by sending a request with `response_format: { type: "json_schema", json_schema: { schema: { type: "object", properties: { name: { type: "string" } } } } }` to an Anthropic model through the gateway. The model should now return valid JSON matching the schema instead of prose.