### PR TITLE
worker: add Peyeeye PII redaction integration

### DIFF
--- a/worker/src/lib/HeliconeProxyRequest/ProxyForwarder.ts
+++ b/worker/src/lib/HeliconeProxyRequest/ProxyForwarder.ts
@@ -18,6 +18,13 @@ import { ClickhouseClientWrapper } from "../db/ClickhouseWrapper";
 import { DBWrapper } from "../db/DBWrapper";
 import { DBLoggable } from "../dbLogger/DBLoggable";
 import { Moderator } from "../managers/ModerationManager";
+import {
+  PEyeEyeManager,
+  PEyeEyeMissingSecretsError,
+  applyRedactedTexts,
+  collectMessageTexts,
+  type ChatMessage,
+} from "../managers/PEyeEyeManager";
 import { RateLimitManager } from "../managers/RateLimitManager";
 import { RequestResponseManager } from "../managers/RequestResponseManager";
 import { SentryManager } from "../managers/SentryManager";
@@ -360,6 +367,53 @@ export async function proxyForwarder(
     }
   }
 
+  // Peyeeye PII redaction (pre-call). Opt-in via `Helicone-Peyeeye-Enabled: true`.
+  // If redaction fails, fail closed -- never forward unredacted text to the LLM.
+  if (proxyRequest.requestWrapper.heliconeHeaders.peyeeyeEnabled) {
+    if (!env.PEYEEYE_API_KEY) {
+      return responseBuilder.build({
+        body: JSON.stringify({
+          success: false,
+          error: {
+            code: "PEYEEYE_MISCONFIGURED",
+            message:
+              "Helicone-Peyeeye-Enabled was set but the worker has no PEYEEYE_API_KEY binding.",
+          },
+        }),
+        status: 500,
+      });
+    }
+    try {
+      const peyeeyeResult = await runPeyeeyeRedaction(proxyRequest, env);
+      if (peyeeyeResult.error) {
+        return responseBuilder.build({
+          body: JSON.stringify({
+            success: false,
+            error: {
+              code: "PEYEEYE_REDACT_FAILED",
+              message: peyeeyeResult.error,
+            },
+          }),
+          status: 502,
+        });
+      }
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "peyeeye redaction failed";
+      const status = err instanceof PEyeEyeMissingSecretsError ? 401 : 502;
+      return responseBuilder.build({
+        body: JSON.stringify({
+          success: false,
+          error: {
+            code: "PEYEEYE_REDACT_FAILED",
+            message,
+          },
+        }),
+        status,
+      });
+    }
+  }
+
   const { data, error } = await handleProxyRequest(
     proxyRequest,
     rateLimited ? responseBuilder.buildRateLimitedResponse() : undefined
@@ -453,11 +507,171 @@ export async function proxyForwarder(
     );
   }
 
+  // Peyeeye rehydration (post-call). For non-streaming responses we buffer
+  // the body, swap placeholders back, and ship a fresh body. For streaming
+  // responses we currently pass through unchanged -- chunked rewriting would
+  // break SSE framing.
+  if (
+    proxyRequest.peyeeyeSessionId &&
+    !proxyRequest.isStream &&
+    response.status >= 200 &&
+    response.status < 300
+  ) {
+    const rehydratedBody = await rehydrateResponseBody(
+      response,
+      proxyRequest.peyeeyeSessionId,
+      env
+    );
+    // Best-effort cleanup of the stateful session.
+    if (
+      proxyRequest.peyeeyeSessionMode === "stateful" &&
+      proxyRequest.peyeeyeSessionId.startsWith("ses_")
+    ) {
+      try {
+        const cleanupManager = new PEyeEyeManager({
+          apiKey: env.PEYEEYE_API_KEY ?? "",
+          apiBase: env.PEYEEYE_API_BASE,
+        });
+        ctx.waitUntil(
+          cleanupManager.deleteSession(proxyRequest.peyeeyeSessionId)
+        );
+      } catch (err) {
+        console.warn("peyeeye: scheduling session cleanup failed", err);
+      }
+    }
+    return responseBuilder.build({
+      body: rehydratedBody,
+      inheritFrom: response,
+      status: response.status,
+    });
+  }
+
   return responseBuilder.build({
     body: response.body,
     inheritFrom: response,
     status: response.status,
   });
