### PR TITLE
feat: add openai/gpt-oss-safeguard-20b pricing for Groq

### DIFF
--- a/packages/cost/providers/groq/index.ts
+++ b/packages/cost/providers/groq/index.ts
@@ -108,6 +108,16 @@ export const costs: ModelRow[] = [
       completion_token: 0.00000059,
     },
   },
+  {
+    model: {
+      operator: "equals",
+      value: "openai/gpt-oss-safeguard-20b",
+    },
+    cost: {
+      prompt_token: 0.000000075,
+      completion_token: 0.0000003,
+    },
+  },
   // Legacy models (keeping for backward compatibility)
   {
     model: {


### PR DESCRIPTION
## Ticket
N/A

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [x] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [x] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos
N/A

## Extra Notes
Pricing sourced from https://groq.com/pricing and https://console.groq.com/docs/model/openai/gpt-oss-safeguard-20b

## Context
Adds cost entry for `openai/gpt-oss-safeguard-20b` on Groq.

- Input: $0.075/M tokens
- Output: $0.30/M tokens
