### PR TITLE
Add QuickSilver Pro provider (DeepSeek V3 + R1)

### DIFF
--- a/packages/cost/models/authors/deepseek/deepseek-reasoner/endpoints.ts
+++ b/packages/cost/models/authors/deepseek/deepseek-reasoner/endpoints.ts
@@ -143,6 +143,35 @@ export const endpoints = {
       "*": {},
     },
   },
+  "deepseek-reasoner:quicksilverpro": {
+    provider: "quicksilverpro",
+    author: "deepseek",
+    providerModelId: "deepseek-r1",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.0000004, // $0.40 per 1M tokens
+        output: 0.0000017, // $1.70 per 1M tokens
+      },
+    ],
+    contextLength: 128_000,
+    maxCompletionTokens: 64_000,
+    supportedParameters: [
+      "frequency_penalty",
+      "max_tokens",
+      "presence_penalty",
+      "response_format",
+      "seed",
+      "stop",
+      "stream",
+      "temperature",
+      "top_p",
+    ],
+    ptbEnabled: false,
+    endpointConfigs: {
+      "*": {},
+    },
+  },
 } satisfies Partial<
   Record<
     `${DeepSeekReasonerModelName}:${ModelProviderName}`,

--- a/packages/cost/models/authors/deepseek/deepseek-v3/endpoints.ts
+++ b/packages/cost/models/authors/deepseek/deepseek-v3/endpoints.ts
@@ -283,6 +283,39 @@ export const endpoints = {
       "*": {},
     },
   },
+  "deepseek-v3:quicksilverpro": {
+    provider: "quicksilverpro",
+    author: "deepseek",
+    providerModelId: "deepseek-v3",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.00000024, // $0.24 per 1M tokens
+        output: 0.0000007, // $0.70 per 1M tokens
+      },
+    ],
+    contextLength: 128_000,
+    maxCompletionTokens: 8_192,
+    supportedParameters: [
+      "frequency_penalty",
+      "function_call",
+      "functions",
+      "max_tokens",
+      "presence_penalty",
+      "response_format",
+      "seed",
+      "stop",
+      "stream",
+      "temperature",
+      "tool_choice",
+      "tools",
+      "top_p",
+    ],
+    ptbEnabled: false,
+    endpointConfigs: {
+      "*": {},
+    },
+  },
 } satisfies Partial<
   Record<`${DeepSeekV3ModelName}:${ModelProviderName}`, ModelProviderConfig>
 >;

--- a/packages/cost/models/provider-helpers.ts
+++ b/packages/cost/models/provider-helpers.ts
@@ -159,6 +159,9 @@ export const dbProviderToProvider = (
   if (provider === "nebius" || provider === "Nebius") {
     return "nebius";
   }
+  if (provider === "quicksilverpro" || provider === "QuickSilver Pro") {
+    return "quicksilverpro";
+  }
   return null;
 };
 

--- a/packages/cost/models/providers/index.ts
+++ b/packages/cost/models/providers/index.ts
@@ -17,6 +17,7 @@ import { NovitaProvider } from "./novita";
 import { OpenAIProvider } from "./openai";
 import { OpenRouterProvider } from "./openrouter";
 import { PerplexityProvider } from "./perplexity";
+import { QuickSilverProProvider } from "./quicksilverpro";
 import { VertexProvider } from "./vertex";
 import { XAIProvider } from "./xai";
 
@@ -41,6 +42,7 @@ export const providers = {
   openai: new OpenAIProvider(),
   openrouter: new OpenRouterProvider(),
   perplexity: new PerplexityProvider(),
+  quicksilverpro: new QuickSilverProProvider(),
   vertex: new VertexProvider(),
   xai: new XAIProvider()
 } as const;
