### PR TITLE
feat: add Auxen as an approved gateway provider

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -143,6 +143,7 @@
                       "integrations/azure/python"
                     ]
                   },
+                  "getting-started/integration-method/auxen",
                   "getting-started/integration-method/deepinfra",
                   "getting-started/integration-method/deepseek",
                   {

--- a/docs/getting-started/integration-method/auxen.mdx
+++ b/docs/getting-started/integration-method/auxen.mdx
@@ -1,0 +1,62 @@
+---
+title: "Auxen Integration"
+sidebarTitle: "Auxen"
+description: "Connect Helicone with Auxen — per-customer dedicated, OpenAI-compatible LLM endpoints running open-source models (Llama, Qwen, Mistral, Gemma, Mixtral, Phi, Command R)."
+"twitter:title": "Auxen Integration - Helicone OSS LLM Observability"
+---
+
+[Auxen](https://auxen.ai) hosts per-customer **dedicated** LLM endpoints with an OpenAI-compatible `/v1/chat/completions` API. Each instance is a dedicated GPU running one open-source model on a stable HTTPS URL of the form `https://api.auxen.ai/v1/<instance_id>/v1`, authenticated with a per-instance `auxk_*` bearer token. Billing is per-minute of runtime, not per-token.
+
+You can follow Auxen's documentation here: [auxen.ai/docs](https://auxen.ai/docs)
+
+# Gateway Integration
+
+<Steps>
+  <Step title="Create a Helicone account">
+    Log into [helicone](https://www.helicone.ai) or create an account. Once you have an account, you can generate an [API key](https://helicone.ai/developer).
+  </Step>
+  <Step title="Create an Auxen account and provision an instance">
+    Log into [auxen.ai](https://auxen.ai) or create an account. Provision an LLM instance — you will be issued a per-instance base URL of the form `https://api.auxen.ai/v1/inst_xxx/v1` and an API key prefixed `auxk_`.
+  </Step>
+  <Step title="Set HELICONE_API_KEY and AUXEN_API_KEY as environment variables">
+```bash
+HELICONE_API_KEY=<your Helicone API key>
+AUXEN_API_KEY=<your auxk_* API key>
+```
+  </Step>
+  <Step title="Modify the base URL and add Auth headers">
+
+Replace the Auxen API base host with the Helicone Gateway host, keeping the per-instance path segments intact:
+
+`https://api.auxen.ai/v1/inst_xxx/v1/chat/completions` -> `https://auxen.helicone.ai/v1/inst_xxx/v1/chat/completions`
+
+Add the standard Helicone authentication header:
+
+```bash
+Helicone-Auth: Bearer <your Helicone API key>
+```
+
+</Step>
+</Steps>
+
+## Example
+
+```bash
+curl --request POST \
+     --url https://auxen.helicone.ai/v1/inst_xxx/v1/chat/completions \
+     --header 'Content-Type: application/json' \
+     --header "Authorization: Bearer $AUXEN_API_KEY" \
+     --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+     --data '{
+         "model": "llama-3.1-8b",
+         "messages": [
+             {
+                 "role": "user",
+                 "content": "Say hello."
+             }
+         ]
+     }'
+```
+
+For more information on Helicone headers, see the [Helicone Headers](https://docs.helicone.ai/helicone-headers/header-directory#utilizing-headers) docs.
+For more information on Auxen, see [auxen.ai/docs](https://auxen.ai/docs).

--- a/docs/getting-started/integration-method/gateway.mdx
+++ b/docs/getting-started/integration-method/gateway.mdx
@@ -337,6 +337,7 @@ curl --request POST \
 | Cohere      | `api.cohere.ai`                   | ❌           | ❌                       |
 | QStash      | `qstash.upstash.io`               | ❌           | `qstash.helicone.ai`     |
 | Firecrawl   | `api.firecrawl.dev`               | ❌           | `firecrawl.helicone.ai`  |
+| Auxen       | `api.auxen.ai`                    | ❌           | `auxen.helicone.ai`      |
 
 ## Unapproved Domains
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -330,6 +330,12 @@ async function modifyEnvBasedOnPath(
         WORKER_TYPE: "GATEWAY_API",
         GATEWAY_TARGET: "https://api.deepseek.com",
       };
+    } else if (hostParts[0] === "auxen") {
+      return {
+        ...env,
+        WORKER_TYPE: "GATEWAY_API",
+        GATEWAY_TARGET: "https://api.auxen.ai",
+      };
     } else if (hostParts[0] === "nebius") {
       return {
         ...env,

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -134,6 +134,7 @@ routes = [
 	{ pattern = "llmmapper.helicone.ai", custom_domain = true, zone_name = "helicone.ai" },
 	{ pattern = "bedrock.helicone.ai", custom_domain = true, zone_name = "helicone.ai" },
 	{ pattern = "deepseek.helicone.ai", custom_domain = true, zone_name = "helicone.ai" },
+	{ pattern = "auxen.helicone.ai", custom_domain = true, zone_name = "helicone.ai" },
 	{ pattern = "x.helicone.ai", custom_domain = true, zone_name = "helicone.ai" },
 	{ pattern = "nebius.helicone.ai", custom_domain = true, zone_name = "helicone.ai" },
 	{ pattern = "perplexity.helicone.ai", custom_domain = true, zone_name = "helicone.ai" },


### PR DESCRIPTION
Adds [Auxen](https://auxen.ai) — per-customer **dedicated**, OpenAI-compatible LLM endpoints — to Helicone's approved-domain gateway list.

## What Auxen is

Each Auxen instance is a dedicated GPU running one open-source model (Llama 3.1/3.2, Qwen 2.5, Mistral, Gemma 2, Mixtral, Phi-3, Command R) on a stable HTTPS URL of the form \`https://api.auxen.ai/v1/<instance_id>/v1\`, authenticated with a per-instance \`auxk_*\` bearer token. Billing is per-minute of GPU runtime, not per-token.

## Why the dedicated-domain pattern works

The instance ID is path-based, and the API is OpenAI-wire-compatible. Callers just replace the \`api.auxen.ai\` host with \`auxen.helicone.ai\` and keep the rest of the path unchanged — no special handling needed in the gateway code beyond the standard \`GATEWAY_TARGET\` mapping that DeepSeek, Together, etc. already use.

\`\`\`
https://api.auxen.ai/v1/inst_xxx/v1/chat/completions
                  ↓
https://auxen.helicone.ai/v1/inst_xxx/v1/chat/completions
\`\`\`

## Files touched

- \`worker/wrangler.toml\` — register \`auxen.helicone.ai\` custom domain
- \`worker/src/index.ts\` — route \`auxen.*\` host to \`https://api.auxen.ai\`
- \`docs/getting-started/integration-method/auxen.mdx\` (new) — integration doc
- \`docs/getting-started/integration-method/gateway.mdx\` — add Auxen to approved-domains table
- \`docs/docs.json\` — sidebar entry

## Note on approval process

Per the gateway docs, dedicated-domain approval is ordinarily a request to engineering@helicone.ai. Filing this as a PR with the proposed wiring to make it easy to review. Happy to follow up with domain ownership verification (TXT record at \`api.auxen.ai\` or direct contact via \`hello@auxen.ai\`) if that's the preferred path.

## Companion PRs (Auxen distribution series)

- [BerriAI/litellm#28532](https://github.com/BerriAI/litellm/pull/28532) — LiteLLM provider
- [vercel/ai#15536](https://github.com/vercel/ai/pull/15536) — Vercel AI SDK community provider
- [langchain-ai/docs#4146](https://github.com/langchain-ai/docs/pull/4146) — LangChain docs (Python + JS)
- [run-llama/llama_index#21764](https://github.com/run-llama/llama_index/pull/21764) — LlamaIndex Python
- [continuedev/continue#12473](https://github.com/continuedev/continue/pull/12473) — Continue.dev provider
- npm: [\`@auxen/ai-sdk-provider\`](https://www.npmjs.com/package/@auxen/ai-sdk-provider) (live)