### PR TITLE
Fix cross-tenant provider key disclosure in VaultManager

### DIFF
--- a/valhalla/jawn/src/managers/VaultManager.ts
+++ b/valhalla/jawn/src/managers/VaultManager.ts
@@ -118,9 +118,10 @@ export class VaultManager extends BaseManager {
         `SELECT id, org_id, decrypted_provider_key, provider_key_name, provider_name, provider_secret_key
          FROM decrypted_provider_keys_v2
          WHERE id = $1
+         AND org_id = $2
          AND soft_delete = false
          LIMIT 1`,
-        [providerKeyId]
+        [providerKeyId, this.authParams.organizationId]
       );
 
       if (result.error || !result.data || result.data.length === 0) {


### PR DESCRIPTION
Fixes #5712.

## Problem

`VaultManager.getDecryptedProviderKeyById` (called by `GET /v1/vault/key/{providerKeyId}`) queries `decrypted_provider_keys_v2` by `id` only:

```sql
WHERE id = $1
AND soft_delete = false
```

Any authenticated admin/owner can supply an arbitrary key UUID and receive the decrypted provider API key (OpenAI, Anthropic, etc.) belonging to a different organization — a classic BOLA/IDOR.

## Fix

Add `AND org_id = $2` scoped to `this.authParams.organizationId`, identical to the guard already present in `KeyManager.getDecryptedProviderKeyById` (`apiKeys/KeyManager.ts:469`):

```sql
WHERE id = $1
AND org_id = $2
AND soft_delete = false
```

`authParams.organizationId` is already used in all other `VaultManager` queries — this is the only one that was missing it.