### PR TITLE
feat(cost): support per-token cost overrides in cost breakdown

### DIFF
--- a/packages/__tests__/cost/modelCostFromRegistry.test.ts
+++ b/packages/__tests__/cost/modelCostFromRegistry.test.ts
@@ -436,4 +436,81 @@ describe("modelCostBreakdownFromRegistry", () => {
       }
     });
   });
+
+  describe("cost override", () => {
+    const usage: ModelUsage = { input: 1000, output: 500 };
+
+    it("overrides both input and output per-token cost", () => {
+      const breakdown = modelCostBreakdownFromRegistry({
+        modelUsage: usage,
+        providerModelId: "gpt-4o",
+        provider: "openai" as ModelProviderName,
+        costOverride: { inputCostPerToken: 0.00001, outputCostPerToken: 0.00002 },
+      });
+
+      expect(breakdown).not.toBeNull();
+      if (breakdown) {
+        expect(breakdown.inputCost).toBe(1000 * 0.00001);
+        expect(breakdown.outputCost).toBe(500 * 0.00002);
+        expect(breakdown.totalCost).toBe(1000 * 0.00001 + 500 * 0.00002);
+      }
+    });
+
+    it("applies a partial override per field, falling back to the registry rate", () => {
+      const inputOnly = modelCostBreakdownFromRegistry({
+        modelUsage: usage,
+        providerModelId: "gpt-4o",
+        provider: "openai" as ModelProviderName,
+        costOverride: { inputCostPerToken: 0.00001 },
+      });
+      expect(inputOnly).not.toBeNull();
+      if (inputOnly) {
+        // input overridden; output keeps the gpt-4o registry rate (0.01 / 1K)
+        expect(inputOnly.inputCost).toBe(1000 * 0.00001);
+        expect(inputOnly.outputCost).toBe(500 * 0.00001);
+      }
+
+      const outputOnly = modelCostBreakdownFromRegistry({
+        modelUsage: usage,
+        providerModelId: "gpt-4o",
+        provider: "openai" as ModelProviderName,
+        costOverride: { outputCostPerToken: 0.00002 },
+      });
+      expect(outputOnly).not.toBeNull();
+      if (outputOnly) {
+        // output overridden; input keeps the gpt-4o registry rate (0.0025 / 1K)
+        expect(outputOnly.inputCost).toBe(1000 * 0.0000025);
+        expect(outputOnly.outputCost).toBe(500 * 0.00002);
+      }
+    });
+
+    it("treats a zero override as free, not as unset", () => {
+      const breakdown = modelCostBreakdownFromRegistry({
+        modelUsage: usage,
+        providerModelId: "gpt-4o",
+        provider: "openai" as ModelProviderName,
+        costOverride: { inputCostPerToken: 0, outputCostPerToken: 0 },
+      });
+
+      expect(breakdown).not.toBeNull();
+      if (breakdown) {
+        expect(breakdown.inputCost).toBe(0);
+        expect(breakdown.outputCost).toBe(0);
+        expect(breakdown.totalCost).toBe(0);
+      }
+    });
+
+    it("uses registry pricing when no override is provided", () => {
+      const breakdown = modelCostBreakdownFromRegistry({
+        modelUsage: usage,
+        providerModelId: "gpt-4o",
+        provider: "openai" as ModelProviderName,
+      });
+
+      expect(breakdown).not.toBeNull();
+      if (breakdown) {
+        expect(breakdown.totalCost).toBe(0.0075);
+      }
+    });
+  });
 });

--- a/packages/cost/costCalc.ts
+++ b/packages/cost/costCalc.ts
@@ -1,7 +1,7 @@
 import { costOfPrompt } from "./index";
 import type { ModelUsage } from "./usage/types";
 import type { ModelProviderName } from "./models/providers";
-import { calculateModelCostBreakdown, CostBreakdown } from "./models/calculate-cost";
+import { calculateModelCostBreakdown, CostBreakdown, CostOverride } from "./models/calculate-cost";
 
 // since costs in clickhouse are multiplied by the multiplier
 // divide to get real cost in USD in dollars
@@ -53,13 +53,15 @@ export function modelCostBreakdownFromRegistry(params: {
   provider: ModelProviderName;
   providerModelId: string;
   requestCount?: number;
+  costOverride?: CostOverride;
 }): CostBreakdown | null {
   const breakdown = calculateModelCostBreakdown({
     modelUsage: params.modelUsage,
     providerModelId: params.providerModelId,
     provider: params.provider,
     requestCount: params.requestCount,
+    costOverride: params.costOverride,
   });
-  
+
   return breakdown;
 }

