### PR TITLE
Add Claude Opus 4.6 model aliases for OpenRouter

### DIFF
--- a/packages/cost/models/authors/anthropic/claude-4.6-opus/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-4.6-opus/endpoints.ts
@@ -118,6 +118,10 @@ export const endpoints = {
     provider: "openrouter",
     author: "anthropic",
     providerModelId: "anthropic/claude-opus-4.6",
+    providerModelIdAliases: [
+      "anthropic/claude-4.6-opus-20260205",
+      "anthropic/claude-opus-4.6-20260205",
+    ],
     pricing: [
       {
         threshold: 0,

--- a/packages/cost/providers/openrouter/index.ts
+++ b/packages/cost/providers/openrouter/index.ts
@@ -769,6 +769,36 @@ export const costs: ModelRow[] = [
   {
     model: {
       operator: "equals",
+      value: "anthropic/claude-opus-4.6",
+    },
+    cost: {
+      prompt_token: 5.275e-6,
+      completion_token: 2.6375e-5,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "anthropic/claude-4.6-opus-20260205",
+    },
+    cost: {
+      prompt_token: 5.275e-6,
+      completion_token: 2.6375e-5,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "anthropic/claude-opus-4.6-20260205",
+    },
+    cost: {
+      prompt_token: 5.275e-6,
+      completion_token: 2.6375e-5,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
       value: "mistralai/codestral-2508",
     },
     cost: {


### PR DESCRIPTION
## Ticket
N/A

## Component/Service
- [x] Packages

## Type of Change
- [x] New feature

## Deployment Notes
- [x] No special deployment steps required

## Context
This change adds support for additional model identifiers for Claude Opus 4.6 on OpenRouter. The model is now accessible via three different provider model IDs:
- `anthropic/claude-opus-4.6` (primary)
- `anthropic/claude-4.6-opus-20260205` (alias)
- `anthropic/claude-opus-4.6-20260205` (alias)

All three identifiers map to the same pricing structure (prompt: $5.275e-6, completion: $2.6375e-5 per token).

## Changes
1. Added three new cost entries in the OpenRouter provider configuration for the different Claude Opus 4.6 model identifiers
2. Updated the Claude 4.6 Opus endpoint configuration to include the two additional model ID aliases

This ensures consistent pricing and model recognition regardless of which identifier format is used when calling the model through OpenRouter.

## Test Plan
No testing needed - configuration change with straightforward data additions.

https://claude.ai/code/session_01PecxfNKaxHoJPF2M3TJzYt