### PR TITLE
fix(shared,worker): validate helicone-fallbacks headers and onCodes correctly

### DIFF
--- a/packages/__tests__/shared/heliconeHeaders.test.ts
+++ b/packages/__tests__/shared/heliconeHeaders.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "@jest/globals";
+import { HeliconeHeaders } from "../../../shared/proxy/heliconeHeaders";
+import { InternalHeaders } from "../../../shared/proxy/types/internalHeaders";
+
+function makeHeaders(headers: Record<string, string>): HeliconeHeaders<InternalHeaders> {
+  return new HeliconeHeaders(new InternalHeaders(headers));
+}
+
+const VALID_TARGET = "https://example.com/fallback";
+
+describe("HeliconeHeaders — helicone-fallbacks validation", () => {
+  it("returns null when the header is absent", () => {
+    const headers = makeHeaders({});
+    expect(headers.fallBacks).toBeNull();
+  });
+
+  it("parses a well-formed fallback entry", () => {
+    const headers = makeHeaders({
+      "helicone-fallbacks": JSON.stringify([
+        {
+          "target-url": VALID_TARGET,
+          headers: { "x-api-key": "abc" },
+          onCodes: [500, 502, { from: 520, to: 530 }],
+        },
+      ]),
+    });
+    expect(headers.fallBacks).toEqual([
+      {
+        "target-url": VALID_TARGET,
+        headers: { "x-api-key": "abc" },
+        onCodes: [500, 502, { from: 520, to: 530 }],
+        bodyKeyOverride: undefined,
+      },
+    ]);
+  });
+
+  it("throws a clear error when headers is a string (not TypeError)", () => {
+    expect(() =>
+      makeHeaders({
+        "helicone-fallbacks": JSON.stringify([
+          {
+            "target-url": VALID_TARGET,
+            headers: "not-an-object",
+            onCodes: [500],
+          },
+        ]),
+      })
+    ).toThrow(
+      "helicone-fallbacks headers must be an object of string keys and string values"
+    );
+  });
+
+  it("throws a clear error when headers is null", () => {
+    // null is caught by the earlier "missing required field" guard, which
+    // already produces a clear message — we just want to make sure the new
+    // validator doesn't crash with TypeError on null.
+    expect(() =>
+      makeHeaders({
+        "helicone-fallbacks": JSON.stringify([
+          {
+            "target-url": VALID_TARGET,
+            headers: null,
+            onCodes: [500],
+          },
+        ]),
+      })
+    ).toThrow(
+      "helicone-fallbacks must have target-url, headers, and onCodes"
+    );
+  });
+
+  it("throws a clear error when headers contains a non-string value", () => {
+    expect(() =>
+      makeHeaders({
+        "helicone-fallbacks": JSON.stringify([
+          {
+            "target-url": VALID_TARGET,
+            headers: { "x-api-key": 123 },
+            onCodes: [500],
+          },
+        ]),
+      })
+    ).toThrow(
+      "helicone-fallbacks headers must be an object of string keys and string values"
+    );
+  });
+
+  it("throws a clear error when onCodes is a string (not TypeError)", () => {
+    expect(() =>
+      makeHeaders({
+        "helicone-fallbacks": JSON.stringify([
+          {
+            "target-url": VALID_TARGET,
+            headers: { "x-api-key": "abc" },
+            onCodes: "oops",
+          },
+        ]),
+      })
+    ).toThrow(
+      "helicone-fallbacks onCodes must be an array of numbers or {from, to} objects"
+    );
+  });
+
+  it("throws a clear error when an onCodes entry is missing from/to", () => {
+    expect(() =>
+      makeHeaders({
+        "helicone-fallbacks": JSON.stringify([
+          {
+            "target-url": VALID_TARGET,
+            headers: { "x-api-key": "abc" },
+            onCodes: [{ from: 500 }],
+          },
+        ]),
+      })
+    ).toThrow(
+      "helicone-fallbacks onCodes must be an array of numbers or {from, to} objects"
+    );
+  });
+
+  it("throws a clear error when an onCodes entry is null", () => {
+    expect(() =>
+      makeHeaders({
+        "helicone-fallbacks": JSON.stringify([
+          {
+            "target-url": VALID_TARGET,
+            headers: { "x-api-key": "abc" },
+            onCodes: [null],
+          },
+        ]),
+      })
+    ).toThrow(
+      "helicone-fallbacks onCodes must be an array of numbers or {from, to} objects"
+    );
+  });
+
+  it("throws when the top-level value is not an array", () => {
+    expect(() =>
+      makeHeaders({
+        "helicone-fallbacks": JSON.stringify({ "target-url": VALID_TARGET }),
+      })
+    ).toThrow("helicone-fallbacks must be an array");
+  });
+
+  it("throws when a fallback entry is missing a required field", () => {
+    expect(() =>
+      makeHeaders({
+        "helicone-fallbacks": JSON.stringify([{ "target-url": VALID_TARGET }]),
+      })
+    ).toThrow(
+      "helicone-fallbacks must have target-url, headers, and onCodes"
+    );
+  });
+});

