### PR TITLE
chore: fix typo in retry-exhausted error message (occured -> occurred)

### DIFF
--- a/valhalla/jawn/src/lib/proxy/ProviderClient.ts
+++ b/valhalla/jawn/src/lib/proxy/ProviderClient.ts
@@ -108,7 +108,7 @@ export async function callProviderWithRetry(
   }
 
   if (lastResponse === undefined) {
-    throw new Error("500 An error occured while retrying your requests");
+    throw new Error("500 An error occurred while retrying your requests");
   }
 
   return lastResponse;

--- a/worker/src/lib/clients/ProviderClient.ts
+++ b/worker/src/lib/clients/ProviderClient.ts
@@ -223,7 +223,7 @@ export async function callProviderWithRetry(
   }
 
   if (lastResponse === undefined) {
-    throw new Error("500 An error occured while retrying your requests");
+    throw new Error("500 An error occurred while retrying your requests");
   }
 
   return lastResponse;


### PR DESCRIPTION
## Summary

Both retry helpers in this repo (`valhalla/jawn/src/lib/proxy/ProviderClient.ts` and `worker/src/lib/clients/ProviderClient.ts`) throw `"500 An error occured while retrying your requests"` when all retries fail.

`occured` is a common misspelling of `occurred`. The string is user-visible — it propagates up when the provider remains unreachable across the entire retry budget, so it can surface in production logs and on-call traces.

## Scope

Pure string change in two files. No logic, control flow, or test affected.

```
- throw new Error("500 An error occured while retrying your requests");
+ throw new Error("500 An error occurred while retrying your requests");
```

## Test plan

- [x] No tests asserted against the exact string.
- [x] grep confirms no other 'occured' typos in source under `valhalla/jawn/src/` or `worker/src/`.