### PR TITLE
fix(jawn): surface S3 upload failures in LoggingHandler.uploadToS3

### DIFF
--- a/valhalla/jawn/src/lib/handlers/LoggingHandler.ts
+++ b/valhalla/jawn/src/lib/handlers/LoggingHandler.ts
@@ -317,40 +317,44 @@ export class LoggingHandler extends AbstractLogHandler {
   }
 
   async uploadToS3(): PromiseGenericResult<string> {
-    const uploadPromises = this.batchPayload.s3Records.map(async (s3Record) => {
-      if (s3Record.location === "clickhouse") {
-        return ok(
-          `Skipping S3 upload for request ID ${s3Record.requestId} as location is clickhouse`
+    const uploadPromises = this.batchPayload.s3Records.map(
+      async (s3Record): Promise<Result<string, string>> => {
+        if (s3Record.location === "clickhouse") {
+          return ok(
+            `Skipping S3 upload for request ID ${s3Record.requestId} as location is clickhouse`
+          );
+        }
+        const key = this.s3Client.getRequestResponseKey(
+          s3Record.requestId,
+          s3Record.organizationId
         );
-      }
-      const key = this.s3Client.getRequestResponseKey(
-        s3Record.requestId,
-        s3Record.organizationId
-      );
 
-      // Upload request and response body
-      const uploadRes = await this.s3Client.store(
-        key,
-        JSON.stringify({
-          request: s3Record.requestBody,
-          response: s3Record.responseBody,
-        })
-      );
-
-      if (uploadRes.error) {
-        return err(
-          `Failed to store request body for request ID ${s3Record.requestId}: ${uploadRes.error}`
+        // Upload request and response body
+        const uploadRes = await this.s3Client.store(
+          key,
+          JSON.stringify({
+            request: s3Record.requestBody,
+            response: s3Record.responseBody,
+          })
         );
+
+        if (uploadRes.error) {
+          return err(
+            `Failed to store request body for request ID ${s3Record.requestId}: ${uploadRes.error}`
+          );
+        }
+
+        // Note: Assets are no longer uploaded to S3, they remain in request/response bodies as raw data
+
+        return ok(`S3 upload successful for request ID ${s3Record.requestId}`);
       }
+    );
 
-      // Note: Assets are no longer uploaded to S3, they remain in request/response bodies as raw data
-
-      return ok(`S3 upload successful for request ID ${s3Record.requestId}`);
-    });
-
-    await Promise.all(uploadPromises);
-
-    // TODO: How to handle errors here?
+    const results = await Promise.all(uploadPromises);
+    const failed = results.find((result) => result.error !== null);
+    if (failed && failed.error !== null) {
+      return err(failed.error);
+    }
 
     return ok("All S3 uploads successful");
   }

--- a/valhalla/jawn/src/lib/handlers/__tests__/LoggingHandler.uploadToS3.test.ts
+++ b/valhalla/jawn/src/lib/handlers/__tests__/LoggingHandler.uploadToS3.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test, jest } from "@jest/globals";
+import { LoggingHandler } from "../LoggingHandler";
+import { err, ok } from "../../../packages/common/result";
+import { S3Client } from "../../shared/db/s3Client";
+import { LogStore } from "../../stores/LogStore";
+import { VersionedRequestStore } from "../../stores/request/VersionedRequestStore";
+
+function makeHandler(storeImpl: S3Client["store"]) {
+  const s3Client = {
+    getRequestResponseKey: (requestId: string, organizationId: string) =>
+      `orgs/${organizationId}/requests/${requestId}/request_response_body`,
+    store: storeImpl,
+  } as unknown as S3Client;
+
+  return new LoggingHandler(
+    {} as LogStore,
+    {} as VersionedRequestStore,
+    s3Client
+  );
+}
+
+describe("LoggingHandler.uploadToS3", () => {
+  test("returns ok when all uploads succeed", async () => {
+    const handler = makeHandler(async () => ok("stored"));
+    (handler as any).batchPayload.s3Records = [
+      {
+        requestId: "req-1",
+        organizationId: "org-1",
+        requestBody: "{}",
+        responseBody: "{}",
+        location: "s3",
+      },
+    ];
+
+    const result = await handler.uploadToS3();
+    expect(result.error).toBeNull();
+    expect(result.data).toBe("All S3 uploads successful");
+  });
+
+  test("returns the first upload error instead of silently succeeding", async () => {
+    const store = jest
+      .fn<S3Client["store"]>()
+      .mockResolvedValueOnce(ok("stored"))
+      .mockResolvedValueOnce(err("AccessDenied"));
+
+    const handler = makeHandler(store);
+    (handler as any).batchPayload.s3Records = [
+      {
+        requestId: "req-ok",
+        organizationId: "org-1",
+        requestBody: "{}",
+        responseBody: "{}",
+        location: "s3",
+      },
+      {
+        requestId: "req-fail",
+        organizationId: "org-1",
+        requestBody: "{}",
+        responseBody: "{}",
+        location: "s3",
+      },
+    ];
+
+    const result = await handler.uploadToS3();
+    expect(result.data).toBeNull();
+    expect(result.error).toContain("req-fail");
+    expect(result.error).toContain("AccessDenied");
+  });
+
+  test("skips clickhouse-located records without calling store", async () => {
+    const store = jest.fn<S3Client["store"]>();
+    const handler = makeHandler(store);
+    (handler as any).batchPayload.s3Records = [
+      {
+        requestId: "req-ch",
+        organizationId: "org-1",
+        requestBody: "{}",
+        responseBody: "{}",
+        location: "clickhouse",
+      },
+    ];
+
+    const result = await handler.uploadToS3();
+    expect(result.error).toBeNull();
+    expect(store).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Ticket
Fixes #5725

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [x] Jawn (Backend)
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [x] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos
N/A (backend-only)

## Extra Notes
`uploadToS3` already returned `err(...)` from each per-record promise, but `Promise.all` results were discarded and the method always returned `ok("All S3 uploads successful")`. `handleResults` therefore never saw `s3Result.error`.

This matches the existing `results.find((result) => result.error)` pattern used elsewhere in jawn (for example HeliconeDatasetManager).

## Context
When an individual S3 store fails, request/response bodies can be lost while the batch path still reports success. This change inspects the upload results and returns the first error so `handleResults` can set `s3Error`.

### Verification
- `npx jest --detectOpenHandles src/lib/handlers/__tests__/LoggingHandler.uploadToS3.test.ts` — 3/3 pass
- `npx tsc --noEmit -p tsconfig.json` in `valhalla/jawn` — clean
