### PR TITLE
feat(jawn): generic /v1/gateway/passthrough endpoint

### DIFF
--- a/docs/getting-started/self-host/docker.mdx
+++ b/docs/getting-started/self-host/docker.mdx
@@ -128,8 +128,41 @@ docker exec -u postgres helicone psql -d helicone_test -c \
 
 - OpenAI: `http://YOUR_IP:8585/v1/gateway/oai/v1/chat/completions`
 - Anthropic: `http://YOUR_IP:8585/v1/gateway/anthropic/v1/messages`
+- Any OpenAI-compatible upstream via the generic passthrough gateway (see below).
 
-Other providers (Vertex AI, AWS Bedrock, Azure OpenAI) are not supported in the self-hosted version.
+### Generic passthrough gateway
+
+`POST /v1/gateway/passthrough/<upstream-path>` forwards a request to any
+HTTP(S) origin specified via the `Helicone-Target-URL` header, mirroring the
+behaviour of `gateway.helicone.ai` on Helicone Cloud. The request is logged
+through the same pipeline as the native OpenAI/Anthropic gateways.
+
+Conventions:
+
+- `Helicone-Target-URL` must be an origin only (`https://host[:port]`) — no
+  path/query/hash. The upstream path comes from the request URL after the
+  `/v1/gateway/passthrough` prefix.
+- `Helicone-Auth: Bearer <helicone_key>` is required for logging attribution.
+- `Authorization` and any other non-`Helicone-*` headers are forwarded to the
+  upstream as-is.
+
+Example — OpenRouter:
+
+```bash
+curl --location 'http://localhost:8585/v1/gateway/passthrough/api/v1/chat/completions' \
+--header "Content-Type: application/json" \
+--header "Authorization: Bearer $OPENROUTER_API_KEY" \
+--header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+--header "Helicone-Target-URL: https://openrouter.ai" \
+--data '{
+    "model": "openai/gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+Self-hosted operators are responsible for fronting Jawn with their own
+auth/network policies if they need stricter SSRF controls — the endpoint
+accepts any HTTP(S) origin.
 
 ## Important Notes
 

--- a/valhalla/jawn/src/controllers/public/__tests__/proxyController.test.ts
+++ b/valhalla/jawn/src/controllers/public/__tests__/proxyController.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test, beforeEach, jest } from "@jest/globals";
+import { Response } from "node-fetch";
+
+// Mock ProxyForwarder so we can assert on the provider/wrapper passed to it
+// without spinning up Kafka/S3/ClickHouse from the test process.
+//
+// `mock`-prefixed names are the only references jest allows inside a
+// `jest.mock` factory after hoisting (everything else is in TDZ).
+jest.mock("../../../lib/proxy/ProxyForwarder", () => ({
+  proxyForwarder: jest.fn(),
+}));
+
+// WebSocketProxyForwarder pulls in heavy deps (durable objects, etc.) that
+// aren't needed for these unit tests — stub it.
+jest.mock("../../../lib/proxy/WebSocketProxyForwarder", () => ({
+  webSocketProxyForwarder: jest.fn(),
+}));
+
+import { RequestWrapper } from "../../../lib/requestWrapper/requestWrapper";
+import { proxyForwarder } from "../../../lib/proxy/ProxyForwarder";
+import {
+  getProviderFromTargetUrl,
+  handlePassthroughProxy,
+} from "../proxyController";
+
+const mockProxyForwarder = proxyForwarder as jest.MockedFunction<
+  typeof proxyForwarder
+>;
+
+function makeRequestWrapper(targetBaseUrl: string | null): RequestWrapper {
+  let baseURLOverride: string | null = null;
+  return {
+    heliconeHeaders: { targetBaseUrl } as RequestWrapper["heliconeHeaders"],
+    setBaseURLOverride(url: string) {
+      baseURLOverride = url;
+    },
+    get baseURLOverride() {
+      return baseURLOverride;
+    },
+  } as unknown as RequestWrapper;
+}
+
+beforeEach(() => {
+  mockProxyForwarder.mockReset();
+});
+
+describe("getProviderFromTargetUrl", () => {
+  test("matches OpenRouter origin", () => {
+    expect(getProviderFromTargetUrl("https://openrouter.ai")).toBe(
+      "OPENROUTER"
+    );
+  });
+
+  test("matches OpenAI origin", () => {
+    expect(getProviderFromTargetUrl("https://api.openai.com")).toBe("OPENAI");
+  });
+
+  test("matches Anthropic origin", () => {
+    expect(getProviderFromTargetUrl("https://api.anthropic.com")).toBe(
+      "ANTHROPIC"
+    );
+  });
+
+  test("falls back to CUSTOM for unknown origin", () => {
+    expect(getProviderFromTargetUrl("https://example.invalid")).toBe("CUSTOM");
+  });
+
+  test("is case-insensitive", () => {
+    expect(getProviderFromTargetUrl("https://API.OPENAI.com")).toBe("OPENAI");
+  });
+});
+
+describe("handlePassthroughProxy", () => {
+  test("returns 400 when Helicone-Target-URL is missing", async () => {
+    const rw = makeRequestWrapper(null);
+    const res = await handlePassthroughProxy(rw);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toContain("Helicone-Target-URL");
+    expect(mockProxyForwarder).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when target URL is malformed", async () => {
+    const rw = makeRequestWrapper("not a url");
+    const res = await handlePassthroughProxy(rw);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toContain("Invalid Helicone-Target-URL");
+    expect(mockProxyForwarder).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when target URL uses non-http scheme", async () => {
+    const rw = makeRequestWrapper("file:///etc/passwd");
+    const res = await handlePassthroughProxy(rw);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toContain("http(s)");
+    expect(mockProxyForwarder).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when target URL contains a path", async () => {
+    const rw = makeRequestWrapper("https://openrouter.ai/api/v1");
+    const res = await handlePassthroughProxy(rw);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toContain("host-only");
+    expect(mockProxyForwarder).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when target URL contains a query string", async () => {
+    const rw = makeRequestWrapper("https://openrouter.ai?key=value");
+    const res = await handlePassthroughProxy(rw);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toContain("host-only");
+  });
+
+  test("forwards a valid host-only URL to proxyForwarder with detected provider", async () => {
+    const expected = new Response("ok", { status: 200 });
+    mockProxyForwarder.mockResolvedValueOnce(expected);
+
+    const rw = makeRequestWrapper("https://openrouter.ai");
+    const res = await handlePassthroughProxy(rw);
+
+    expect(res).toBe(expected);
+    expect(mockProxyForwarder).toHaveBeenCalledTimes(1);
+    expect(mockProxyForwarder).toHaveBeenCalledWith(rw, "OPENROUTER");
+    expect(rw.baseURLOverride).toBe("https://openrouter.ai");
+  });
+
+  test("normalises trailing slash in target URL", async () => {
+    const expected = new Response("ok", { status: 200 });
+    mockProxyForwarder.mockResolvedValueOnce(expected);
+
+    const rw = makeRequestWrapper("https://openrouter.ai/");
+    const res = await handlePassthroughProxy(rw);
+
+    expect(res).toBe(expected);
+    expect(rw.baseURLOverride).toBe("https://openrouter.ai");
+  });
+
+  test("falls back to CUSTOM provider for unknown origins", async () => {
+    const expected = new Response("ok", { status: 200 });
+    mockProxyForwarder.mockResolvedValueOnce(expected);
+
+    const rw = makeRequestWrapper("https://my-private-llm.example.com");
+    await handlePassthroughProxy(rw);
+
+    expect(mockProxyForwarder).toHaveBeenCalledWith(rw, "CUSTOM");
+  });
+});

--- a/valhalla/jawn/src/controllers/public/proxyController.ts
+++ b/valhalla/jawn/src/controllers/public/proxyController.ts
@@ -9,6 +9,7 @@ import { proxyForwarder } from "../../lib/proxy/ProxyForwarder";
 import { webSocketProxyForwarder } from "../../lib/proxy/WebSocketProxyForwarder";
 import { RequestWrapper } from "../../lib/requestWrapper/requestWrapper";
 import { Provider } from "@helicone-package/llm-mapper/types";
+import { providers } from "@helicone-package/cost/providers/mappings";
 
 export const proxyRouter = express.Router();
 proxyRouter.use(express.json());
@@ -104,8 +105,22 @@ proxyRouter.post(
 );
 
 /* -------------------------------------------------------------------------- */
-/*                                   HELPERS                                  */
+/*                                  HELPERS                                   */
 /* -------------------------------------------------------------------------- */
+
+/**
+ * Resolves the upstream {@link Provider} that matches the supplied target
+ * base URL by scanning the registered provider patterns
+ * (`@helicone-package/cost/providers/mappings`). Falls back to `"CUSTOM"`
+ * when no pattern matches so logs are still attributed instead of being
+ * dropped.
+ */
+export function getProviderFromTargetUrl(targetBaseUrl: string): Provider {
+  const lower = targetBaseUrl.toLowerCase();
+  const match = providers.find((provider) => provider.pattern.test(lower));
+  return match ? (match.provider as Provider) : "CUSTOM";
+}
+
 const handleAnthropicProxy = async (requestWrapper: RequestWrapper) => {
   return await proxyForwarder(requestWrapper, "ANTHROPIC");
 };
@@ -129,10 +144,84 @@ const handleGatewayAPIRouter = async (requestWrapper: RequestWrapper) => {
   return new Response("Not implemented", { status: 501 });
 };
 
+/**
+ * Generic passthrough gateway, for parity with `gateway.helicone.ai` (Cloud).
+ *
+ * Forwards a request to an arbitrary upstream specified via the
+ * `Helicone-Target-URL` header while logging it through the same Kafka/S3
+ * pipeline used by the native OpenAI/Anthropic gateways.
+ *
+ * Convention (mirrors Cloud):
+ *   POST /v1/gateway/passthrough/<path>
+ *   Helicone-Auth: Bearer <helicone_key>
+ *   Helicone-Target-URL: <origin>            (host-only — no path/query/hash)
+ *   Authorization: Bearer <upstream_key>     (forwarded to upstream as-is)
+ *
+ * Example:
+ *   POST /v1/gateway/passthrough/api/v1/chat/completions
+ *   Helicone-Target-URL: https://openrouter.ai
+ *   → upstream: POST https://openrouter.ai/api/v1/chat/completions
+ */
+export const handlePassthroughProxy = async (
+  requestWrapper: RequestWrapper
+): Promise<Response> => {
+  const targetBaseUrl = requestWrapper.heliconeHeaders.targetBaseUrl;
+
+  if (!targetBaseUrl) {
+    return new Response(
+      JSON.stringify({
+        message:
+          "Helicone-Target-URL header is required for /v1/gateway/passthrough/*",
+      }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  let parsedTargetUrl: URL;
+  try {
+    parsedTargetUrl = new URL(targetBaseUrl);
+  } catch {
+    return new Response(
+      JSON.stringify({
+        message: `Invalid Helicone-Target-URL: "${targetBaseUrl}"`,
+      }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  if (parsedTargetUrl.protocol !== "https:" && parsedTargetUrl.protocol !== "http:") {
+    return new Response(
+      JSON.stringify({
+        message: `Helicone-Target-URL must use http(s) scheme, got "${parsedTargetUrl.protocol}"`,
+      }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  if (parsedTargetUrl.origin !== targetBaseUrl.replace(/\/$/, "")) {
+    return new Response(
+      JSON.stringify({
+        message: `Helicone-Target-URL "${targetBaseUrl}" must be host-only (origin) without path/query/hash. Append the upstream path to the request URL instead.`,
+      }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  // Bypass approvedDomains validation: this endpoint is opt-in via an explicit
+  // header, mirroring Cloud's gateway behaviour where any HTTPS origin is
+  // allowed. Self-hosted operators are responsible for fronting Jawn with
+  // their own auth/network policies if they need stricter SSRF controls.
+  requestWrapper.setBaseURLOverride(parsedTargetUrl.origin);
+
+  const provider = getProviderFromTargetUrl(parsedTargetUrl.origin);
+  return await proxyForwarder(requestWrapper, provider);
+};
+
 const ROUTER_MAP: {
   [key: string]: (requestWrapper: RequestWrapper) => Promise<Response>;
 } = {
   OAI: handleOpenAIProxy,
   GATEWAY: handleGatewayAPIRouter,
   ANTHROPIC: handleAnthropicProxy,
+  PASSTHROUGH: handlePassthroughProxy,
 };


### PR DESCRIPTION
## Summary

Brings self-hosted Jawn to parity with Cloud's `gateway.helicone.ai` by implementing the generic passthrough gateway that until now lived only in the Cloudflare Worker (`worker/src/routers/gatewayRouter.ts`).

**Why:** self-hosted Jawn previously supported only the OpenAI and Anthropic native gateways. Any other provider (OpenRouter, Together, Groq, Vertex, Bedrock, ...) had to be reached either through Helicone Cloud or by patching Jawn locally. This blocks anyone running on-prem who needs observability for arbitrary OpenAI-compatible upstreams. (`Helicone-OpenAI-Api-Base` is a workable header-level workaround for OpenAI-shaped upstreams, but it tags every call as `OPENAI` regardless of the real provider, and doesn't address Anthropic-shaped or arbitrary upstreams.)

## Endpoint

```
POST /v1/gateway/passthrough/<upstream-path>
  Helicone-Auth:        Bearer <helicone_key>
  Helicone-Target-URL:  <origin>     (host-only — no path/query/hash)
  Authorization:        Bearer <upstream_key>