--- a/shared/proxy/heliconeHeaders.ts
+++ b/shared/proxy/heliconeHeaders.ts
@@ -176,26 +176,32 @@ export class HeliconeHeaders<T extends IInternalHeaders>
       }
 
       if (
-        typeof fb.headers !== "object" &&
-        fb.headers.entries.every(
-          ([key, value]: [object, object]) =>
+        typeof fb.headers !== "object" ||
+        fb.headers === null ||
+        !Object.entries(fb.headers).every(
+          ([key, value]) =>
             typeof key === "string" && typeof value === "string"
         )
       ) {
-        throw new Error("helicone-fallbacks headers must be an object");
+        throw new Error(
+          "helicone-fallbacks headers must be an object of string keys and string values"
+        );
       }
 
       if (
-        !Array.isArray(fb.onCodes) &&
-        fb.onCodes.every(
+        !Array.isArray(fb.onCodes) ||
+        !fb.onCodes.every(
           (x: HeliconeFallbackCode) =>
             typeof x === "number" ||
             (typeof x === "object" &&
+              x !== null &&
               typeof x.from === "number" &&
               typeof x.to === "number")
         )
       ) {
-        throw new Error("helicone-fallbacks onCodes must be an array");
+        throw new Error(
+          "helicone-fallbacks onCodes must be an array of numbers or {from, to} objects"
+        );
       }
 
       return {

--- a/worker/src/lib/models/HeliconeHeaders.ts
+++ b/worker/src/lib/models/HeliconeHeaders.ts
@@ -247,26 +247,32 @@ export class HeliconeHeaders implements IHeliconeHeaders {
       }
 
       if (
-        typeof fb.headers !== "object" &&
-        fb.headers.entries.every(
-          ([key, value]: [object, object]) =>
+        typeof fb.headers !== "object" ||
+        fb.headers === null ||
+        !Object.entries(fb.headers).every(
+          ([key, value]) =>
             typeof key === "string" && typeof value === "string"
         )
       ) {
-        throw new Error("helicone-fallbacks headers must be an object");
+        throw new Error(
+          "helicone-fallbacks headers must be an object of string keys and string values"
+        );
       }
 
       if (
-        !Array.isArray(fb.onCodes) &&
-        fb.onCodes.every(
+        !Array.isArray(fb.onCodes) ||
+        !fb.onCodes.every(
           (x: HeliconeFallbackCode) =>
             typeof x === "number" ||
             (typeof x === "object" &&
+              x !== null &&
               typeof x.from === "number" &&
               typeof x.to === "number")
         )
       ) {
-        throw new Error("helicone-fallbacks onCodes must be an array");
+        throw new Error(
+          "helicone-fallbacks onCodes must be an array of numbers or {from, to} objects"
+        );
       }
 
       return {


### PR DESCRIPTION
Fixes #5728.

## Summary

`HeliconeHeaders.getFallBacks()` had two logic errors that made its `headers` and `onCodes` validators effectively dead. A malformed `helicone-fallbacks` header (e.g. `headers: "oops"` or `onCodes: "oops"`) returned a 500 with a `TypeError` instead of a clear validation error.

## Root cause

Two issues in both the shared and worker copies of the file:

1. The conditions used `&&` where `||` was needed. With the wrong operator, the throw only fired when `headers` was NOT an object AND every entry happened to be a string. For any well-formed object, the first clause is `false`, the `&&` short-circuits, and the throw is skipped.
2. `fb.headers.entries.every(...)` was called on a plain object, which has no `.entries` method. The line crashed with `TypeError: fb.headers.entries is not a function` before the throw could run.

Same shape applied to `onCodes` — a non-array value made `fb.onCodes.every(...)` throw `TypeError` before the validator's own throw.

## Fix

- `&&` → `||` in both conditions.
- `fb.headers.entries.every(...)` → `Object.entries(fb.headers).every(...)` with a `fb.headers === null` guard (since `typeof null === "object"`).
- Added `x !== null` to the onCodes type guard.
- Updated the error messages to name the failing field.

## Files

- `shared/proxy/heliconeHeaders.ts` (used by Jawn)
- `worker/src/lib/models/HeliconeHeaders.ts` (used by the worker)
- `packages/__tests__/shared/heliconeHeaders.test.ts` (new — regression coverage)

## Test

```
PASS __tests__/shared/heliconeHeaders.test.ts
Tests: 10 passed, 10 total
```

Covers: well-formed input, absent header, non-object headers, null headers, non-string header value, non-array onCodes, onCodes entry missing `from`/`to`, null onCodes entry, non-array top-level, missing required field.

Existing test suites that were exercised: `npx jest` in `packages/` (588 passed, 8 snapshots passed, 3 skipped, no regressions).

## Backward compatibility

No behavior change for valid `helicone-fallbacks` headers. Malformed input now returns a clear 4xx with a specific message instead of a 500 with a `TypeError`. Clients matching on the previous `TypeError` text would need to match the new message instead.

## Risk

Low. The change is local to a validation function. Valid inputs parse identically; malformed inputs get a more informative error.
