### PR TITLE
fix(web): send session cookies on playground/agent generate requests

### DIFF
--- a/web/lib/api/llm/generate.ts
+++ b/web/lib/api/llm/generate.ts
@@ -184,6 +184,8 @@ export async function generate<T extends object | undefined = undefined>(
     `${env("NEXT_PUBLIC_HELICONE_JAWN_SERVICE")}/v1/${apiEndpoint}/generate`,
     {
       method: "POST",
+      credentials: "include",
+      signal: params.signal,
       body: JSON.stringify({
         messages: params.messages,
         stream: !!params.stream,


### PR DESCRIPTION
## Summary
- Add `credentials: "include"` to the Playground/Agent `generate()` fetch so Better Auth session cookies reach Jawn on cross-origin self-hosted deployments (`localhost:3000` → `:8585`).
- Forward `params.signal` to `fetch` so streaming cancel works as intended.

Closes #5653

## Problem
Self-hosted Playground returns `401 Invalid session` on `POST /v1/playground/generate` even when the user is logged in. Other dashboard Jawn calls succeed because they use `getJawnClient()`, which always sends `credentials: "include"`. The Playground path uses a raw `fetch()` without credentials, so the session cookie is omitted and `BetterAuthWrapper.getSession()` fails.

## Test plan
- [ ] Self-hosted all-in-one: log in, open Playground, click Run — request includes Cookie header and does not return `Invalid session`
- [ ] Agent chat generate path (`/v1/agent/generate`) works in self-hosted Better Auth mode
- [ ] Cloud/hosted Helicone Playground still works
- [ ] Cancel mid-stream still aborts the request

Made with [Cursor](https://cursor.com)