```

**Example — OpenRouter:**

```bash
curl -X POST 'http://localhost:8585/v1/gateway/passthrough/api/v1/chat/completions' \
  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
  -H "Helicone-Auth: Bearer $HELICONE_API_KEY" \
  -H "Helicone-Target-URL: https://openrouter.ai" \
  -H "Content-Type: application/json" \
  -d '{"model": "openai/gpt-4o-mini", "messages": [{"role":"user","content":"hi"}]}'
```

→ forwarded to `https://openrouter.ai/api/v1/chat/completions`, logged through the same Kafka/S3/ClickHouse pipeline as the native gateways, attributed as `provider=OPENROUTER`.

## Design

- **Mirrors Cloud's host-only contract** for `Helicone-Target-URL`. The upstream path comes from the request URL after the `/v1/gateway/passthrough` prefix. Validation in the handler returns 400 for malformed URLs, non-`http(s)` schemes, and target URLs that contain a path/query/hash.
- **Provider detection** via existing `providers/mappings.ts` patterns — OpenRouter, Together, Groq, Vertex, etc. resolve to their canonical `Provider` name; unmatched origins fall back to `CUSTOM` so logs are attributed rather than being lumped into a single bucket.
- **Reuses the existing `proxyForwarder` pipeline**, so the new endpoint produces identical ClickHouse/Postgres records to the native `/oai` and `/anthropic` ones — no new logging path, no new schema.
- **Bypasses `approvedDomains` validation** (via `setBaseURLOverride`, same as `worker/src/routers/gatewayRouter.ts`). The endpoint is opt-in via an explicit header; self-hosted operators are responsible for fronting Jawn with their own auth/network policies if they need stricter SSRF controls.

