### PR TITLE
fix(prompts): substitute template variables with falsy values (0, false, "")

### DIFF
--- a/packages/__tests__/prompts/templates.test.ts
+++ b/packages/__tests__/prompts/templates.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "@jest/globals";
+import { HeliconeTemplateManager } from "@helicone-package/prompts/templates";
+
+describe("HeliconeTemplateManager.substituteVariables", () => {
+  it("substitutes falsy-but-valid values (0, false, empty string)", () => {
+    expect(
+      HeliconeTemplateManager.substituteVariables(
+        "You have {{hc:count:number}} new messages",
+        { count: 0 },
+        {}
+      ).result
+    ).toBe("You have 0 new messages");
+
+    expect(
+      HeliconeTemplateManager.substituteVariables(
+        "Enabled: {{hc:flag:boolean}}",
+        { flag: false },
+        {}
+      ).result
+    ).toBe("Enabled: false");
+
+    expect(
+      HeliconeTemplateManager.substituteVariables(
+        "Name=[{{hc:name:string}}]",
+        { name: "" },
+        {}
+      ).result
+    ).toBe("Name=[]");
+  });
+
+  it("still substitutes truthy values and leaves missing variables untouched", () => {
+    expect(
+      HeliconeTemplateManager.substituteVariables(
+        "You have {{hc:count:number}} new messages",
+        { count: 5 },
+        {}
+      ).result
+    ).toBe("You have 5 new messages");
+
+    // Missing input -> placeholder is left as-is
+    expect(
+      HeliconeTemplateManager.substituteVariables(
+        "Hi {{hc:name:string}}",
+        {},
+        {}
+      ).result
+    ).toBe("Hi {{hc:name:string}}");
+  });
+});

--- a/packages/prompts/templates.ts
+++ b/packages/prompts/templates.ts
@@ -129,7 +129,7 @@ export class HeliconeTemplateManager {
     TEMPLATE_REGEX.lastIndex = 0;
     result = result.replace(TEMPLATE_REGEX, (match, name) => {
       const value = name.trim() in inputs ? inputs[name.trim()] : undefined;
-      return value ? String(value) : match;
+      return value !== undefined && value !== null ? String(value) : match;
     });
     
     return {


### PR DESCRIPTION
## What's broken
`HeliconeTemplateManager.substituteVariables` left the raw `{{hc:NAME:type}}` placeholder in the rendered prompt whenever an input value was falsy (`0`, `false`, or `""`), so those literals were sent to the LLM instead of the real value.

```
input {count: 0}     => "You have {{hc:count:number}} new messages"   (want "You have 0 new messages")
input {flag: false}  => "Enabled: {{hc:flag:boolean}}"                (want "Enabled: false")
```

## Why it happens
The replacement callback used `value ? String(value) : match`, which treats `0`/`false`/`""` as "missing". The JSON substitution path (`performRegexReplacement`) already guards with `value !== undefined && value !== null`; the string path didn't.

## Fix
One line in `packages/prompts/templates.ts` — switch the truthiness check to an explicit `undefined`/`null` check, matching the JSON path. Missing variables (genuinely `undefined`) still leave the placeholder untouched.

## Test
Added `packages/__tests__/prompts/templates.test.ts`. Fails before the change (placeholder leaks for `count: 0`), passes after. Truthy values and missing-variable behavior unchanged.
