### PR TITLE
fix: update GitHub repository link on the llm cost calculator page

### DIFF
--- a/bifrost/app/llm-cost/CalculatorInfo.tsx
+++ b/bifrost/app/llm-cost/CalculatorInfo.tsx
@@ -327,12 +327,12 @@ const ContributingSection = () => (
         <li>
           Visit our GitHub repository:{" "}
           <a
-            href="https://github.com/Helicone/helicone/tree/main/costs"
+            href="https://github.com/Helicone/helicone/tree/main"
             className="underline"
             target="_blank"
             rel="noopener noreferrer"
           >
-            Helicone Costs
+            Helicone
           </a>
         </li>
         <li>


### PR DESCRIPTION
## Ticket
Link to the ticket(s) this pull request addresses.

## Component/Service
What part of Helicone does this affect?
- [x] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [x] Documentation

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [x] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
|                      |                   |

## Extra Notes
Any additional context, considerations, or notes for reviewers.

## Context
I was going over the documentation to contribute to the calculator/costs page and the link was broken. Here is a potential fix. Let me know if you would like to point to a different link.

## Screenshots / Demos
