### PR TITLE
banner: AWS issue banner -> resolved + blog link

### DIFF
--- a/web/components/layout/AWSIssueBanner.tsx
+++ b/web/components/layout/AWSIssueBanner.tsx
@@ -1,12 +1,21 @@
-import { AlertTriangle } from "lucide-react";
+import { CheckCircle2 } from "lucide-react";
 
 const AWSIssueBanner = () => {
   return (
-    <div className="relative flex w-full items-center justify-center gap-2 bg-amber-500 px-4 py-2 text-amber-950 dark:bg-amber-600 dark:text-amber-50">
-      <AlertTriangle size={16} className="shrink-0" />
+    <div className="relative flex w-full items-center justify-center gap-2 bg-emerald-600 px-4 py-2 text-emerald-50 dark:bg-emerald-700">
+      <CheckCircle2 size={16} className="shrink-0" />
       <p className="text-sm font-medium">
-        We&apos;re currently experiencing an issue with our AWS account and are
-        actively working to resolve it. Thanks for your patience.
+        Resolved: the AWS account issue is fixed. The proxy stayed up the whole
+        time and no data was lost. The backlog is still processing.{" "}
+        <a
+          href="https://www.helicone.ai/blog/aws-account-incident"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2 hover:text-white"
+        >
+          What happened
+        </a>
+        .
       </p>
     </div>
   );


### PR DESCRIPTION
## What

Updates the hardcoded AWS issue banner (`web/components/layout/AWSIssueBanner.tsx`, added in #5678, rendered globally in `web/pages/_app.tsx`) from "currently experiencing an issue" to a resolved state.

- Copy: resolved, proxy stayed up the whole time, no data lost, backlog still processing
- Style: amber warning -> emerald (resolved), warning icon -> check icon
- Adds a clickable **"What happened"** link to the incident write-up: https://www.helicone.ai/blog/aws-account-incident (opens in new tab)

## Notes

- This banner is **not** the DB `alert_banners` system. There is no active row in that table; the live banner is this hardcoded component, so this edit is the actual change users see.
- Still always-on. Once enough time has passed / backlog fully drained, follow up by removing `<AWSIssueBanner />` from `_app.tsx` (or gating it).
- Companion to the merged blog post PR #5681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)