### PR TITLE
fix(proxy/ProviderClient): honour Retry-After on 429 in callProviderWithRetry

### DIFF
--- a/valhalla/jawn/src/lib/proxy/ProviderClient.ts
+++ b/valhalla/jawn/src/lib/proxy/ProviderClient.ts
@@ -66,6 +66,45 @@ export function buildTargetUrl(originalUrl: URL, apiBase: string): URL {
   return new URL(`${apiBaseUrl.origin}${pathname}${originalUrl.search}`);
 }
 
+// Hard cap so a hostile or misconfigured provider cannot make the proxy wait
+// for an unbounded amount of time before retrying.
+const MAX_RETRY_AFTER_MS = 60_000;
+
+/**
+ * Parse an RFC 7231 `Retry-After` header value into milliseconds.
+ *
+ * Accepts either a non-negative integer number of seconds or an HTTP-date.
+ * Returns `null` when the header is absent, malformed, or already in the past
+ * — in which case the caller should fall back to its default backoff strategy.
+ * The returned value is clamped to {@link MAX_RETRY_AFTER_MS} to prevent abuse.
+ */
+export function parseRetryAfter(
+  value: string | null | undefined,
+  now: number = Date.now()
+): number | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+
+  // delta-seconds form (RFC 7231 §7.1.3 first alternative)
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number.parseInt(trimmed, 10);
+    if (Number.isNaN(seconds) || seconds < 0) return null;
+    return Math.min(seconds * 1000, MAX_RETRY_AFTER_MS);
+  }
+
+  // HTTP-date form (RFC 7231 §7.1.3 second alternative)
+  const date = Date.parse(trimmed);
+  if (Number.isNaN(date)) return null;
+  const delta = date - now;
+  if (delta <= 0) return null;
+  return Math.min(delta, MAX_RETRY_AFTER_MS);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function callProviderWithRetry(
   callProps: CallProps,
   retryOptions: RetryOptions
@@ -82,6 +121,18 @@ export async function callProviderWithRetry(
           lastResponse = res;
           // Throw an error if the status code is 429
           if (res.status === 429 || res.status === 500 || res.status === 522) {
+            // For 429 the provider can explicitly tell us how long to wait via
+            // the Retry-After header. Honour it as a minimum delay before the
+            // next retry kicks in; async-retry's exponential backoff still
+            // applies on top, so this only ever lengthens the wait.
+            if (res.status === 429) {
+              const retryAfterMs = parseRetryAfter(
+                res.headers.get("retry-after")
+              );
+              if (retryAfterMs !== null && retryAfterMs > 0) {
+                await sleep(retryAfterMs);
+              }
+            }
             throw new Error(`Status code ${res.status}`);
           }
           return res;

--- a/valhalla/jawn/src/lib/proxy/__tests__/ProviderClient.test.ts
+++ b/valhalla/jawn/src/lib/proxy/__tests__/ProviderClient.test.ts
@@ -1,0 +1,50 @@
+import { parseRetryAfter } from "../ProviderClient";
+
+describe("parseRetryAfter", () => {
+  // Frozen reference point so the HTTP-date cases are deterministic.
+  const NOW = Date.UTC(2026, 4, 16, 12, 0, 0); // 2026-05-16T12:00:00Z
+
+  it("returns null for missing or empty values", () => {
+    expect(parseRetryAfter(null)).toBeNull();
+    expect(parseRetryAfter(undefined)).toBeNull();
+    expect(parseRetryAfter("")).toBeNull();
+    expect(parseRetryAfter("   ")).toBeNull();
+  });
+
+  it("parses delta-seconds form into milliseconds", () => {
+    expect(parseRetryAfter("0")).toBe(0);
+    expect(parseRetryAfter("1")).toBe(1_000);
+    expect(parseRetryAfter("30")).toBe(30_000);
+  });
+
+  it("trims surrounding whitespace before parsing seconds", () => {
+    expect(parseRetryAfter("  5  ")).toBe(5_000);
+  });
+
+  it("caps very large delta-seconds at 60 seconds", () => {
+    // 1 hour Retry-After should be clamped so a hostile provider cannot freeze
+    // the proxy for an unbounded amount of time.
+    expect(parseRetryAfter("3600")).toBe(60_000);
+  });
+
+  it("rejects non-numeric, non-date strings", () => {
+    expect(parseRetryAfter("soon")).toBeNull();
+    expect(parseRetryAfter("1.5")).toBeNull();
+    expect(parseRetryAfter("-1")).toBeNull();
+  });
+
+  it("parses HTTP-date form into milliseconds from `now`", () => {
+    const fiveSecondsFromNow = new Date(NOW + 5_000).toUTCString();
+    expect(parseRetryAfter(fiveSecondsFromNow, NOW)).toBe(5_000);
+  });
+
+  it("returns null for HTTP-date values in the past", () => {
+    const tenSecondsAgo = new Date(NOW - 10_000).toUTCString();
+    expect(parseRetryAfter(tenSecondsAgo, NOW)).toBeNull();
+  });
+
+  it("caps HTTP-date values far in the future at 60 seconds", () => {
+    const oneHourFromNow = new Date(NOW + 3_600_000).toUTCString();
+    expect(parseRetryAfter(oneHourFromNow, NOW)).toBe(60_000);
+  });
+});


### PR DESCRIPTION
Closes #5672.

## Summary

`valhalla/jawn`'s `callProviderWithRetry` retried 429 responses with the same `async-retry` `exponentialDelay` it uses for 5xx, never consulting the provider's `Retry-After` header. With the defaults that means three retries fire well within most providers' cooldown windows, each one earning another 429 — exactly the loop the original report calls out.

This PR keeps the rest of the retry machinery untouched and adds two pieces:

### `parseRetryAfter`

A small pure helper that accepts either RFC 7231 form:

- **delta-seconds** — e.g. `Retry-After: 30` → `30_000` ms.
- **HTTP-date** — e.g. `Retry-After: Wed, 21 Oct 2026 07:28:00 GMT` → milliseconds remaining from `now`.

It returns `null` for missing, malformed, or already-in-the-past values so the caller can transparently fall back to the existing backoff. The result is also clamped to **60 s** so a hostile or misconfigured upstream cannot freeze the proxy for an unbounded amount of time.

### Retry loop change

Inside the `async-retry` callback, when a 429 is received the proxy now sleeps for the parsed `Retry-After` value (when present) before throwing. `async-retry`'s exponential backoff still applies on top, so the provider-mandated minimum can only ever lengthen the wait, never shorten one of the existing retries.

```ts
if (res.status === 429) {
  const retryAfterMs = parseRetryAfter(res.headers.get("retry-after"));
  if (retryAfterMs !== null && retryAfterMs > 0) {
    await sleep(retryAfterMs);
  }
}
throw new Error(`Status code ${res.status}`);
```

5xx behaviour is **unchanged**: 5xx responses still throw immediately and rely on the exponential backoff alone.

## Scope

- One file modified: `valhalla/jawn/src/lib/proxy/ProviderClient.ts` (+50 lines).
- One new unit-test file: `valhalla/jawn/src/lib/proxy/__tests__/ProviderClient.test.ts` covering the helper end-to-end (delta-seconds, HTTP-date, negative cases, the 60 s cap).
- `worker/src/lib/clients/ProviderClient.ts` has the same retry pattern and would benefit from the same treatment in a follow-up. I intentionally kept this PR narrow to the file the issue cites; happy to spin off the worker patch in a second PR if you'd prefer that shape.

## Tested

```
$ cd valhalla/jawn
$ npx jest src/lib/proxy/__tests__/ProviderClient.test.ts
PASS src/lib/proxy/__tests__/ProviderClient.test.ts
  parseRetryAfter
    ✓ returns null for missing or empty values
    ✓ parses delta-seconds form into milliseconds
    ✓ trims surrounding whitespace before parsing seconds
    ✓ caps very large delta-seconds at 60 seconds
    ✓ rejects non-numeric, non-date strings
    ✓ parses HTTP-date form into milliseconds from `now`
    ✓ returns null for HTTP-date values in the past
    ✓ caps HTTP-date values far in the future at 60 seconds

Tests: 8 passed, 8 total

$ npx tsc --noEmit       # 0 errors
```
