### PR TITLE
fix(worker): read Supabase credentials from env vars in e2e tests

### DIFF
--- a/worker/e2e_test.py
+++ b/worker/e2e_test.py
@@ -6,9 +6,14 @@ import time
 import openai
 import json
 # import httpx
-openai.api_base = "http://127.0.0.1:8787/v1"
-SUPABASE_SERVICE_ROLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU"
-SUPABASE_URL = "http://localhost:54321"
+openai.api_base = os.environ.get("OPENAI_API_BASE", "http://127.0.0.1:8787/v1")
+SUPABASE_SERVICE_ROLE_KEY = os.environ.get(
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0."
+    "EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU",
+)
+SUPABASE_URL = os.environ.get("SUPABASE_URL", "http://localhost:54321")
 
 supabase: Client = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 


### PR DESCRIPTION
## Summary
- Replace hardcoded Supabase service role key and URL in `worker/e2e_test.py` with `os.environ.get()` calls
- Keep the existing default values for local development convenience while allowing CI/production overrides
- Also make `openai.api_base` configurable via `OPENAI_API_BASE` env var

## Test plan
- [ ] Run e2e tests locally with default values — should work as before
- [ ] Run with custom env vars (`SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_URL`, `OPENAI_API_BASE`) — should use those values

Generated with Claude Code (https://claude.com/claude-code)