### PR TITLE
fix(packages): replace any type with proper type for error messages

### DIFF
--- a/packages/llm-mapper/types.ts
+++ b/packages/llm-mapper/types.ts
@@ -111,7 +111,7 @@ type LLMResponseBody = {
   instructions?: string | null;
   model?: string | null;
   error?: {
-    heliconeMessage: any;
+    heliconeMessage: string | Record<string, unknown>;
   };
   toolDetailsResponse?: {
     status: string;
@@ -275,7 +275,7 @@ type HeliconeMetadata = {
   storageLocation?: string | null;
 };
 
-// UNORGANZIED
+// UNORGANIZED
 export type PromptMessage = Message | string;
 // These are planned I think?
 export type HeliconeErrorType = {


### PR DESCRIPTION
## Summary
- Replace `heliconeMessage: any` with `string | Record<string, unknown>` in LLMResponseBody type (packages/llm-mapper/types.ts:114)
- The Gemini mappers assign an object {message, code} while other mappers assign strings - the union type accurately reflects actual usage
- Fix typo in comment: UNORGANZIED -> UNORGANIZED

## Test plan
- [ ] Verify TypeScript compilation passes: cd packages && npx tsc --noEmit
- [ ] Verify existing tests pass: cd packages && npx jest

Generated with Claude Code (https://claude.com/claude-code)