### PR TITLE
feat(costs): add gpt-image-2 pricing support

### DIFF
--- a/packages/cost/models/authors/openai/gpt-image-2/endpoints.ts
+++ b/packages/cost/models/authors/openai/gpt-image-2/endpoints.ts
@@ -1,0 +1,31 @@
+import { ModelProviderName } from "../../../providers";
+import type { ModelProviderConfig } from "../../../types";
+import { GPTImage2ModelName } from "./models";
+
+export const endpoints = {
+  "gpt-image-2:openai": {
+    providerModelId: "gpt-image-2",
+    provider: "openai",
+    author: "openai",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.00001, // $10.00 per 1M tokens
+        output: 0.00004, // $40.00 per 1M tokens
+      },
+    ],
+    contextLength: 8192,
+    maxCompletionTokens: 4096,
+    rateLimits: {
+      rpm: 500,
+      tpm: 1000000,
+    },
+    supportedParameters: ["n"],
+    ptbEnabled: false,
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+} satisfies Partial<
+  Record<`${GPTImage2ModelName}:${ModelProviderName}`, ModelProviderConfig>
+>;

--- a/packages/cost/models/authors/openai/gpt-image-2/models.ts
+++ b/packages/cost/models/authors/openai/gpt-image-2/models.ts
@@ -1,0 +1,17 @@
+import type { ModelConfig } from "../../../types";
+
+export const models = {
+  "gpt-image-2": {
+    name: "OpenAI GPT Image 2",
+    author: "openai",
+    description:
+      "GPT Image 2 is OpenAI's advanced image generation model with superior text rendering, instruction following, and image editing capabilities. It supports text and image inputs to produce high-fidelity images.",
+    contextLength: 8192,
+    maxOutputTokens: 4096,
+    created: "2025-03-25T00:00:00.000Z",
+    modality: { inputs: ["text", "image"], outputs: ["image", "text"] },
+    tokenizer: "GPT",
+  },
+} satisfies Record<string, ModelConfig>;
+
+export type GPTImage2ModelName = keyof typeof models;

--- a/packages/cost/models/authors/openai/index.ts
+++ b/packages/cost/models/authors/openai/index.ts
@@ -17,6 +17,7 @@ import { models as gpt52Models } from "./gpt-5.2/models";
 import { models as gpt54Models } from "./gpt-5.4/models";
 import { models as ossModels } from "./oss/models";
 import { models as gptImage1Models } from "./gpt-image-1/models";
+import { models as gptImage2Models } from "./gpt-image-2/models";
 
 // Import endpoints
 import { endpoints as gpt4oEndpoints } from "./gpt-4o/endpoints";
@@ -30,6 +31,7 @@ import { endpoints as gpt52Endpoints } from "./gpt-5.2/endpoints";
 import { endpoints as gpt54Endpoints } from "./gpt-5.4/endpoints";
 import { endpoints as ossEndpoints } from "./oss/endpoints";
 import { endpoints as gptImage1Endpoints } from "./gpt-image-1/endpoints";
+import { endpoints as gptImage2Endpoints } from "./gpt-image-2/endpoints";
 
 // Aggregate models
 export const openaiModels = {
@@ -44,6 +46,7 @@ export const openaiModels = {
   ...gpt54Models,
   ...ossModels,
   ...gptImage1Models,
+  ...gptImage2Models,
 } satisfies Record<string, ModelConfig>;
 
 // Aggregate endpoints
@@ -59,4 +62,5 @@ export const openaiEndpointConfig = {
   ...gpt54Endpoints,
   ...ossEndpoints,
   ...gptImage1Endpoints,
+  ...gptImage2Endpoints,
 } satisfies Record<string, ModelProviderConfig>;


### PR DESCRIPTION
## Summary

Add pricing support for OpenAI's `gpt-image-2` model. Currently Helicone shows "Cost Unsupported" for gpt-image-2 requests because the model is missing from the cost package.

## Changes

- **`packages/cost/models/authors/openai/gpt-image-2/models.ts`** — Model definition for gpt-image-2
- **`packages/cost/models/authors/openai/gpt-image-2/endpoints.ts`** — Token pricing: input $10/1M tokens, output $40/1M tokens ([source](https://platform.openai.com/docs/pricing#image-generation))
- **`packages/cost/models/authors/openai/index.ts`** — Register gpt-image-2 in the OpenAI model aggregation

## Pricing Reference

From [OpenAI pricing page](https://platform.openai.com/docs/pricing#image-generation):

| Token Type | Price |
|---|---|
| Input (text + image) | $10.00 / 1M tokens |
| Output (image) | $40.00 / 1M tokens |

Follows the same pattern as existing `gpt-image-1` and `gpt-image-1.5` entries.