### PR TITLE
fix(worker): validate property names in AlertStore to prevent ClickHouse injection

### DIFF
--- a/worker/src/lib/db/AlertStore.ts
+++ b/worker/src/lib/db/AlertStore.ts
@@ -59,9 +59,11 @@ export class AlertStore {
     if (!alert.grouping) return "";
 
     if (alert.grouping_is_property) {
-      // Sanitize property name: escape single quotes to prevent injection
-      const sanitized = alert.grouping.replace(/'/g, "\\'");
-      return `properties['${sanitized}']`;
+      // Validate property name against safe identifier pattern to prevent ClickHouse injection
+      if (!AlertStore.SAFE_IDENTIFIER.test(alert.grouping)) {
+        throw new Error(`Invalid property name for grouping: ${alert.grouping}`);
+      }
+      return `properties['${alert.grouping}']`;
     }
 
     const mapped = AlertStore.STANDARD_GROUPING_MAP[alert.grouping];


### PR DESCRIPTION
## Summary
- Validate property names in AlertStore.buildGroupByColumn() against the SAFE_IDENTIFIER regex instead of only escaping single quotes
- The previous sanitization (replace single quotes with escaped quotes) was insufficient. Special characters like ], backslash, or newlines in property names could break the ClickHouse properties[...] syntax

## Test plan
- [ ] Verify that valid property names (alphanumeric + underscore) continue to work
- [ ] Verify that property names with special characters are rejected with an error
- [ ] Existing alert grouping tests should still pass

Generated with Claude Code (https://claude.com/claude-code)