### PR TITLE
fix: provide ws transport to Supabase client (Node 20 dashboard auth break)

### DIFF
--- a/valhalla/jawn/src/packages/common/toImplement/server/SupabaseAuthWrapper.ts
+++ b/valhalla/jawn/src/packages/common/toImplement/server/SupabaseAuthWrapper.ts
@@ -13,6 +13,7 @@ import { AuthParams } from "../../auth/types";
 import { OrgParams } from "../../auth/types";
 import { HeliconeUserResult } from "../../auth/types";
 import { createClient } from "@supabase/supabase-js";
+import WebSocket from "ws";
 import { KVCache } from "../../../../lib/cache/kvCache";
 import { Database } from "../../../../lib/db/database.types";
 import { SupabaseClient } from "@supabase/supabase-js";
@@ -51,7 +52,16 @@ export class SupabaseConnector {
     }
     const staticClient: SupabaseClient<Database> = createClient(
       supabaseURL,
-      supabaseServiceRoleKey
+      supabaseServiceRoleKey,
+      {
+        // Node 20 (see valhalla/dockerfile: node:20.19.4) has no global
+        // WebSocket. @supabase/realtime-js >=2.15 throws at client
+        // construction time without a transport, which breaks all auth.
+        // Provide the `ws` implementation explicitly.
+        realtime: {
+          transport: WebSocket as unknown as typeof globalThis.WebSocket,
+        },
+      }
     );
 
     this.client = staticClient;


### PR DESCRIPTION
## Problem

Dashboard auth was returning **400 \"Invalid token\"** for all users. jawn logs showed, on every request:

```
Error processing authentication: Error: Node.js 20 detected without native WebSocket support.
... Context: AuthenticationHandler
```

## Root cause

- `@supabase/realtime-js` >= 2.15 throws **at Supabase client construction time** if there is no global `WebSocket` and no transport is supplied — even when realtime is never used.
- The jawn container runs `node:20.19.4-bookworm-slim` (`valhalla/dockerfile:6`). Node 20 has no global `WebSocket` (default only in Node 21/22).
- `SupabaseConnector` (`SupabaseAuthWrapper.ts`) constructs a client via `createClient()` with no realtime transport, so every construction threw → `AuthenticationHandler` failed → 400 for all dashboard auth.

## Why now

Not a code or lockfile change in May. `yarn.lock` has resolved `@supabase/supabase-js@2.55.0` / `@supabase/realtime-js@2.15.1` since **#4266 (2025-08-13)**. Production ran an older `jawn:us` image built *before* that resolution. It only detonated when `jawn:us` was rebuilt + redeployed during the May 14 infra recovery — the first fresh build to bundle the throwing realtime-js on Node 20.

## Fix

Pass the already-present `ws` package (`ws@8.17.1`, `@types/ws` already direct deps) as the realtime `transport` to `createClient`, exactly as the error message recommends. Minimal and targeted: no version bumps, no Node upgrade.

## Testing

- `tsc --noEmit` clean for the changed file.
- jawn never uses Supabase realtime; this only unblocks client construction so `auth.getUser()` / table reads work again.

## Follow-up (not in this PR)

Consider pinning `@supabase/supabase-js` to an exact version so a future lockfile regen can't silently reintroduce a breaking transitive change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)