@@ -84,6 +86,7 @@ export const ResponsesAPIEnabledProviders: ModelProviderName[] = [
   "novita",
   "openrouter",
   "perplexity",
+  "quicksilverpro",
   "xai",
   "baseten",
   "fireworks",

--- a/packages/cost/models/providers/priorities.ts
+++ b/packages/cost/models/providers/priorities.ts
@@ -36,6 +36,7 @@ export const PROVIDER_PRIORITIES: Record<ModelProviderName, number> = {
   novita: 4,
 
   perplexity: 4,
+  quicksilverpro: 4,
   vertex: 4,
   xai: 4,
 

--- a/packages/cost/models/providers/quicksilverpro.ts
+++ b/packages/cost/models/providers/quicksilverpro.ts
@@ -1,0 +1,14 @@
+import { BaseProvider } from "./base";
+import type { RequestParams, Endpoint } from "../types";
+
+export class QuickSilverProProvider extends BaseProvider {
+  readonly displayName = "QuickSilver Pro";
+  readonly baseUrl = "https://api.quicksilverpro.io/";
+  readonly auth = "api-key" as const;
+  readonly pricingPages = ["https://quicksilverpro.io/#pricing"];
+  readonly modelPages = ["https://quicksilverpro.io/#models"];
+
+  buildUrl(endpoint: Endpoint, requestParams: RequestParams): string {
+    return `${this.baseUrl}v1/chat/completions`;
+  }
+}

--- a/packages/cost/usage/getUsageProcessor.ts
+++ b/packages/cost/usage/getUsageProcessor.ts
@@ -27,6 +27,7 @@ export function getUsageProcessor(
     case "fireworks":
     case "cerebras":
     case "perplexity":
+    case "quicksilverpro":
       return new OpenAIUsageProcessor();
     case "anthropic":
       return new AnthropicUsageProcessor();


### PR DESCRIPTION
## Summary

Adds [QuickSilver Pro](https://quicksilverpro.io) as a provider in the Model Registry v2, so Helicone users who route DeepSeek V3 or DeepSeek R1 traffic through QuickSilver Pro get correct cost attribution.

QuickSilver Pro is an OpenAI-compatible inference API reselling open-source LLMs at 20% below the per-token rates of OpenRouter / Together AI / Fireworks AI / DeepInfra on the same models.

## What this PR adds

- **`packages/cost/models/providers/quicksilverpro.ts`** — \`BaseProvider\` implementation. OpenAI-compatible endpoint at \`https://api.quicksilverpro.io/v1/chat/completions\`, Bearer auth.
- Registered in:
  - \`providers/index.ts\` — singleton registry
  - \`providers/priorities.ts\` — priority 4 (same as DeepInfra / Novita / Chutes)
  - \`models/provider-helpers.ts\` — \`getProvider\` lookup (accepts \"quicksilverpro\" / \"QuickSilver Pro\")
  - \`usage/getUsageProcessor.ts\` — uses \`OpenAIUsageProcessor\` (same as DeepInfra / Novita / Fireworks)
- **DeepSeek V3 endpoint** (\`deepseek-v3:quicksilverpro\`) — \$0.24 input / \$0.70 output per 1M tokens
- **DeepSeek R1 endpoint** (\`deepseek-reasoner:quicksilverpro\`) — \$0.40 input / \$1.70 output per 1M tokens

## What this PR does NOT add

- **\`ptbEnabled: false\`** for both endpoints — QuickSilver Pro does not (yet) have a pass-through billing partnership with Helicone. Users bring their own QSP API key (BYOK). This matches the intent of the reseller-friendly precedent in the registry.
- **Qwen3.5-35B-A3B** — QuickSilver Pro also resells this model, but Helicone's registry doesn't yet have a \`Qwen3.5-35B-A3B\` model entry under \`authors/alibaba/\`. Happy to open a follow-up PR adding the model definition + endpoint if maintainers want it.
- **\`providers/mappings.ts\`** (observability proxy URL detection) — would require adding a legacy \`Provider\` enum entry in \`@helicone-package/llm-mapper/types\`. Left out to keep this PR minimal; can follow up.

## Disclosure

I help operate QuickSilver Pro (MachineFi Inc., Menlo Park, CA). Submitting per the reseller-friendly precedent set by the existing DeepInfra / Novita / Chutes / Cerebras / Baseten entries. Happy to iterate on naming or scope.

## Test plan

- [ ] \`providers/index.ts\` compiles — \`quicksilverpro\` key added to singleton map and to \`ResponsesAPIEnabledProviders\`
- [ ] Endpoint keys match \`\${DeepSeekV3ModelName}:\${ModelProviderName}\` and \`\${DeepSeekReasonerModelName}:\${ModelProviderName}\` type constraints
- [ ] Cost calculation for \`deepseek-v3:quicksilverpro\` returns input \* 0.00000024 + output \* 0.0000007
- [ ] \`getUsageProcessor(\"quicksilverpro\")\` returns \`OpenAIUsageProcessor\` (correct for OpenAI-compatible API)