### PR TITLE
docs: add SECURITY.md for private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+We release security updates for the latest `main` branch and the most recent published releases of Helicone components. Please upgrade to the latest version when possible.
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+If you believe you have found a security vulnerability in Helicone, report it privately so we can investigate and remediate before public disclosure.
+
+### Preferred channels
+
+1. **GitHub Private Vulnerability Reporting** (when enabled on this repository): use the **Security** tab → **Report a vulnerability**.
+2. **Email**: [support@helicone.ai](mailto:support@helicone.ai) with subject line `[SECURITY] …`
+3. If email is unavailable, contact the team via [Discord](https://discord.com/invite/zsSTcH2qhG) and ask for a private security channel — do not paste exploit details in public channels.
+
+Please include:
+
+- A description of the issue and its impact
+- Steps to reproduce (or a proof of concept)
+- Affected component(s), versions, and environment details
+- Any suggested remediation if known
+
+### What to expect
+
+- We will acknowledge receipt as soon as possible.
+- We will keep you informed of the investigation and remediation timeline.
+- We ask that you give us a reasonable window to fix and release a patch before public disclosure.
+
+Thank you for helping keep Helicone and its users safe.


### PR DESCRIPTION
## Ticket
Fixes #5718

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [x] Documentation

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [x] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
| No SECURITY.md / private disclosure path | Root SECURITY.md with private reporting channels |

## Extra Notes
Adds a root `SECURITY.md` describing supported versions and private disclosure channels (GitHub private reporting / support email / Discord escalation) so researchers are not forced to file public issues.

## Context
Issue #5718: researchers need a private security contact; repo had no SECURITY.md.
