### PR TITLE
fix(cost): apply tier pricing for openai/azure/openrouter/helicone (#5690)

### DIFF
--- a/packages/__tests__/cost/modelCostFromRegistry.test.ts
+++ b/packages/__tests__/cost/modelCostFromRegistry.test.ts
@@ -322,6 +322,26 @@ describe("modelCostBreakdownFromRegistry", () => {
       }
     });
 
+    it("should use higher tier pricing for openai gpt-5.4 over 272K tokens", () => {
+      const modelUsage: ModelUsage = {
+        input: 300000, // 300K tokens - over 272K threshold
+        output: 50000,
+      };
+
+      const breakdown = modelCostBreakdownFromRegistry({
+        modelUsage,
+        providerModelId: "gpt-5.4",
+        provider: "openai" as ModelProviderName,
+      });
+
+      expect(breakdown).not.toBeNull();
+      if (breakdown) {
+        // Higher tier (>272K): $5/M input, $22.50/M output
+        expect(breakdown.inputCost).toBe(300000 * 0.000005);
+        expect(breakdown.outputCost).toBe(50000 * 0.0000225);
+      }
+    });
+
     it("should use base tier pricing for Gemini 3 Pro Preview under 200K tokens", () => {
       const modelUsage: ModelUsage = {
         input: 150000, // 150K tokens - under threshold

--- a/packages/cost/models/calculate-cost.ts
+++ b/packages/cost/models/calculate-cost.ts
@@ -161,6 +161,21 @@ function getThresholdValueFunction(provider: ModelProviderName): (usage: ModelUs
             return 0;
         }
       }
+    case "openai":
+    case "azure":
+    case "openrouter":
+    case "helicone":
+      // Tier threshold is based on total prompt size (input + cached input).
+      return (usage: ModelUsage, field: CostBreakdownField) => {
+        switch (field) {
+          case "inputCost":
+          case "outputCost":
+          case "cachedInputCost":
+            return usage.input + (usage.cacheDetails?.cachedInput ?? 0);
+          default:
+            return 0;
+        }
+      };
     default:
       return () => 0;
   }


### PR DESCRIPTION
## What

Fixes #5690.

`packages/cost/models/calculate-cost.ts` → `getThresholdValueFunction(provider)` only handled `vertex`, `google-ai-studio`, `anthropic` and `xai`. Every other provider — including `openai`, `azure`, `openrouter` and `helicone` — fell to `default: () => 0`. Since `getPricingTier` selects the highest tier whose `threshold <= value`, a constant `0` always picked the cheapest base tier, so higher-context tiers were unreachable for those providers.

Concrete impact: `gpt-5.4` (`packages/cost/models/authors/openai/gpt-5.4/endpoints.ts`) has a base tier and a `threshold: 272000` tier (input 2×, output 1.5×). For an `openai` `gpt-5.4` request with `input=300000, output=50000`:

- Expected: `300000 × 0.000005 + 50000 × 0.0000225 = $2.625`
- Actual (pre-fix): base tier → `300000 × 0.0000025 + 50000 × 0.000015 = $1.50` (~43% under)

The same tiered config exists for the `azure`, `openrouter` and `helicone` variants of `gpt-5.4`, all unhandled.

## Change

Adds `openai` / `azure` / `openrouter` / `helicone` cases to `getThresholdValueFunction`, mirroring the existing `xai` handler — the threshold value is the total prompt size (`usage.input + (usage.cacheDetails?.cachedInput ?? 0)`). For `cachedInputCost`, the same total prompt size is used so the cached-input rate also tier-switches at the configured threshold.

## Test

Adds a regression test in `packages/__tests__/cost/modelCostFromRegistry.test.ts`'s existing `describe("threshold-based pricing")` block:

- `openai` `gpt-5.4` with `input=300000, output=50000` → asserts the >272K tier rates (`inputCost === 300000 * 0.000005`, `outputCost === 50000 * 0.0000225`).

Without this PR's source change, that test computes the base-tier values (`$0.75` / `$0.75`) and fails. With the fix it passes. (I wasn't able to spin up jest on Windows locally — running `npx jest __tests__/` from `/packages` errored on a missing `ts-jest` preset in this checkout — but the change is mechanical: it adds 4 provider keys to the same switch that already handles `xai` identically and is exercised by the existing Anthropic 250K test at lines 299-323.)

## Scope

No behaviour change for any currently-handled provider (`vertex`, `google-ai-studio`, `anthropic`, `xai`); they keep their own threshold functions. Models on `openai` / `azure` / `openrouter` / `helicone` that don't define a higher-threshold tier are unaffected — `getPricingTier` simply picks the base tier as before.

## Related context

PR #5268 introduced the threshold mechanism and wired the four providers above; the openai-shaped providers weren't wired at the same time, which is what surfaces here.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
