### PR TITLE
fix(cost): tier Anthropic cache reads by the whole prompt size

### DIFF
--- a/packages/__tests__/cost/modelCostFromRegistry.test.ts
+++ b/packages/__tests__/cost/modelCostFromRegistry.test.ts
@@ -317,8 +317,37 @@ describe("modelCostBreakdownFromRegistry", () => {
         // Higher tier: $6/M input, $22.50/M output (multipliers inherited from base tier)
         expect(breakdown.inputCost).toBe(250000 * 0.000006);
         expect(breakdown.outputCost).toBe(50000 * 0.0000225);
-        expect(breakdown.cachedInputCost).toBe(10000 * 0.000003 * 0.1);
+        // The cache read belongs to a prompt that is over the threshold, so it
+        // bills at the same higher tier as the input - matching how the Gemini
+        // case below prices its cache read.
+        expect(breakdown.cachedInputCost).toBe(10000 * 0.000006 * 0.1);
+        // Cache writes still use the base tier: calculateModelCostBreakdown
+        // prices those from basePricing directly, for every provider.
         expect(breakdown.cacheWrite5mCost).toBe(5000 * 0.000003 * 1.25);
+      }
+    });
+
+    it("should tier a Claude cache read by the whole prompt size", () => {
+      // Regression: the cache read was priced from tier 0 regardless of prompt
+      // size, because the anthropic threshold function returned 0 for
+      // cachedInputCost. A mostly-cached long prompt was billed at half rate.
+      const modelUsage: ModelUsage = {
+        input: 10000,
+        output: 100,
+        cacheDetails: {
+          cachedInput: 240000, // prompt totals 250K, over the 200K threshold
+        },
+      };
+
+      const breakdown = modelCostBreakdownFromRegistry({
+        modelUsage,
+        providerModelId: "claude-sonnet-4-20250514",
+        provider: "anthropic" as ModelProviderName,
+      });
+
+      expect(breakdown).not.toBeNull();
+      if (breakdown) {
+        expect(breakdown.cachedInputCost).toBe(240000 * 0.000006 * 0.1);
       }
     });
 

--- a/packages/cost/models/calculate-cost.ts
+++ b/packages/cost/models/calculate-cost.ts
@@ -142,9 +142,13 @@ function getThresholdValueFunction(provider: ModelProviderName): (usage: ModelUs
         switch (field) {
           case "inputCost":
           case "outputCost":
-            return usage.input + 
-              (usage.cacheDetails?.cachedInput ?? 0) + 
-              (usage.cacheDetails?.write5m ?? 0) + 
+          // Anthropic's long-context tier is chosen by the size of the whole
+          // prompt, so a cache read on a >threshold request is billed at the
+          // same higher tier as the input it belongs to.
+          case "cachedInputCost":
+            return usage.input +
+              (usage.cacheDetails?.cachedInput ?? 0) +
+              (usage.cacheDetails?.write5m ?? 0) +
               (usage.cacheDetails?.write1h ?? 0);
           default:
             return 0;


### PR DESCRIPTION
Anthropic cache reads are always priced from the base tier, so a long prompt is billed at half rate.

## Problem

`getThresholdValueFunction` returns `0` for `cachedInputCost` on the `anthropic` branch (it falls through to `default`), so `getPricingTier` always resolves to tier 0 — even though `inputCost` and `outputCost` on the same request use the prompt total.

For `claude-sonnet-4-20250514`, tier 200000 doubles the input rate (`0.000003` -> `0.000006`) and inherits the `cachedInput: 0.1` multiplier. A 250K prompt with a 240K cache read:

| | charged | correct |
|---|---|---|
| cachedInputCost | `$0.072` | `$0.144` |

`inputCost` on that same request is already tiered correctly, so only the cache read is wrong.

## Why this looks like an oversight

`vertex`, `google-ai-studio` and `xai` all list `cachedInputCost` in their threshold cases; only `anthropic` omits it. The existing Gemini over-threshold test asserts its cache read at the *higher* tier (`25000 * 0.000004 * 0.1`, commented "Total prompt = input + cachedInput = 325000 (over threshold)"), while the Anthropic one asserted the base rate for the same situation. Anthropic's published pricing also tiers cache reads above 200K.

## Change

Add `cachedInputCost` to the anthropic case so it uses the same prompt total as `inputCost`/`outputCost`.

I also updated the existing over-threshold assertion, since it had encoded the old behaviour, and added a mostly-cached long prompt as a regression test. I verified both fail against the current code and pass with the change.

## Notes

- Cache **writes** (`cacheWrite5m`/`1h`) still price from `basePricing` unconditionally for every provider, so they ignore tiers too. That looked like a separate question so I left it alone and noted it in the test.
- Doesn't overlap #5691, which adds openai/azure/openrouter/helicone cases; this only touches the existing `anthropic` block.
- `__tests__/cost` passes (188). The 3 `registrySnapshots` failures reproduce on a clean checkout in my environment and are unrelated.