### PR TITLE
fix: ai-gateway exits 127 in all-in-one image (#5657)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -161,8 +161,11 @@ ENV S3_BUCKET_NAME=request-response-storage
 ENV S3_PROMPT_BUCKET_NAME=prompt-body-storage
 ENV BETTER_AUTH_SECRET=change-me-in-production
 
+# Pull the AI Gateway binary from the published image so supervisord can run it.
+COPY --from=helicone/ai-gateway:latest /usr/local/bin/ai-gateway /usr/local/bin/ai-gateway
+
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
 
 # --------------------------------------------------------------------------------------------------------------------
 
-EXPOSE 3000 8585 8123 9080 9001 5432
+EXPOSE 3000 8585 8123 8788 9080 9001 5432

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -92,8 +92,7 @@ stdout_logfile=/var/log/supervisor/minio-setup.out.log
 environment=MINIO_ROOT_USER="minioadmin",MINIO_ROOT_PASSWORD="minioadmin"
 
 [program:ai-gateway]
-command=yarn start
-directory=/app/gateway
+command=/usr/local/bin/ai-gateway
 autostart=true
 autorestart=true
 stderr_logfile=/var/log/supervisor/ai-gateway.err.log


### PR DESCRIPTION
## Summary

Fixes #5657 — `docker run helicone/helicone-all-in-one:latest` fails because the `ai-gateway` supervisord program loops with **exit status 127** until it hits FATAL.

## Root cause

`supervisord.conf` runs the gateway with:

```ini
[program:ai-gateway]
command=yarn start
directory=/app/gateway
```

This was added in d8bf4ca33, but it has two problems:

1. `ai-gateway` is a **Rust binary**, not a Node project — `yarn start` was never the right entry point.
2. The Dockerfile additions from that same commit (`COPY --from=helicone/ai-gateway:latest /app /app/gateway`, the second `COPY supervisord.conf`, the `monitor_logs.sh`/`debug_jawn.sh`/`health_check.sh` copies, and the `8788` in `EXPOSE`) are no longer in `Dockerfile`, so `/app/gateway` doesn't exist in the published image at all.

Result: supervisord tries `cd /app/gateway && yarn start`, the directory doesn't exist, the process exits with 127, supervisord retries, gives up: `gave up: ai-gateway entered FATAL state, too many start retries too quickly`. The other commenter's "wait for DB" theory doesn't fit — the gateway exits in <1 s before any DB connect would be attempted, and a Rust DB connect failure wouldn't surface as 127.

## Fix

- **Dockerfile**: copy the published `ai-gateway` binary (`/usr/local/bin/ai-gateway` per the upstream `Helicone/ai-gateway` Dockerfile) into the all-in-one image.
- **supervisord.conf**: invoke the binary directly; drop the bogus `yarn start` and the missing `directory`.
- Add `8788` to `EXPOSE` to document the gateway port.

## Test plan

- [ ] `docker buildx build -t helicone-all-in-one:test .` succeeds
- [ ] `docker run --rm -p 3000:3000 -p 8585:8585 -p 9080:9080 helicone-all-in-one:test` — `ai-gateway` no longer enters FATAL; `docker exec <id> supervisorctl status ai-gateway` shows `RUNNING`
- [ ] `curl http://localhost:8788` from inside the container responds (port not forwarded by default; use `docker exec`)
- [ ] Other services (web, jawn, postgres, clickhouse, minio) still come up

