### PR TITLE
Fix ReadableStream reuse in retries by fetching fresh body

### DIFF
--- a/worker/src/lib/clients/ProviderClient.ts
+++ b/worker/src/lib/clients/ProviderClient.ts
@@ -10,7 +10,10 @@ export interface CallProps {
   headers: Headers;
   method: string;
   apiBase: string;
-  body: ValidRequestBody;
+  // Factory returning a fresh body for each fetch attempt. ReadableStream
+  // bodies can only be consumed once, so retries must re-fetch the body
+  // from the buffer rather than reuse a stored reference.
+  getBody: () => Promise<ValidRequestBody>;
   increaseTimeout: boolean;
   originalUrl: URL;
   extraHeaders: Headers | null;
@@ -22,7 +25,13 @@ export function callPropsFromProxyRequest(
 ): CallProps {
   return {
     apiBase: proxyRequest.api_base,
-    body: proxyRequest.body,
+    getBody: async () => {
+      try {
+        return await proxyRequest.requestWrapper.safelyGetBody();
+      } catch (e) {
+        return await proxyRequest.requestWrapper.unsafeGetBodyText();
+      }
+    },
     headers: proxyRequest.requestWrapper.getHeaders(),
     method: proxyRequest.requestWrapper.getMethod(),
     increaseTimeout:
@@ -101,7 +110,7 @@ async function callWithMapper(
 }
 
 export async function callProvider(props: CallProps): Promise<Response> {
-  const { headers, method, apiBase, body, increaseTimeout, originalUrl, env } =
+  const { headers, method, apiBase, increaseTimeout, originalUrl, env } =
     props;
 
   const mockResponseHeader = headers.get("__helicone-mock-response");
@@ -156,7 +165,13 @@ export async function callProvider(props: CallProps): Promise<Response> {
   }
 
   const baseInit = { method, headers: headersWithExtra };
-  const init = method === "GET" ? { ...baseInit } : { ...baseInit, body };
+  // Fetch a fresh body per attempt: a ReadableStream can only be consumed
+  // once, so sharing the same body reference across retries triggers
+  // "Body has already been used" on the second attempt.
+  const init =
+    method === "GET"
+      ? { ...baseInit }
+      : { ...baseInit, body: await props.getBody() };
 
   let response: Response;
   if (increaseTimeout) {

--- a/worker/src/lib/models/HeliconeProxyRequest.ts
+++ b/worker/src/lib/models/HeliconeProxyRequest.ts
@@ -156,15 +156,16 @@ export class HeliconeProxyRequestMapper {
         isStream || targetUrl.pathname.includes("invoke-with-response-stream");
     }
 
-    // Apply token limit exception handler before fetching the body so we
-    // only materialize the stream once. Fetching twice with a Remote buffer
-    // leaks a ReadableStream from the container DO on every request.
-    await this.request.applyTokenLimitExceptionHandler(this.provider);
-
-    // NOTE: `body` is kept on HeliconeProxyRequest for loggable wiring but
-    // must NOT be consumed here by callers — callProvider fetches a fresh
-    // body via getBody() so retries get a new stream each attempt.
     let body: ValidRequestBody;
+    try {
+      body = await this.request.safelyGetBody();
+    } catch (e) {
+      body = await this.request.unsafeGetBodyText();
+    }
+
+    // Apply token limit exception handler
+    await this.request.applyTokenLimitExceptionHandler(this.provider);
+    // Re-fetch body after potential modification
     try {
       body = await this.request.safelyGetBody();
     } catch (e) {

--- a/worker/src/lib/models/HeliconeProxyRequest.ts
+++ b/worker/src/lib/models/HeliconeProxyRequest.ts
@@ -156,16 +156,15 @@ export class HeliconeProxyRequestMapper {
         isStream || targetUrl.pathname.includes("invoke-with-response-stream");
     }
 
-    let body: ValidRequestBody;
-    try {
-      body = await this.request.safelyGetBody();
-    } catch (e) {
-      body = await this.request.unsafeGetBodyText();
-    }
-
-    // Apply token limit exception handler
+    // Apply token limit exception handler before fetching the body so we
+    // only materialize the stream once. Fetching twice with a Remote buffer
+    // leaks a ReadableStream from the container DO on every request.
     await this.request.applyTokenLimitExceptionHandler(this.provider);
-    // Re-fetch body after potential modification
+
+    // NOTE: `body` is kept on HeliconeProxyRequest for loggable wiring but
+    // must NOT be consumed here by callers — callProvider fetches a fresh
+    // body via getBody() so retries get a new stream each attempt.
+    let body: ValidRequestBody;
     try {
       body = await this.request.safelyGetBody();
     } catch (e) {


### PR DESCRIPTION
## Ticket
N/A

## Component/Service
- [x] Worker (Proxy)

## Type of Change
- [x] Bug fix
- [x] Performance improvement

## Deployment Notes
- [x] No special deployment steps required

## Context
ReadableStream bodies can only be consumed once. When `callProvider` retries a request, reusing the same body reference causes a "Body has already been used" error on the second attempt. Additionally, fetching the body twice from a Remote buffer in `HeliconeProxyRequestMapper` leaks a ReadableStream from the container DO on every request.

## Changes
1. **ProviderClient.ts**: Changed `CallProps.body` from a static `ValidRequestBody` to a `getBody()` factory function that returns a fresh body for each fetch attempt. This ensures retries get a new stream instead of reusing a consumed one.

2. **ProviderClient.ts**: Updated `callProvider` to call `props.getBody()` only when needed (non-GET requests), fetching a fresh body per attempt.

3. **HeliconeProxyRequestMapper.ts**: Removed the initial body fetch before `applyTokenLimitExceptionHandler`. The body is now only fetched once after the handler runs, and callers must use the `getBody()` factory instead of consuming the stored reference directly.

4. **callPropsFromProxyRequest**: Implemented the `getBody()` factory to safely fetch the body with fallback to text extraction.

## Extra Notes
The body is retained on `HeliconeProxyRequest` for logging purposes but must not be consumed by callers—they must use the `getBody()` factory to ensure fresh streams on retries.

## Test Plan
Existing tests should pass. The change is backward compatible at the call site since `getBody()` is invoked transparently within `callProvider`.

https://claude.ai/code/session_01FtHETTgsrBtPz9BLB3KmHh