--- a/packages/cost/models/calculate-cost.ts
+++ b/packages/cost/models/calculate-cost.ts
@@ -166,13 +166,19 @@ function getThresholdValueFunction(provider: ModelProviderName): (usage: ModelUs
   }
 }
 
+export interface CostOverride {
+  inputCostPerToken?: number;
+  outputCostPerToken?: number;
+}
+
 export function calculateModelCostBreakdown(params: {
   modelUsage: ModelUsage;
   providerModelId: string;
   provider: ModelProviderName;
   requestCount?: number;
+  costOverride?: CostOverride;
 }): CostBreakdown | null {
-  const { modelUsage, providerModelId, provider, requestCount = 1 } = params;
+  const { modelUsage, providerModelId, provider, requestCount = 1, costOverride } = params;
 
   const configResult = registry.getModelProviderConfigByProviderModelId(
     providerModelId,
@@ -205,7 +211,7 @@ export function calculateModelCostBreakdown(params: {
   };
 
   const inputPricing = getPricingTier(preprocessedPricing, getThresholdValue(modelUsage, "inputCost"));
-  breakdown.inputCost = modelUsage.input * inputPricing.input;
+  breakdown.inputCost = modelUsage.input * (costOverride?.inputCostPerToken ?? inputPricing.input);
 
   if (modelUsage.cacheDetails) {
     if (modelUsage.cacheDetails.cachedInput > 0) {
@@ -229,7 +235,7 @@ export function calculateModelCostBreakdown(params: {
   }
 
   const outputPricing = getPricingTier(preprocessedPricing, getThresholdValue(modelUsage, "outputCost"));
-  breakdown.outputCost = modelUsage.output * outputPricing.output;
+  breakdown.outputCost = modelUsage.output * (costOverride?.outputCostPerToken ?? outputPricing.output);
 
   if (modelUsage.thinking) {
     const thinkingRate = basePricing.thinking ?? basePricing.output;


### PR DESCRIPTION
## Ticket

Closes #5172

## Component(s)

- [x] Packages (`@helicone-package/cost`)

## Type of change

- [x] New feature

## What this does

#5172 asks for per-request cost overrides via headers (`Helicone-Input-Token-Cost` / `Helicone-Output-Token-Cost`), because OpenRouter costs vary by the underlying provider and the registry's single rate is wrong for those requests.

This adds the cost-engine foundation that feature needs: an optional `costOverride` on `calculateModelCostBreakdown` and `modelCostBreakdownFromRegistry`:

```ts
costOverride?: { inputCostPerToken?: number; outputCostPerToken?: number }
```

- applied per field, so a missing field falls back to the registry rate (override just input, just output, or both)
- uses `??` so an explicit `0` is honored as a free rate rather than treated as unset
- input/output only; cache and modality costs keep using registry rates

Unit is per-token USD, matching `ModelPricing` in the registry, so the value multiplies token counts directly with no conversion.

## How it was tested

`jest __tests__/cost/modelCostFromRegistry.test.ts` passes (22 tests), including 4 new cases: both-field override, per-field partial override with registry fallback, the zero-override-is-free case (guards the `??` vs `||` choice), and the no-override registry path.

## Proposed wiring (follow-up; I'd like your input first)

To make the headers take effect end to end, the override needs threading from the request into both cost paths:

1. parse + validate the two headers in `worker/src/lib/models/HeliconeHeaders.ts` (reject negative / non-numeric -> ignore)
2. pass it into the proxy cost call in `ProxyForwarder.ts`, and stash it into `heliconeMeta` so the authoritative async cost calc in jawn (`ResponseBodyHandler.ts`) honors it too

I scoped this PR to the cost engine because two points are unspecified in the issue and worth your call before I wire the proxy and jawn paths:

- units: per-token USD (this PR) vs per-million-tokens (OpenRouter's unit). I can switch or accept both
- unknown models: `calculateModelCostBreakdown` returns `null` when the registry has no config for a model, so an override alone won't price a model that isn't in the registry. If OpenRouter pass-through models with no registry entry are in scope, that needs an explicit branch

Happy to follow up with the worker + jawn wiring and the header doc once you confirm the units and the unknown-model behavior.