+}
+
+// Pre-call: redact every text-bearing chunk in the request body and write
+// the redacted body back via `setBody`. Stores the returned session id /
+// sealed key on the proxy request for the post-call hook to pick up.
+async function runPeyeeyeRedaction(
+  proxyRequest: HeliconeProxyRequest,
+  env: Env
+): Promise<{ error: string | null }> {
+  let bodyText: string;
+  try {
+    bodyText = (await proxyRequest.requestWrapper.unsafeGetBodyText()) || "";
+  } catch (err) {
+    return {
+      error: `peyeeye: failed to read request body: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+  if (!bodyText) return { error: null };
+
+  let parsed: { messages?: ChatMessage[]; [k: string]: unknown };
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    // Not JSON (e.g. multipart or empty) -- skip.
+    return { error: null };
+  }
+  const messages = Array.isArray(parsed?.messages) ? parsed.messages : [];
+  if (messages.length === 0) return { error: null };
+
+  const parts = collectMessageTexts(messages);
+  if (parts.length === 0) return { error: null };
+
+  const sessionMode =
+    proxyRequest.requestWrapper.heliconeHeaders.peyeeyeSessionMode ??
+    "stateful";
+
+  const manager = new PEyeEyeManager({
+    apiKey: env.PEYEEYE_API_KEY ?? "",
+    apiBase: env.PEYEEYE_API_BASE,
+    sessionMode,
+  });
+
+  const { redacted, sessionId } = await manager.redact(
+    parts.map((p) => p.text)
+  );
+
+  applyRedactedTexts(messages, parts, redacted);
+  parsed.messages = messages;
+  await proxyRequest.requestWrapper.setBody(JSON.stringify(parsed));
+
+  if (sessionId) {
+    proxyRequest.peyeeyeSessionId = sessionId;
+    proxyRequest.peyeeyeSessionMode = sessionMode;
+  }
+
+  return { error: null };
+}
+
+// Post-call: read the response body once, parse JSON, rehydrate any
+// chat-completion-style text fields, return a fresh body string. Best-effort
+// -- on any failure we fall back to the original body so the caller still
+// gets their response.
+async function rehydrateResponseBody(
+  response: Response,
+  sessionId: string,
+  env: Env
+): Promise<string> {
+  let raw: string;
+  try {
+    raw = await response.clone().text();
+  } catch (err) {
+    console.warn("peyeeye: failed to read response body for rehydration", err);
+    return await response.text().catch(() => "");
+  }
+  if (!raw) return raw;
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Not JSON; ship as-is.
+    return raw;
+  }
+
+  const manager = new PEyeEyeManager({
+    apiKey: env.PEYEEYE_API_KEY ?? "",
+    apiBase: env.PEYEEYE_API_BASE,
+  });
+
+  try {
+    const choices = Array.isArray(parsed?.choices) ? parsed.choices : [];
+    for (const choice of choices) {
+      const message = choice?.message;
+      if (!message) continue;
+      if (typeof message.content === "string" && message.content) {
+        message.content = await manager.rehydrate(message.content, sessionId);
+      } else if (Array.isArray(message.content)) {
+        for (const part of message.content) {
+          if (part && typeof part === "object" && part.type === "text") {
+            const t = typeof part.text === "string" ? part.text : "";
+            if (t) part.text = await manager.rehydrate(t, sessionId);
+          }
+        }
+      }
+    }
+    // Anthropic-style: top-level `content` array of `{type:"text", text}`.
+    if (Array.isArray(parsed?.content)) {
+      for (const part of parsed.content) {
+        if (part && typeof part === "object" && part.type === "text") {
+          const t = typeof part.text === "string" ? part.text : "";
+          if (t) part.text = await manager.rehydrate(t, sessionId);
+        }
+      }
+    }
+    return JSON.stringify(parsed);
+  } catch (err) {
+    console.warn("peyeeye: rehydrate pass failed", err);
+    return raw;
+  }
 }
 
 async function parseLatestMessage(

--- a/worker/src/lib/managers/PEyeEyeManager.ts
+++ b/worker/src/lib/managers/PEyeEyeManager.ts
@@ -1,0 +1,309 @@
+/**
+ * Peyeeye PII redaction & rehydration manager.
+ *
+ * Pre-call: redact every text-bearing chunk in the request body so PII never
+ * reaches the upstream LLM provider. Post-call: rehydrate the model's
+ * response by swapping the placeholder tokens back to the original values.
+ *
+ * Two session modes:
+ *   - "stateful" (default): peyeeye stores the token -> value mapping under a
+ *     `ses_...` id; rehydrate references the id, and the manager DELETEs the
+ *     session after rehydrate.
+ *   - "stateless": peyeeye returns a sealed `skey_...` AEAD blob; nothing is
+ *     retained server-side.
+ *
+ * Brand note: the class is `PEyeEyeManager` (P-Eye-Eye) so the brand is
+ * legible in code; snake-case identifiers and prose stay `peyeeye`.
+ */
+
+const DEFAULT_API_BASE = "https://api.peyeeye.ai";
+const REQUEST_TIMEOUT_MS = 15_000;
+
+export class PEyeEyeAPIError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PEyeEyeAPIError";
+  }
+}
+
+export class PEyeEyeMissingSecretsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PEyeEyeMissingSecretsError";
+  }
+}
+
+export type PEyeEyeSessionMode = "stateful" | "stateless";
+
+export interface PEyeEyeManagerOptions {
+  apiKey: string;
+  apiBase?: string;
+  locale?: string;
+  entities?: string[];
+  sessionMode?: PEyeEyeSessionMode;
+  // Injectable for tests.
+  fetchImpl?: typeof fetch;
+}
+
+export interface PEyeEyeRedactResult {
+  redacted: string[];
+  sessionId: string | null;
+}
+
+interface RedactResponse {
+  text?: string | string[];
+  session_id?: string;
+  session?: string;
+  rehydration_key?: string;
+}
+
+interface RehydrateResponse {
+  text?: string;
+  replaced?: number;
+}
+
+export class PEyeEyeManager {
+  private readonly apiKey: string;
+  private readonly apiBase: string;
+  private readonly locale: string;
+  private readonly entities: string[] | undefined;
+  private readonly sessionMode: PEyeEyeSessionMode;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: PEyeEyeManagerOptions) {
+    if (!opts.apiKey) {
+      throw new PEyeEyeMissingSecretsError(
+        "Peyeeye API key is required. Set the PEYEEYE_API_KEY environment variable."
+      );
+    }
+    this.apiKey = opts.apiKey;
+    this.apiBase = (opts.apiBase ?? DEFAULT_API_BASE).replace(/\/+$/, "");
+    this.locale = opts.locale ?? "auto";
+    this.entities =
+      opts.entities && opts.entities.length > 0 ? opts.entities : undefined;
+    this.sessionMode = opts.sessionMode ?? "stateful";
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  /**
+   * Redact a list of text strings via /v1/redact. The returned `redacted`
+   * array is the SAME LENGTH as `texts` -- if peyeeye returns a different
+   * count or an unexpected shape, this throws rather than silently
+   * forwarding unredacted text.
+   */
+  async redact(texts: string[]): Promise<PEyeEyeRedactResult> {
+    if (texts.length === 0) {
+      return { redacted: [], sessionId: null };
+    }
+
+    const body: Record<string, unknown> = {
+      text: texts,
+      locale: this.locale,
+    };
+    if (this.entities) {
+      body.entities = this.entities;
+    }
+    if (this.sessionMode === "stateless") {
+      body.session = "stateless";
+    }
+
+    const payload = await this.post<RedactResponse>("/v1/redact", body);
+
+    const out = payload.text;
+    let redacted: string[];
+    if (typeof out === "string") {
+      redacted = [out];
+    } else if (Array.isArray(out)) {
+      redacted = out.map((x) => String(x));
+    } else {
+      throw new PEyeEyeAPIError(
+        "peyeeye /v1/redact returned unexpected response shape; refusing to forward unredacted text"
+      );
+    }
+
+    // Length-guard the zip: refuse to forward partially-redacted data.
+    if (redacted.length !== texts.length) {
+      throw new PEyeEyeAPIError(
+        `peyeeye /v1/redact returned ${redacted.length} texts for ${texts.length} inputs; ` +
+          "refusing to forward partially-redacted data"
+      );
+    }
+
+    const sessionId =
+      this.sessionMode === "stateless"
+        ? (payload.rehydration_key ?? null)
+        : (payload.session_id ?? payload.session ?? null);
+
+    return { redacted, sessionId };
+  }
+
+  /**
+   * Rehydrate a single text string against the given session id (`ses_...`)
+   * or sealed key (`skey_...`). Best-effort: on failure returns the input
+   * unchanged so the user still gets something.
+   */
+  async rehydrate(text: string, sessionId: string): Promise<string> {
+    if (!text) return text;
+    try {
+      const payload = await this.post<RehydrateResponse>("/v1/rehydrate", {
+        text,
+        session: sessionId,
+      });
+      return typeof payload.text === "string" ? payload.text : text;
+    } catch (err) {
+      console.warn("peyeeye: rehydrate failed", err);
+      return text;
+    }
+  }
+
+  /**
+   * Best-effort: drop a stateful session server-side. Stateless `skey_...`
+   * blobs hold no server state, so this is a no-op for them.
+   */
+  async deleteSession(sessionId: string): Promise<void> {
+    if (!sessionId.startsWith("ses_")) return;
+    const url = `${this.apiBase}/v1/sessions/${encodeURIComponent(sessionId)}`;
+    try {
+      await this.fetchImpl(url, {
+        method: "DELETE",
+        headers: this.headers(),
+        signal: timeoutSignal(REQUEST_TIMEOUT_MS),
+      });
+    } catch (err) {
+      console.warn("peyeeye: best-effort session cleanup failed", err);
+    }
+  }
+
+  // -------------------------------------------------------------- internals
+
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    const url = `${this.apiBase}${path}`;
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify(body),
+        signal: timeoutSignal(REQUEST_TIMEOUT_MS),
+      });
+    } catch (err) {
+      if (err instanceof PEyeEyeAPIError) throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      throw new PEyeEyeAPIError(`peyeeye ${path} failed: ${message}`);
+    }
+
+    if (!response.ok) {
+      const status = response.status;
+      if (status === 401) {
+        throw new PEyeEyeMissingSecretsError("Invalid peyeeye API key");
+      }
+      if (status === 429) {
+        throw new PEyeEyeAPIError("peyeeye rate limit exceeded");
+      }
+      throw new PEyeEyeAPIError(`peyeeye ${path} returned ${status}`);
+    }
+
+    try {
+      return (await response.json()) as T;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new PEyeEyeAPIError(
+        `peyeeye ${path} returned non-JSON body: ${message}`
+      );
+    }
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json",
+    };
+  }
+}
+
+function timeoutSignal(ms: number): AbortSignal {
+  // AbortSignal.timeout exists on modern runtimes (Cloudflare Workers, Node 18+).
+  if (typeof AbortSignal !== "undefined" && "timeout" in AbortSignal) {
+    return (
+      AbortSignal as unknown as { timeout: (ms: number) => AbortSignal }
+    ).timeout(ms);
+  }
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), ms);
+  return controller.signal;
+}
+
+// ---------------------------------------------------------- message helpers
+
+export type ChatMessage = {
+  role?: string;
+  // Either a plain string or a multimodal content list.
+  content?:
+    | string
+    | Array<{ type?: string; text?: string; [k: string]: unknown }>;
+  [k: string]: unknown;
+};
+
+/**
+ * `(messageIndex, partPath, text)` triples for every text-bearing chunk in a
+ * chat-completion-style messages array. `partPath` is `"content"` for the
+ * plain-string case, or an integer index into a multimodal `content` list.
+ */
+export type TextPart = {
+  messageIndex: number;
+  partPath: "content" | number;
+  text: string;
+};
+
+export function collectMessageTexts(messages: ChatMessage[]): TextPart[] {
+  const out: TextPart[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (!msg || typeof msg !== "object") continue;
+    const content = msg.content;
+    if (typeof content === "string") {
+      if (content.length > 0) {
+        out.push({ messageIndex: i, partPath: "content", text: content });
+      }
+    } else if (Array.isArray(content)) {
+      for (let j = 0; j < content.length; j++) {
+        const part = content[j];
+        if (part && typeof part === "object" && part.type === "text") {
+          const t = typeof part.text === "string" ? part.text : "";
+          if (t.length > 0) {
+            out.push({ messageIndex: i, partPath: j, text: t });
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
+export function applyRedactedTexts(
+  messages: ChatMessage[],
+  parts: TextPart[],
+  redacted: string[]
+): ChatMessage[] {
+  if (parts.length !== redacted.length) {
+    throw new PEyeEyeAPIError(
+      `peyeeye redacted-text count (${redacted.length}) does not match input count (${parts.length})`
+    );
+  }
+  // Mutate in place; callers pass in their own array.
+  for (let k = 0; k < parts.length; k++) {
+    const { messageIndex, partPath } = parts[k];
+    const value = redacted[k];
+    const msg = messages[messageIndex];
+    if (!msg) continue;
+    if (partPath === "content") {
+      msg.content = value;
+    } else if (Array.isArray(msg.content)) {
+      const part = msg.content[partPath];
+      if (part && typeof part === "object") {
+        part.text = value;
+      }
+    }
+  }
+  return messages;
+}

--- a/worker/src/lib/models/HeliconeHeaders.ts
+++ b/worker/src/lib/models/HeliconeHeaders.ts
@@ -90,6 +90,8 @@ export interface IHeliconeHeaders {
   promptSecurityEnabled: Nullable<boolean>;
   promptSecurityAdvanced: Nullable<string>;
   moderationsEnabled: boolean;
+  peyeeyeEnabled: boolean;
+  peyeeyeSessionMode: Nullable<"stateful" | "stateless">;
   posthogKey: Nullable<string>;
   lytixKey: Nullable<string>;
   lytixHost: Nullable<string>;
@@ -157,6 +159,8 @@ export class HeliconeHeaders implements IHeliconeHeaders {
   promptSecurityEnabled: Nullable<boolean>;
   promptSecurityAdvanced: Nullable<string>;
   moderationsEnabled: boolean;
+  peyeeyeEnabled: boolean;
+  peyeeyeSessionMode: Nullable<"stateful" | "stateless">;
   posthogKey: Nullable<string>;
   posthogHost: Nullable<string>;
   gatewayConfig: {
@@ -210,6 +214,8 @@ export class HeliconeHeaders implements IHeliconeHeaders {
     this.promptSecurityEnabled = heliconeHeaders.promptSecurityEnabled;
     this.promptSecurityAdvanced = heliconeHeaders.promptSecurityAdvanced;
     this.moderationsEnabled = heliconeHeaders.moderationsEnabled;
+    this.peyeeyeEnabled = heliconeHeaders.peyeeyeEnabled;
+    this.peyeeyeSessionMode = heliconeHeaders.peyeeyeSessionMode;
     this.lytixKey = heliconeHeaders.lytixKey;
     this.lytixHost = heliconeHeaders.lytixHost;
     this.posthogKey = heliconeHeaders.posthogKey;
@@ -413,6 +419,16 @@ export class HeliconeHeaders implements IHeliconeHeaders {
         this.headers.get("Helicone-Moderations-Enabled") == "true"
           ? true
           : false,
+      peyeeyeEnabled:
+        (this.headers.get("Helicone-Peyeeye-Enabled") ?? "").toLowerCase() ===
+        "true",
+      peyeeyeSessionMode: ((): Nullable<"stateful" | "stateless"> => {
+        const mode = this.headers
+          .get("Helicone-Peyeeye-Session-Mode")
+          ?.toLowerCase();
+        if (mode === "stateful" || mode === "stateless") return mode;
+        return null;
+      })(),
       posthogKey: this.headers.get("Helicone-Posthog-Key") ?? null,
       lytixKey: this.headers.get("Helicone-Lytix-Key") ?? null,
       lytixHost: this.headers.get("Helicone-Lytix-Host") ?? null,

--- a/worker/src/lib/models/HeliconeProxyRequest.ts
+++ b/worker/src/lib/models/HeliconeProxyRequest.ts
@@ -54,6 +54,8 @@ export interface HeliconeProxyRequest {
   targetUrl: URL;
   threat?: boolean;
   flaggedForModeration?: boolean;
+  peyeeyeSessionId?: string;
+  peyeeyeSessionMode?: "stateful" | "stateless";
   cf?: CfProperties;
   escrowInfo?: EscrowInfo;
   env: Env;

--- a/worker/test/managers/peyeeye.spec.ts
+++ b/worker/test/managers/peyeeye.spec.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  PEyeEyeAPIError,
+  PEyeEyeManager,
+  PEyeEyeMissingSecretsError,
+  applyRedactedTexts,
+  collectMessageTexts,
+} from "../../src/lib/managers/PEyeEyeManager";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+function buildManager(fetchMock: FetchMock, opts: Partial<{
+  sessionMode: "stateful" | "stateless";
+  apiKey: string;
+}> = {}) {
+  return new PEyeEyeManager({
+    apiKey: opts.apiKey ?? "test_pek_key",
+    apiBase: "https://api.peyeeye.ai",
+    sessionMode: opts.sessionMode ?? "stateful",
+    fetchImpl: fetchMock as unknown as typeof fetch,
+  });
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+describe("PEyeEyeManager", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("throws PEyeEyeMissingSecretsError when no API key is provided", () => {
+      expect(
+        () =>
+          new PEyeEyeManager({
+            apiKey: "",
+            fetchImpl: vi.fn() as unknown as typeof fetch,
+          })
+      ).toThrow(PEyeEyeMissingSecretsError);
+    });
+  });
+
+  describe("redact", () => {
+    it("redacts a batch of texts and returns the session id (stateful)", async () => {
+      const fetchMock = vi.fn(async (url: string, init: RequestInit) => {
+        expect(url).toBe("https://api.peyeeye.ai/v1/redact");
+        expect(init.method).toBe("POST");
+        const body = JSON.parse(String(init.body));
+        expect(body.text).toEqual([
+          "Email me at alice@example.com",
+          "Call 555-867-5309",
+        ]);
+        expect(body.locale).toBe("auto");
+        expect(body.session).toBeUndefined();
+        return jsonResponse({
+          text: ["Email me at [EMAIL_1]", "Call [PHONE_1]"],
+          session_id: "ses_abc123",
+        });
+      });
+
+      const manager = buildManager(fetchMock);
+      const result = await manager.redact([
+        "Email me at alice@example.com",
+        "Call 555-867-5309",
+      ]);
+
+      expect(result.redacted).toEqual([
+        "Email me at [EMAIL_1]",
+        "Call [PHONE_1]",
+      ]);
+      expect(result.sessionId).toBe("ses_abc123");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("requests a stateless session when configured and reads rehydration_key", async () => {
+      const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+        const body = JSON.parse(String(init.body));
+        expect(body.session).toBe("stateless");
+        return jsonResponse({
+          text: ["[EMAIL_1]"],
+          rehydration_key: "skey_zzz",
+        });
+      });
+
+      const manager = buildManager(fetchMock, { sessionMode: "stateless" });
+      const result = await manager.redact(["alice@example.com"]);
+      expect(result.sessionId).toBe("skey_zzz");
+    });
+
+    it("returns empty result when given no texts (no HTTP call)", async () => {
+      const fetchMock = vi.fn();
+      const manager = buildManager(fetchMock);
+      const result = await manager.redact([]);
+      expect(result).toEqual({ redacted: [], sessionId: null });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("raises PEyeEyeAPIError when the redact response is the wrong shape", async () => {
+      const fetchMock = vi.fn(async () => jsonResponse({ session_id: "ses_x" }));
+      const manager = buildManager(fetchMock);
+      await expect(manager.redact(["hi"])).rejects.toBeInstanceOf(
+        PEyeEyeAPIError
+      );
+    });
+
+    it("raises PEyeEyeAPIError when the redact response length doesn't match input", async () => {
+      const fetchMock = vi.fn(async () =>
+        jsonResponse({
+          text: ["only one"],
+          session_id: "ses_x",
+        })
+      );
+      const manager = buildManager(fetchMock);
+      await expect(
+        manager.redact(["one", "two", "three"])
+      ).rejects.toMatchObject({
+        name: "PEyeEyeAPIError",
+        message: expect.stringContaining("refusing to forward"),
+      });
+    });
+
+    it("maps a 401 response to PEyeEyeMissingSecretsError", async () => {
+      const fetchMock = vi.fn(async () =>
+        new Response("unauthorized", { status: 401 })
+      );
+      const manager = buildManager(fetchMock);
+      await expect(manager.redact(["hi"])).rejects.toBeInstanceOf(
+        PEyeEyeMissingSecretsError
+      );
+    });
+
+    it("maps a 429 response to a rate-limit PEyeEyeAPIError", async () => {
+      const fetchMock = vi.fn(async () =>
+        new Response("rate limit", { status: 429 })
+      );
+      const manager = buildManager(fetchMock);
+      await expect(manager.redact(["hi"])).rejects.toMatchObject({
+        name: "PEyeEyeAPIError",
+        message: expect.stringContaining("rate limit"),
+      });
+    });
+  });
+
+  describe("rehydrate", () => {
+    it("round-trips redact -> rehydrate", async () => {
+      const calls: { url: string; body: any }[] = [];
+      const fetchMock = vi.fn(async (url: string, init: RequestInit) => {
+        const body = JSON.parse(String(init.body));
+        calls.push({ url, body });
+        if (url.endsWith("/v1/redact")) {
+          return jsonResponse({
+            text: ["Hello [NAME_1]"],
+            session_id: "ses_abc123",
+          });
+        }
+        if (url.endsWith("/v1/rehydrate")) {
+          return jsonResponse({
+            text: "Hello Alice",
+            replaced: 1,
+          });
+        }
+        throw new Error(`unexpected url ${url}`);
+      });
+
+      const manager = buildManager(fetchMock);
+      const redactRes = await manager.redact(["Hello Alice"]);
+      const rehydrated = await manager.rehydrate(
+        redactRes.redacted[0],
+        redactRes.sessionId!
+      );
+      expect(rehydrated).toBe("Hello Alice");
+      expect(calls).toHaveLength(2);
+      expect(calls[1].body).toEqual({
+        text: "Hello [NAME_1]",
+        session: "ses_abc123",
+      });
+    });
+
+    it("returns the input unchanged on rehydrate failure (best-effort)", async () => {
+      const fetchMock = vi.fn(async () =>
+        new Response("oops", { status: 500 })
+      );
+      const manager = buildManager(fetchMock);
+      const out = await manager.rehydrate("Hello [NAME_1]", "ses_abc");
+      expect(out).toBe("Hello [NAME_1]");
+    });
+
+    it("is a no-op for empty input (no HTTP call)", async () => {
+      const fetchMock = vi.fn();
+      const manager = buildManager(fetchMock);
+      const out = await manager.rehydrate("", "ses_abc");
+      expect(out).toBe("");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("deleteSession", () => {
+    it("DELETEs stateful sessions only", async () => {
+      const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+      const manager = buildManager(fetchMock);
+      await manager.deleteSession("ses_abc");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("https://api.peyeeye.ai/v1/sessions/ses_abc");
+      expect((init as RequestInit).method).toBe("DELETE");
+    });
+
+    it("skips deletion for stateless skey_ sealed blobs", async () => {
+      const fetchMock = vi.fn();
+      const manager = buildManager(fetchMock);
+      await manager.deleteSession("skey_zzz");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("collectMessageTexts / applyRedactedTexts", () => {
+  it("collects plain string content and writes it back", () => {
+    const messages = [
+      { role: "user", content: "alice@example.com" },
+      { role: "assistant", content: "" },
+    ];
+    const parts = collectMessageTexts(messages);
+    expect(parts).toEqual([
+      { messageIndex: 0, partPath: "content", text: "alice@example.com" },
+    ]);
+    applyRedactedTexts(messages, parts, ["[EMAIL_1]"]);
+    expect(messages[0].content).toBe("[EMAIL_1]");
+  });
+
+  it("collects multimodal text parts and writes them back", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "alice@example.com" },
+          { type: "image_url", image_url: { url: "https://x" } },
+          { type: "text", text: "hello" },
+        ],
+      },
+    ];
+    const parts = collectMessageTexts(messages);
+    expect(parts).toEqual([
+      { messageIndex: 0, partPath: 0, text: "alice@example.com" },
+      { messageIndex: 0, partPath: 2, text: "hello" },
+    ]);
+    applyRedactedTexts(messages, parts, ["[EMAIL_1]", "[GREETING]"]);
+    const content = messages[0].content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toBe("[EMAIL_1]");
+    expect(content[1]).toEqual({ type: "image_url", image_url: { url: "https://x" } });
+    expect(content[2].text).toBe("[GREETING]");
+  });
+
+  it("opt-out: when no peyeeye-related work happens (no text parts), returns empty", () => {
+    const messages = [
+      { role: "user", content: "" },
+      {
+        role: "assistant",
+        content: [{ type: "image_url", image_url: { url: "https://x" } }],
+      },
+    ];
+    const parts = collectMessageTexts(messages);
+    expect(parts).toEqual([]);
+  });
+
+  it("throws when applying mismatched redacted-text count", () => {
+    const messages = [
+      { role: "user", content: "a" },
+      { role: "user", content: "b" },
+    ];
+    const parts = collectMessageTexts(messages);
+    expect(() =>
+      applyRedactedTexts(messages, parts, ["only-one"])
+    ).toThrow(PEyeEyeAPIError);
+  });
+});

--- a/worker/test/managers/vitest.config.mts
+++ b/worker/test/managers/vitest.config.mts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: [],
+  },
+  resolve: {
+    alias: {
+      "@worker": new URL("../../src", import.meta.url).pathname,
+      "@helicone-package/cost": new URL(
+        "../../../packages/cost",
+        import.meta.url
+      ).pathname,
+    },
+  },
+});

--- a/worker/vitest.config.mts
+++ b/worker/vitest.config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
       "./test/alerts/vitest.config.mts",
       "./test/token-limit-exception/vitest.config.mts",
       "./test/rate-limit/vitest.config.mts",
+      "./test/managers/vitest.config.mts",
     ],
   },
 });

--- a/worker/worker-configuration.d.ts
+++ b/worker/worker-configuration.d.ts
@@ -47,6 +47,8 @@ declare namespace Cloudflare {
 		CUSTOMER_GATEWAY_URL: string;
 		RESEND_API_KEY: string;
 		PROMPTARMOR_API_KEY: string;
+		PEYEEYE_API_KEY: string;
+		PEYEEYE_API_BASE: string;
 		DATADOG_ENABLED: string;
 		DATADOG_API_KEY: string;
 		DATADOG_ENDPOINT: string;

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -66,6 +66,12 @@ OPENAI_ORG_ID = ""
 CUSTOMER_GATEWAY_URL = ""
 RESEND_API_KEY = ""
 PROMPTARMOR_API_KEY = ""
+# Peyeeye PII redaction (https://peyeeye.ai). Required when
+# `Helicone-Peyeeye-Enabled: true` requests come through. Set as a Wrangler
+# secret in production (`wrangler secret put PEYEEYE_API_KEY`); blank by
+# default so dev opt-out is the default.
+PEYEEYE_API_KEY = ""
+PEYEEYE_API_BASE = ""
 DATADOG_ENABLED = "false"
 DATADOG_API_KEY = ""
 DATADOG_ENDPOINT = ""


### PR DESCRIPTION
## Summary

Adds a per-request opt-in integration with [Peyeeye](https://peyeeye.ai), a PII redaction & rehydration API. When a client sends `Helicone-Peyeeye-Enabled: true`, the worker:

1. **Pre-call**: redacts every text-bearing chunk in the request body (plain string `messages[].content` and multimodal `[{type:"text", text:...}]` lists) via `POST /v1/redact`, swaps in the redacted text via `RequestWrapper.setBody`, and stashes the returned session id on the proxy request.
2. **Forwards** the redacted body to the upstream LLM provider as usual. The provider never sees raw PII.
3. **Post-call**: for non-streaming JSON responses, buffers the body, calls `POST /v1/rehydrate` for each choice's `message.content` (string or multimodal `text` parts) plus Anthropic-style top-level `content[]`, and ships the rehydrated body. Stateful sessions get a best-effort `DELETE /v1/sessions/{id}` via `ctx.waitUntil`.

Two session modes (defaults to stateful):

- `stateful` — peyeeye stores the token-to-value mapping under a `ses_...` id.
- `stateless` — peyeeye returns a sealed AEAD `skey_...` blob; nothing retained server-side. Opt in via `Helicone-Peyeeye-Session-Mode: stateless`.

### Why this lives in the worker
This mirrors the existing per-request opt-in patterns (`Helicone-Moderations-Enabled`, `Helicone-LLM-Security-Enabled`) and slots in right after the moderations block in `ProxyForwarder.ts`. Per-org configuration in Jawn could come later -- this PR is the smallest useful surface area.

### Files

- `worker/src/lib/managers/PEyeEyeManager.ts` (new) -- HTTP client, length-guarded redact, typed errors (`PEyeEyeAPIError`, `PEyeEyeMissingSecretsError`), best-effort rehydrate, message-text helpers.
- `worker/src/lib/HeliconeProxyRequest/ProxyForwarder.ts` -- pre-call + post-call wiring.
- `worker/src/lib/models/HeliconeHeaders.ts` -- registers `Helicone-Peyeeye-Enabled` and `Helicone-Peyeeye-Session-Mode`.
- `worker/src/lib/models/HeliconeProxyRequest.ts` -- carries `peyeeyeSessionId` / `peyeeyeSessionMode` between hooks.
- `worker/wrangler.toml` + `worker-configuration.d.ts` -- blank `PEYEEYE_API_KEY` / `PEYEEYE_API_BASE` bindings (set the key as a Wrangler secret in prod; blank in dev so opt-out stays the default).
- `worker/test/managers/peyeeye.spec.ts` (new) -- 17 vitest specs.
- `worker/vitest.config.mts` -- registers the new project.

### Behavioral invariants preserved

- **No silent PII passthrough.** If `/v1/redact` returns an unexpected shape or the redacted-text count doesn't match the input count, the manager throws and the worker returns a 502 -- it never forwards unredacted text on a fallback path.
- **Pre-call mutates the request body in place** via `setBody`; the rest of the proxy pipeline (cache key, AWS signing, etc.) sees the redacted version.
- **Streaming responses pass through unchanged.** Chunked rewriting of SSE frames isn't safe to retrofit here, so we only rehydrate JSON bodies for now. Streaming users still get redaction on the way in; the response just carries placeholder tokens until they call `/v1/rehydrate` themselves.
- **Stateful session cleanup** runs via `ctx.waitUntil` so the response isn't blocked on it; failures are logged and swallowed.
- **Naming**: TypeScript class is `PEyeEyeManager` (P-Eye-Eye, brand-legible); snake-case identifiers, env vars, and prose stay `peyeeye` / `Peyeeye`.

## Test plan

- [x] `cd worker && npm run test:run` -- all 1443 tests across 32 files pass, including the 17 new peyeeye specs (mocked HTTP fetch; no live API calls).
- [x] `cd worker && npm run lint` -- exits 0; no warnings on the new files.
- [ ] Smoke test against a deployed worker with a real `PEYEEYE_API_KEY` (reviewer can request a key).

The new test file covers:

- redact happy path (stateful + stateless), length-mismatch raise, unexpected-shape raise, 401 -> `PEyeEyeMissingSecretsError`, 429 -> rate-limit `PEyeEyeAPIError`, no-input no-op
- rehydrate roundtrip, best-effort fallback on failure, no-input no-op
- `deleteSession` only fires for `ses_...` ids (skipped for stateless `skey_...`)
- `collectMessageTexts` / `applyRedactedTexts` for plain string and multimodal content, mismatched-count raise, opt-out (no text parts) returns empty
