### PR TITLE
docs: add Auxen integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -128,6 +128,14 @@
                   },
                   "getting-started/integration-method/anyscale",
                   {
+                    "group": "Auxen",
+                    "pages": [
+                      "integrations/auxen/curl",
+                      "integrations/auxen/javascript",
+                      "integrations/auxen/python"
+                    ]
+                  },
+                  {
                     "group": "AWS Bedrock",
                     "pages": [
                       "integrations/bedrock/javascript",

--- a/docs/integrations/auxen/curl.mdx
+++ b/docs/integrations/auxen/curl.mdx
@@ -1,0 +1,67 @@
+---
+title: "Auxen cURL Integration"
+sidebarTitle: "cURL"
+description: "Use Auxen's private AI model instances with Helicone observability via cURL."
+"twitter:title": "Auxen cURL Integration - Helicone OSS LLM Observability"
+icon: "terminal"
+iconType: "solid"
+---
+
+[Auxen](https://auxen.ai) provisions private AI model endpoints on dedicated GPUs. Each instance is OpenAI-compatible, so any cURL call you'd make to an Auxen instance directly can route through Helicone with two headers added.
+
+<Steps>
+  <Step title="Generate Helicone + Auxen credentials">
+    - **Helicone API key**: from [helicone.ai/developer](https://helicone.ai/developer)
+    - **Auxen endpoint URL + API key**: from [auxen.ai/dashboard](https://auxen.ai/dashboard) after provisioning a model
+  </Step>
+
+  <Step title="Send a chat completion through the gateway">
+
+```bash
+curl -X POST https://gateway.helicone.ai/v1/chat/completions \
+  -H "Authorization: Bearer $AUXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+  -H "Helicone-Target-URL: $AUXEN_BASE_URL" \
+  -d '{
+    "model": "llama-3.1-8b",
+    "messages": [
+      {"role": "user", "content": "Hello"}
+    ]
+  }'
+```
+
+Where:
+- `AUXEN_BASE_URL`: your per-instance Auxen URL, e.g. `https://api.auxen.ai/v1/inst_abc123`
+- `AUXEN_API_KEY`: your per-instance Auxen key, starts with `auxk_`
+- `HELICONE_API_KEY`: your Helicone API key
+
+  </Step>
+
+  <Step title="Verify the request appeared in Helicone">
+    Open the [Helicone dashboard](https://helicone.ai/requests). The request should appear within a few seconds with full token counts, latency, and request/response bodies.
+  </Step>
+</Steps>
+
+## Streaming
+
+Add `"stream": true` to the JSON body and Helicone will forward the SSE stream from Auxen unchanged:
+
+```bash
+curl -N -X POST https://gateway.helicone.ai/v1/chat/completions \
+  -H "Authorization: Bearer $AUXEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Helicone-Auth: Bearer $HELICONE_API_KEY" \
+  -H "Helicone-Target-URL: $AUXEN_BASE_URL" \
+  -d '{
+    "model": "llama-3.1-8b",
+    "messages": [{"role": "user", "content": "Tell me a story"}],
+    "stream": true
+  }'
+```
+
+## Related
+
+- [Auxen homepage](https://auxen.ai)
+- [Auxen docs](https://auxen.ai/docs)
+- [Auxen MCP server](https://github.com/auxen-ai/mcp-server)

--- a/docs/integrations/auxen/javascript.mdx
+++ b/docs/integrations/auxen/javascript.mdx
@@ -1,0 +1,96 @@
+---
+title: "Auxen JavaScript SDK Integration"
+sidebarTitle: "JavaScript"
+description: "Use Auxen's private AI model instances with Helicone observability via the OpenAI-compatible API."
+"twitter:title": "Auxen JavaScript SDK Integration - Helicone OSS LLM Observability"
+icon: "js"
+iconType: "solid"
+---
+
+[Auxen](https://auxen.ai) provisions private AI model endpoints on dedicated GPUs (Llama, Qwen, Mistral, Gemma, Phi-3, Mixtral). Each instance is OpenAI-compatible and has its own base URL, so Helicone proxies through the generic `gateway.helicone.ai` endpoint using the `Helicone-Target-URL` header.
+
+<Note>
+
+Auxen issues a **per-instance** base URL (`https://api.auxen.ai/v1/inst_xxx`) and API key (`auxk_...`) at provision time. Set those as environment variables before configuring Helicone.
+
+</Note>
+
+<Steps>
+  <Step title="Create a Helicone account + Generate an API Key">
+    Log into [helicone](https://www.helicone.ai) or create an account. Once you have an account, you can generate an [API key](https://helicone.ai/developer).
+  </Step>
+
+  <Step title="Provision an Auxen instance">
+    Sign up at [auxen.ai/dashboard](https://auxen.ai/dashboard), provision a model, and copy the **endpoint URL** + **API key** Auxen returns.
+  </Step>
+
+  <Step title="Set environment variables">
+```bash
+HELICONE_API_KEY=<your-helicone-api-key>
+AUXEN_BASE_URL=https://api.auxen.ai/v1/inst_xxx     # from the Auxen dashboard
+AUXEN_API_KEY=auxk_...                              # from the Auxen dashboard
+```
+  </Step>
+
+  <Step title="Use the OpenAI SDK with the Helicone gateway + Auxen target">
+<CodeGroup>
+
+```javascript OpenAI SDK
+import OpenAI from "openai";
+
+const auxen = new OpenAI({
+  apiKey: process.env.AUXEN_API_KEY,
+  baseURL: "https://gateway.helicone.ai/v1",
+  defaultHeaders: {
+    "Helicone-Auth": `Bearer ${process.env.HELICONE_API_KEY}`,
+    "Helicone-Target-URL": process.env.AUXEN_BASE_URL,
+  },
+});
+
+const completion = await auxen.chat.completions.create({
+  model: "llama-3.1-8b",
+  messages: [{ role: "user", content: "Hello" }],
+});
+
+console.log(completion.choices[0].message.content);
+```
+
+```javascript Vercel AI SDK
+import { createAuxen } from "@auxen-ai/ai-sdk-provider";
+import { generateText } from "ai";
+
+const auxen = createAuxen({
+  baseURL: process.env.AUXEN_BASE_URL,
+  apiKey: process.env.AUXEN_API_KEY,
+  headers: {
+    "Helicone-Auth": `Bearer ${process.env.HELICONE_API_KEY}`,
+    "Helicone-Target-URL": process.env.AUXEN_BASE_URL,
+  },
+  // override the base URL to route through Helicone
+  baseURL: "https://gateway.helicone.ai/v1",
+});
+
+const { text } = await generateText({
+  model: auxen("llama-3.1-8b"),
+  prompt: "Hello",
+});
+```
+
+</CodeGroup>
+  </Step>
+</Steps>
+
+## What gets logged
+
+- Token counts (prompt + completion)
+- Latency
+- Cost estimates (LiteLLM does cost lookup via per-token rates; Auxen bills per minute of GPU runtime — see the [Auxen pricing docs](https://auxen.ai/docs) for ground-truth billing)
+- Errors and retry behavior
+- Full request/response bodies (subject to your Helicone data-retention settings)
+
+## Related
+
+- [Auxen homepage](https://auxen.ai)
+- [Auxen Python SDK](https://github.com/auxen-ai/auxen-python)
+- [Auxen AI SDK Provider for Vercel AI SDK](https://github.com/auxen-ai/ai-sdk-provider)
+- [Auxen MCP server](https://github.com/auxen-ai/mcp-server)

--- a/docs/integrations/auxen/python.mdx
+++ b/docs/integrations/auxen/python.mdx
@@ -1,0 +1,117 @@
+---
+title: "Auxen Python SDK Integration"
+sidebarTitle: "Python"
+description: "Use Auxen's private AI model instances with Helicone observability via the OpenAI-compatible API."
+"twitter:title": "Auxen Python SDK Integration - Helicone OSS LLM Observability"
+icon: "python"
+iconType: "solid"
+---
+
+[Auxen](https://auxen.ai) provisions private AI model endpoints on dedicated GPUs (Llama, Qwen, Mistral, Gemma, Phi-3, Mixtral). Each instance is OpenAI-compatible and has its own base URL, so Helicone proxies through the generic `gateway.helicone.ai` endpoint using the `Helicone-Target-URL` header.
+
+<Note>
+
+Auxen issues a **per-instance** base URL (`https://api.auxen.ai/v1/inst_xxx`) and API key (`auxk_...`) at provision time. Set those as environment variables before configuring Helicone.
+
+</Note>
+
+<Steps>
+  <Step title="Create a Helicone account + Generate an API Key">
+    Log into [helicone](https://www.helicone.ai) or create an account. Once you have an account, you can generate an [API key](https://helicone.ai/developer).
+  </Step>
+
+  <Step title="Provision an Auxen instance">
+    Sign up at [auxen.ai/dashboard](https://auxen.ai/dashboard), provision a model, and copy the **endpoint URL** + **API key** Auxen returns.
+  </Step>
+
+  <Step title="Set environment variables">
+```bash
+export HELICONE_API_KEY=<your-helicone-api-key>
+export AUXEN_BASE_URL=https://api.auxen.ai/v1/inst_xxx     # from the Auxen dashboard
+export AUXEN_API_KEY=auxk_...                              # from the Auxen dashboard
+```
+  </Step>
+
+  <Step title="Use the OpenAI SDK with the Helicone gateway + Auxen target">
+<CodeGroup>
+
+```python OpenAI SDK
+import os
+from openai import OpenAI
+
+auxen = OpenAI(
+    api_key=os.environ["AUXEN_API_KEY"],
+    base_url="https://gateway.helicone.ai/v1",
+    default_headers={
+        "Helicone-Auth": f"Bearer {os.environ['HELICONE_API_KEY']}",
+        "Helicone-Target-URL": os.environ["AUXEN_BASE_URL"],
+    },
+)
+
+response = auxen.chat.completions.create(
+    model="llama-3.1-8b",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+
+print(response.choices[0].message.content)
+```
+
+```python auxen SDK (with Helicone headers)
+import os
+from auxen import Auxen
+
+# Route the Auxen Python SDK through Helicone via base_url override
+auxen = Auxen(
+    api_key=os.environ["AUXEN_API_KEY"],
+    base_url="https://gateway.helicone.ai/v1",
+    default_headers={
+        "Helicone-Auth": f"Bearer {os.environ['HELICONE_API_KEY']}",
+        "Helicone-Target-URL": os.environ["AUXEN_BASE_URL"],
+    },
+)
+
+response = auxen.chat.completions.create(
+    model="llama-3.1-8b",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+```
+
+</CodeGroup>
+  </Step>
+</Steps>
+
+## Async + streaming
+
+Helicone passes through OpenAI's standard async + streaming behavior — no extra config needed.
+
+```python
+import asyncio
+import os
+from openai import AsyncOpenAI
+
+async def main():
+    auxen = AsyncOpenAI(
+        api_key=os.environ["AUXEN_API_KEY"],
+        base_url="https://gateway.helicone.ai/v1",
+        default_headers={
+            "Helicone-Auth": f"Bearer {os.environ['HELICONE_API_KEY']}",
+            "Helicone-Target-URL": os.environ["AUXEN_BASE_URL"],
+        },
+    )
+
+    stream = await auxen.chat.completions.create(
+        model="llama-3.1-8b",
+        messages=[{"role": "user", "content": "Tell me a story"}],
+        stream=True,
+    )
+    async for chunk in stream:
+        print(chunk.choices[0].delta.content or "", end="")
+
+asyncio.run(main())
+```
+
+## Related
+
+- [Auxen homepage](https://auxen.ai)
+- [Auxen Python SDK](https://github.com/auxen-ai/auxen-python) (`pip install auxen`)
+- [Auxen MCP server](https://github.com/auxen-ai/mcp-server)


### PR DESCRIPTION
Adds documentation for routing [Auxen](https://auxen.ai) private-model inference requests through Helicone's gateway for observability.

**About Auxen:** Auxen provisions per-instance OpenAI-compatible LLM endpoints on dedicated GPUs (Llama, Qwen, Mistral, Gemma, Phi-3, Mixtral). Each instance has its own base URL + API key.

**Integration shape:** Because Auxen instances are per-customer (no single global API host), this integration uses Helicone's generic gateway (`gateway.helicone.ai`) with the `Helicone-Target-URL` header pointing at the user's Auxen instance. **No Helicone-side changes needed** — purely docs.

**Files:**
- `docs/integrations/auxen/javascript.mdx` — Quickstart with OpenAI SDK + Vercel AI SDK provider examples
- `docs/integrations/auxen/python.mdx` — Quickstart with OpenAI Python SDK + Auxen Python SDK examples (async + streaming)
- `docs/integrations/auxen/curl.mdx` — Raw cURL recipe

**Navigation:** `docs/docs.json` updated — new `Auxen` group inserted alphabetically between Anyscale and AWS Bedrock.

**Example usage (excerpt):**

```javascript
const auxen = new OpenAI({
  apiKey: process.env.AUXEN_API_KEY,
  baseURL: "https://gateway.helicone.ai/v1",
  defaultHeaders: {
    "Helicone-Auth": `Bearer ${process.env.HELICONE_API_KEY}`,
    "Helicone-Target-URL": process.env.AUXEN_BASE_URL,
  },
});
```

**Links:**
- [Auxen homepage](https://auxen.ai)
- [Auxen Python SDK (github.com/auxen-ai/auxen-python)](https://github.com/auxen-ai/auxen-python)
- [Auxen MCP server (github.com/auxen-ai/mcp-server)](https://github.com/auxen-ai/mcp-server)