### PR TITLE
feat(cost): add Claude Opus 4.7 and 4.8 

### DIFF
--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -1165,6 +1165,214 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
       ],
     },
   },
+  "anthropic/claude-4.7-opus": {
+    "claude-4.7-opus:anthropic": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 128000,
+      "modelId": "claude-opus-4-7-20260416",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "anthropic",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+    "claude-4.7-opus:bedrock": {
+      "context": 1000000,
+      "crossRegion": true,
+      "maxTokens": 128000,
+      "modelId": "anthropic.claude-opus-4-7-20260416-v1:0",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p",
+      ],
+      "provider": "bedrock",
+      "ptbEnabled": true,
+      "regions": [
+        "us-east-1",
+      ],
+    },
+    "claude-4.7-opus:helicone": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 128000,
+      "modelId": "pa/claude-opus-4-7",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "helicone",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+    "claude-4.7-opus:openrouter": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 128000,
+      "modelId": "anthropic/claude-opus-4.7",
+      "parameters": [
+        "max_tokens",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p",
+      ],
+      "provider": "openrouter",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+    "claude-4.7-opus:vertex": {
+      "context": 1000000,
+      "crossRegion": true,
+      "maxTokens": 128000,
+      "modelId": "claude-opus-4-7@20260416",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "vertex",
+      "ptbEnabled": true,
+      "regions": [
+        "global",
+      ],
+    },
+  },
+  "anthropic/claude-4.8-opus": {
+    "claude-4.8-opus:anthropic": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 128000,
+      "modelId": "claude-opus-4-8-20260528",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "anthropic",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+    "claude-4.8-opus:bedrock": {
+      "context": 1000000,
+      "crossRegion": true,
+      "maxTokens": 128000,
+      "modelId": "anthropic.claude-opus-4-8-20260528-v1:0",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p",
+      ],
+      "provider": "bedrock",
+      "ptbEnabled": true,
+      "regions": [
+        "us-east-1",
+      ],
+    },
+    "claude-4.8-opus:helicone": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 128000,
+      "modelId": "pa/claude-opus-4-8",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "helicone",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+    "claude-4.8-opus:openrouter": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 128000,
+      "modelId": "anthropic/claude-opus-4.8",
+      "parameters": [
+        "max_tokens",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p",
+      ],
+      "provider": "openrouter",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+    "claude-4.8-opus:vertex": {
+      "context": 1000000,
+      "crossRegion": true,
+      "maxTokens": 128000,
+      "modelId": "claude-opus-4-8@20260528",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "vertex",
+      "ptbEnabled": true,
+      "regions": [
+        "global",
+      ],
+    },
+  },
   "anthropic/claude-haiku-4-5-20251001": {
     "claude-haiku-4-5-20251001:anthropic": {
       "context": 200000,
@@ -7372,6 +7580,20 @@ exports[`Registry Snapshots model coverage snapshot 1`] = `
     "helicone",
     "vertex",
   ],
+  "anthropic/claude-4.7-opus": [
+    "anthropic",
+    "bedrock",
+    "helicone",
+    "openrouter",
+    "vertex",
+  ],
+  "anthropic/claude-4.8-opus": [
+    "anthropic",
+    "bedrock",
+    "helicone",
+    "openrouter",
+    "vertex",
+  ],
   "anthropic/claude-haiku-4-5-20251001": [
     "anthropic",
     "bedrock",
@@ -8299,6 +8521,126 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
         },
         "input": 0.000003,
         "output": 0.000015,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+  },
+  "anthropic/claude-4.7-opus": {
+    "anthropic": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write1h": 2,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+    "bedrock": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+    "helicone": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write1h": 2,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+    "openrouter": [
+      {
+        "input": 0.000005275,
+        "output": 0.000026375,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+    "vertex": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+  },
+  "anthropic/claude-4.8-opus": {
+    "anthropic": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write1h": 2,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+    "bedrock": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+    "helicone": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write1h": 2,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+    "openrouter": [
+      {
+        "input": 0.000005275,
+        "output": 0.000026375,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+    "vertex": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
         "threshold": 0,
         "web_search": 0.01,
       },
@@ -10054,6 +10396,26 @@ exports[`Registry Snapshots verify registry state 1`] = `
       ],
     },
     {
+      "model": "claude-4.7-opus",
+      "providers": [
+        "anthropic",
+        "bedrock",
+        "helicone",
+        "openrouter",
+        "vertex",
+      ],
+    },
+    {
+      "model": "claude-4.8-opus",
+      "providers": [
+        "anthropic",
+        "bedrock",
+        "helicone",
+        "openrouter",
+        "vertex",
+      ],
+    },
+    {
       "model": "claude-haiku-4-5-20251001",
       "providers": [
         "anthropic",
@@ -10846,7 +11208,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
   ],
   "providerBreakdown": [
     {
-      "modelCount": 15,
+      "modelCount": 17,
       "provider": "anthropic",
     },
     {
@@ -10858,7 +11220,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "baseten",
     },
     {
-      "modelCount": 14,
+      "modelCount": 16,
       "provider": "bedrock",
     },
     {
@@ -10894,7 +11256,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "groq",
     },
     {
-      "modelCount": 55,
+      "modelCount": 57,
       "provider": "helicone",
     },
     {
@@ -10914,7 +11276,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "openai",
     },
     {
-      "modelCount": 71,
+      "modelCount": 73,
       "provider": "openrouter",
     },
     {
@@ -10922,7 +11284,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
       "provider": "perplexity",
     },
     {
-      "modelCount": 23,
+      "modelCount": 25,
       "provider": "vertex",
     },
     {
@@ -10941,6 +11303,8 @@ exports[`Registry Snapshots verify registry state 1`] = `
     "claude-4.5-sonnet",
     "claude-4.6-opus",
     "claude-4.6-sonnet",
+    "claude-4.7-opus",
+    "claude-4.8-opus",
     "claude-haiku-4-5-20251001",
     "claude-opus-4",
     "claude-opus-4-1",
@@ -11049,9 +11413,9 @@ exports[`Registry Snapshots verify registry state 1`] = `
     "claude-3.5-haiku:anthropic:*",
   ],
   "totalArchivedConfigs": 0,
-  "totalEndpoints": 329,
-  "totalModelProviderConfigs": 329,
-  "totalModelsWithPtb": 108,
+  "totalEndpoints": 339,
+  "totalModelProviderConfigs": 339,
+  "totalModelsWithPtb": 110,
   "totalProviders": 21,
 }
 `;

--- a/packages/cost/models/authors/anthropic/claude-4.7-opus/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-4.7-opus/endpoints.ts
@@ -1,0 +1,185 @@
+import { ModelProviderName } from "../../../providers";
+import type { ModelProviderConfig } from "../../../types";
+import { ClaudeOpus47ModelName } from "./model";
+
+export const endpoints = {
+  "claude-4.7-opus:anthropic": {
+    providerModelId: "claude-opus-4-7-20260416",
+    provider: "anthropic",
+    author: "anthropic",
+    version: "20260416",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+          write1h: 2.0, // $10 / MTok (200% of $5)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    supportedPlugins: ["web"],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+
+  "claude-4.7-opus:vertex": {
+    providerModelId: "claude-opus-4-7@20260416",
+    provider: "vertex",
+    author: "anthropic",
+    version: "vertex-2023-10-16",
+    ptbEnabled: true,
+    crossRegion: true,
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      global: {
+        providerModelId: "claude-opus-4-7@20260416",
+      },
+    },
+  },
+  "claude-4.7-opus:bedrock": {
+    provider: "bedrock",
+    author: "anthropic",
+    providerModelId: "anthropic.claude-opus-4-7-20260416-v1:0",
+    version: "20260416",
+    crossRegion: true,
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+      "top_p",
+      "top_k",
+    ],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "us-east-1": {},
+    },
+  },
+  "claude-4.7-opus:openrouter": {
+    provider: "openrouter",
+    author: "anthropic",
+    providerModelId: "anthropic/claude-opus-4.7",
+    providerModelIdAliases: [
+      "anthropic/claude-4.7-opus-20260416",
+      "anthropic/claude-opus-4.7-20260416",
+    ],
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005275, // $5.275/1M - worst-case: $5.00/1M (Anthropic/Google) * 1.055
+        output: 0.000026375, // $26.375/1M - worst-case: $25.00/1M (Anthropic/Google) * 1.055
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "tools",
+      "tool_choice",
+      "top_p",
+      "top_k",
+    ],
+    ptbEnabled: true,
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+  "claude-4.7-opus:helicone": {
+    provider: "helicone",
+    author: "anthropic",
+    providerModelId: "pa/claude-opus-4-7",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+          write1h: 2.0, // $10 / MTok (200% of $5)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+} satisfies Partial<
+  Record<`${ClaudeOpus47ModelName}:${ModelProviderName}`, ModelProviderConfig>
+>;

--- a/packages/cost/models/authors/anthropic/claude-4.7-opus/model.ts
+++ b/packages/cost/models/authors/anthropic/claude-4.7-opus/model.ts
@@ -1,0 +1,17 @@
+import type { ModelConfig } from "../../../types";
+
+export const models = {
+  "claude-4.7-opus": {
+    name: "Anthropic: Claude Opus 4.7",
+    author: "anthropic",
+    description:
+      "Claude Opus 4.7 is Anthropic's most capable model, released April 2026. Building on the intelligence of Opus 4.6, it brings new levels of reliability and precision to coding, agents, and enterprise workflows. Features a 1M context window, hybrid reasoning with extended thinking, and state-of-the-art performance on coding and agentic tasks. API model name: claude-opus-4-7",
+    contextLength: 1000000,
+    maxOutputTokens: 128000,
+    created: "2026-04-16T00:00:00.000Z",
+    modality: { inputs: ["text", "image"], outputs: ["text"] },
+    tokenizer: "Claude",
+  },
+} satisfies Record<string, ModelConfig>;
+
+export type ClaudeOpus47ModelName = keyof typeof models;

--- a/packages/cost/models/authors/anthropic/claude-4.8-opus/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-4.8-opus/endpoints.ts
@@ -1,0 +1,185 @@
+import { ModelProviderName } from "../../../providers";
+import type { ModelProviderConfig } from "../../../types";
+import { ClaudeOpus48ModelName } from "./model";
+
+export const endpoints = {
+  "claude-4.8-opus:anthropic": {
+    providerModelId: "claude-opus-4-8-20260528",
+    provider: "anthropic",
+    author: "anthropic",
+    version: "20260528",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+          write1h: 2.0, // $10 / MTok (200% of $5)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    supportedPlugins: ["web"],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+
+  "claude-4.8-opus:vertex": {
+    providerModelId: "claude-opus-4-8@20260528",
+    provider: "vertex",
+    author: "anthropic",
+    version: "vertex-2023-10-16",
+    ptbEnabled: true,
+    crossRegion: true,
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      global: {
+        providerModelId: "claude-opus-4-8@20260528",
+      },
+    },
+  },
+  "claude-4.8-opus:bedrock": {
+    provider: "bedrock",
+    author: "anthropic",
+    providerModelId: "anthropic.claude-opus-4-8-20260528-v1:0",
+    version: "20260528",
+    crossRegion: true,
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+      "top_p",
+      "top_k",
+    ],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "us-east-1": {},
+    },
+  },
+  "claude-4.8-opus:openrouter": {
+    provider: "openrouter",
+    author: "anthropic",
+    providerModelId: "anthropic/claude-opus-4.8",
+    providerModelIdAliases: [
+      "anthropic/claude-4.8-opus-20260528",
+      "anthropic/claude-opus-4.8-20260528",
+    ],
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005275, // $5.275/1M - worst-case: $5.00/1M (Anthropic/Google) * 1.055
+        output: 0.000026375, // $26.375/1M - worst-case: $25.00/1M (Anthropic/Google) * 1.055
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "tools",
+      "tool_choice",
+      "top_p",
+      "top_k",
+    ],
+    ptbEnabled: true,
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+  "claude-4.8-opus:helicone": {
+    provider: "helicone",
+    author: "anthropic",
+    providerModelId: "pa/claude-opus-4-8",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+          write1h: 2.0, // $10 / MTok (200% of $5)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+} satisfies Partial<
+  Record<`${ClaudeOpus48ModelName}:${ModelProviderName}`, ModelProviderConfig>
+>;

--- a/packages/cost/models/authors/anthropic/claude-4.8-opus/model.ts
+++ b/packages/cost/models/authors/anthropic/claude-4.8-opus/model.ts
@@ -1,0 +1,17 @@
+import type { ModelConfig } from "../../../types";
+
+export const models = {
+  "claude-4.8-opus": {
+    name: "Anthropic: Claude Opus 4.8",
+    author: "anthropic",
+    description:
+      "Claude Opus 4.8 is Anthropic's most capable model, released May 2026. Building on the intelligence of Opus 4.7, it brings new levels of reliability and precision to coding, agents, and enterprise workflows. Features a 1M context window, hybrid reasoning with extended thinking, and state-of-the-art performance on coding and agentic tasks. API model name: claude-opus-4-8",
+    contextLength: 1000000,
+    maxOutputTokens: 128000,
+    created: "2026-05-28T00:00:00.000Z",
+    modality: { inputs: ["text", "image"], outputs: ["text"] },
+    tokenizer: "Claude",
+  },
+} satisfies Record<string, ModelConfig>;
+
+export type ClaudeOpus48ModelName = keyof typeof models;

--- a/packages/cost/models/authors/anthropic/index.ts
+++ b/packages/cost/models/authors/anthropic/index.ts
@@ -20,6 +20,8 @@ import { models as claudeHaiku4520251001Models } from "./claude-haiku-4-5-202510
 import { models as claudeOpus4120250805Models } from "./claude-opus-4-1-20250805/model";
 import { models as claudeOpus45Models } from "./claude-4.5-opus/model";
 import { models as claudeOpus46Models } from "./claude-4.6-opus/model";
+import { models as claudeOpus47Models } from "./claude-4.7-opus/model";
+import { models as claudeOpus48Models } from "./claude-4.8-opus/model";
 import { models as claudeSonnet46Models } from "./claude-4.6-sonnet/model";
 
 // Import endpoints
@@ -37,6 +39,8 @@ import { endpoints as claudeHaiku4520251001Endpoints } from "./claude-haiku-4-5-
 import { endpoints as claudeOpus4120250805Endpoints } from "./claude-opus-4-1-20250805/endpoints";
 import { endpoints as claudeOpus45Endpoints } from "./claude-4.5-opus/endpoints";
 import { endpoints as claudeOpus46Endpoints } from "./claude-4.6-opus/endpoints";
+import { endpoints as claudeOpus47Endpoints } from "./claude-4.7-opus/endpoints";
+import { endpoints as claudeOpus48Endpoints } from "./claude-4.8-opus/endpoints";
 import { endpoints as claudeSonnet46Endpoints } from "./claude-4.6-sonnet/endpoints";
 
 // Aggregate models
@@ -55,6 +59,8 @@ export const anthropicModels = {
   ...claudeOpus4120250805Models,
   ...claudeOpus45Models,
   ...claudeOpus46Models,
+  ...claudeOpus47Models,
+  ...claudeOpus48Models,
   ...claudeSonnet46Models,
 } satisfies Record<string, ModelConfig>;
 
@@ -74,5 +80,7 @@ export const anthropicEndpointConfig = {
   ...claudeOpus4120250805Endpoints,
   ...claudeOpus45Endpoints,
   ...claudeOpus46Endpoints,
+  ...claudeOpus47Endpoints,
+  ...claudeOpus48Endpoints,
   ...claudeSonnet46Endpoints,
 } satisfies Record<string, ModelProviderConfig>;


### PR DESCRIPTION
## Ticket
N/A

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [X] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [X] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
|                      |                   |

## Extra Notes
Any additional context, considerations, or notes for reviewers.

## Context
Why are you making this change?

Claude Opus 4.7 (released April 16, 2026) and Claude Opus 4.8 (released May 28, 2026) 
are publicly available via the Anthropic API but missing from the cost package. 
This adds pricing entries for both models across Anthropic, Vertex, Bedrock, 
OpenRouter, and Helicone providers.

Pricing source: https://www.anthropic.com/pricing and 
https://platform.claude.com/docs/en/about-claude/models/overview

Both models are $5.00/MTok input and $25.00/MTok output, same as Opus 4.6.

## Screenshots / Demos
