### PR TITLE
Fix Groq gpt-oss and Bedrock Claude 3.5 Sonnet v2 pricing to match provider pages

### DIFF
--- a/packages/cost/models/authors/anthropic/claude-3.5-sonnet-v2/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-3.5-sonnet-v2/endpoints.ts
@@ -84,8 +84,8 @@ export const endpoints = {
     pricing: [
       {
         threshold: 0,
-        input: 0.000003,
-        output: 0.000015,
+        input: 0.000006, // AWS "Public Extended Access" pricing effective Dec 1, 2025
+        output: 0.00003,
         web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
         cacheMultipliers: {
           cachedInput: 0.1,

--- a/packages/cost/models/authors/openai/oss/endpoints.ts
+++ b/packages/cost/models/authors/openai/oss/endpoints.ts
@@ -10,7 +10,7 @@ export const endpoints = {
       {
         threshold: 0,
         input: 0.00000015,
-        output: 0.00000075,
+        output: 0.0000006,
         web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
       },
     ],
@@ -49,8 +49,8 @@ export const endpoints = {
     pricing: [
       {
         threshold: 0,
-        input: 0.0000001,
-        output: 0.0000005,
+        input: 0.000000075,
+        output: 0.0000003,
         web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
       },
     ],


### PR DESCRIPTION
Updates 5 price values in the cost package that have drifted from the providers' current published prices (both verified 2026-07-04).

**`packages/cost/models/authors/openai/oss/endpoints.ts`** — vs https://groq.com/pricing:

| endpoint | field | before | after | Groq's pricing page |
|---|---|---|---|---|
| `gpt-oss-120b:groq` | output | $0.75/M | $0.60/M | "GPT OSS 120B 128k ... Output Token Price (Per Million Tokens) $0.60" |
| `gpt-oss-20b:groq` | input | $0.10/M | $0.075/M | "GPT OSS 20B 128k ... Input Token Price (Per Million Tokens) $0.075" |
| `gpt-oss-20b:groq` | output | $0.50/M | $0.30/M | "Output Token Price (Per Million Tokens) $0.30" |

**`packages/cost/models/authors/anthropic/claude-3.5-sonnet-v2/endpoints.ts`** — vs https://aws.amazon.com/bedrock/pricing/:

| endpoint | field | before | after |
|---|---|---|---|
| `claude-3.5-sonnet-v2:bedrock` | input | $3.00/M | $6.00/M |
| `claude-3.5-sonnet-v2:bedrock` | output | $15.00/M | $30.00/M |

AWS moved Claude 3.5 Sonnet v2 to "Public Extended Access" pricing effective December 1, 2025 — the Bedrock pricing page now lists "$6.00 / $30.00" per million tokens (cache write $7.50, cache read $0.60 — the existing `cacheMultipliers` of 1.25 / 0.1 remain exactly right against the new base, so they are untouched). The Anthropic-direct and Vertex endpoints in the same file are intentionally left as-is.

Found while cross-auditing community cost datasets against primary sources for FactQuire (https://factquire.com), a source-verified facts feed for LLM APIs — every entry carries a verbatim provider quote (e.g. https://factquire.com/models/groq/openai_gpt-oss-20b.html) if useful for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