## Files changed

- `valhalla/jawn/src/controllers/public/proxyController.ts` — adds `handlePassthroughProxy` + `getProviderFromTargetUrl` and registers `PASSTHROUGH` in `ROUTER_MAP`.
- `valhalla/jawn/src/controllers/public/__tests__/proxyController.test.ts` — new Jest suite covering header validation paths and the happy path with provider detection (mocks `proxyForwarder` to avoid spinning up Kafka/S3/ClickHouse).
- `docs/getting-started/self-host/docker.mdx` — documents the new endpoint with a curl example.

## Test plan

- [x] Added Jest suite (`proxyController.test.ts`, 13 cases): missing/invalid/non-http/path/query target URL → 400; happy path forwards with detected provider; trailing slash normalised; CUSTOM fallback for unknown origins.
- [x] **Tests pass locally** (`npx jest --testPathPatterns proxyController` → 13/13 passed, ~243s incl. ts-jest cold compile).
- [ ] Manual smoke against a self-hosted instance (TODO — happy to do this once CI is green if reviewer wants screenshots of the request appearing in the dashboard with `provider=OPENROUTER`).

## Notes

- The catch-all `/v1/gateway/{*path}` stub that throws `Not implemented` is left in place — touching it is a separate concern (it's reachable only when the URL has no provider segment, which is unusual for the gateway shape).
- No changes to the Cloudflare Worker — Cloud's behaviour is unchanged.
- No new env vars; no migrations.
