### PR TITLE
fix(cost): reach higher pricing tiers on non-tiered providers

### DIFF
--- a/packages/__tests__/cost/modelCostFromRegistry.test.ts
+++ b/packages/__tests__/cost/modelCostFromRegistry.test.ts
@@ -411,6 +411,169 @@ describe("modelCostBreakdownFromRegistry", () => {
       }
     });
 
+    it("should use higher tier pricing for OpenAI GPT-5.4 over 272K tokens", () => {
+      const modelUsage: ModelUsage = {
+        input: 300000, // over the 272K threshold
+        output: 50000,
+      };
+
+      const breakdown = modelCostBreakdownFromRegistry({
+        modelUsage,
+        providerModelId: "gpt-5.4",
+        provider: "openai" as ModelProviderName,
+      });
+
+      expect(breakdown).not.toBeNull();
+      if (breakdown) {
+        // Higher tier: $5/M input, $22.50/M output
+        expect(breakdown.inputCost).toBe(300000 * 0.000005);
+        expect(breakdown.outputCost).toBe(50000 * 0.0000225);
+        expect(breakdown.totalCost).toBeCloseTo(2.625, 10);
+      }
+    });
+
+    it("should keep base tier pricing for OpenAI GPT-5.4 under 272K tokens", () => {
+      const modelUsage: ModelUsage = {
+        input: 200000,
+        output: 50000,
+        cacheDetails: {
+          cachedInput: 10000,
+        },
+      };
+
+      const breakdown = modelCostBreakdownFromRegistry({
+        modelUsage,
+        providerModelId: "gpt-5.4",
+        provider: "openai" as ModelProviderName,
+      });
+
+      expect(breakdown).not.toBeNull();
+      if (breakdown) {
+        // Base tier: $2.50/M input, $15/M output, cachedInput multiplier 0.1
+        expect(breakdown.inputCost).toBe(200000 * 0.0000025);
+        expect(breakdown.outputCost).toBe(50000 * 0.000015);
+        expect(breakdown.cachedInputCost).toBe(10000 * 0.0000025 * 0.1);
+      }
+    });
+
+    it("should count cached input toward the GPT-5.4 threshold", () => {
+      const modelUsage: ModelUsage = {
+        input: 200000,
+        output: 1000,
+        cacheDetails: {
+          // input alone is under 272K; input + cachedInput is over it
+          cachedInput: 100000,
+        },
+      };
+
+      const breakdown = modelCostBreakdownFromRegistry({
+        modelUsage,
+        providerModelId: "gpt-5.4",
+        provider: "openai" as ModelProviderName,
+      });
+
+      expect(breakdown).not.toBeNull();
+      if (breakdown) {
+        expect(breakdown.inputCost).toBe(200000 * 0.000005);
+        expect(breakdown.outputCost).toBe(1000 * 0.0000225);
+        expect(breakdown.cachedInputCost).toBe(100000 * 0.000005 * 0.1);
+      }
+    });
+
+    it.each([
+      ["azure", 0.000005, 0.0000225],
+      ["helicone", 0.000005, 0.0000225],
+      ["openrouter", 0.000005_275, 0.000023_7375],
+    ])(
+      "should use higher tier pricing for GPT-5.4 on %s over 272K tokens",
+      (provider, inputRate, outputRate) => {
+        const modelUsage: ModelUsage = {
+          input: 300000,
+          output: 50000,
+        };
+
+        const breakdown = modelCostBreakdownFromRegistry({
+          modelUsage,
+          providerModelId:
+            provider === "openrouter" ? "openai/gpt-5.4" : provider === "helicone" ? "pa/gpt-5.4" : "gpt-5.4",
+          provider: provider as ModelProviderName,
+        });
+
+        expect(breakdown).not.toBeNull();
+        if (breakdown) {
+          expect(breakdown.inputCost).toBeCloseTo(300000 * inputRate, 10);
+          expect(breakdown.outputCost).toBeCloseTo(50000 * outputRate, 10);
+        }
+      }
+    );
+
+    it("should apply the Anthropic threshold rule to Claude Sonnet 4 on Bedrock", () => {
+      const modelUsage: ModelUsage = {
+        input: 150000,
+        output: 10000,
+        cacheDetails: {
+          // Anthropic counts cache writes as prompt, so 150K + 30K + 40K is over 200K
+          cachedInput: 30000,
+          write5m: 40000,
+        },
+      };
+
+      const breakdown = modelCostBreakdownFromRegistry({
+        modelUsage,
+        providerModelId: "anthropic.claude-sonnet-4-20250514-v1:0",
+        provider: "bedrock" as ModelProviderName,
+      });
+
+      expect(breakdown).not.toBeNull();
+      if (breakdown) {
+        // Higher tier: $6/M input, $22.50/M output
+        expect(breakdown.inputCost).toBe(150000 * 0.000006);
+        expect(breakdown.outputCost).toBe(10000 * 0.0000225);
+      }
+    });
+
+    it("should keep base tier pricing for a Bedrock request under the threshold", () => {
+      const modelUsage: ModelUsage = {
+        input: 100000,
+        output: 10000,
+        cacheDetails: {
+          cachedInput: 10000,
+        },
+      };
+
+      const breakdown = modelCostBreakdownFromRegistry({
+        modelUsage,
+        providerModelId: "anthropic.claude-sonnet-4-20250514-v1:0",
+        provider: "bedrock" as ModelProviderName,
+      });
+
+      expect(breakdown).not.toBeNull();
+      if (breakdown) {
+        expect(breakdown.inputCost).toBe(100000 * 0.000003);
+        expect(breakdown.outputCost).toBe(10000 * 0.000015);
+        expect(breakdown.cachedInputCost).toBe(10000 * 0.000003 * 0.1);
+      }
+    });
+
+    it("should leave single-tier model pricing unchanged", () => {
+      const modelUsage: ModelUsage = {
+        input: 500000,
+        output: 1000,
+      };
+
+      const breakdown = modelCostBreakdownFromRegistry({
+        modelUsage,
+        providerModelId: "gpt-4o",
+        provider: "openai" as ModelProviderName,
+      });
+
+      expect(breakdown).not.toBeNull();
+      if (breakdown) {
+        expect(breakdown.inputCost).toBe(500000 * 0.0000025);
+        expect(breakdown.outputCost).toBe(1000 * 0.00001);
+      }
+    });
+
     it("should handle Vertex Gemini 3 Pro with threshold pricing", () => {
       const modelUsage: ModelUsage = {
         input: 250000, // Over 200K threshold

--- a/packages/cost/models/calculate-cost.ts
+++ b/packages/cost/models/calculate-cost.ts
@@ -1,5 +1,5 @@
 import type { ModelUsage, ModalityUsage } from "../usage/types";
-import type { ModelProviderConfig, ModelPricing, ModalityPricing } from "./types";
+import type { AuthorName, ModelProviderConfig, ModelPricing, ModalityPricing } from "./types";
 import type { ModelProviderName } from "./providers";
 import { registry } from "./registry";
 
@@ -111,7 +111,24 @@ function getPricingTier(
   return preprocessedPricing[matchedTierIndex];
 }
 
-function getThresholdValueFunction(provider: ModelProviderName): (usage: ModelUsage, field: CostBreakdownField) => number {
+// total prompt length: fresh input plus anything read from cache
+function promptLength(usage: ModelUsage): number {
+  return usage.input + (usage.cacheDetails?.cachedInput ?? 0);
+}
+
+// Anthropic bills cache writes as part of the prompt, so they count toward the threshold
+function anthropicPromptLength(usage: ModelUsage): number {
+  return (
+    promptLength(usage) +
+    (usage.cacheDetails?.write5m ?? 0) +
+    (usage.cacheDetails?.write1h ?? 0)
+  );
+}
+
+function getThresholdValueFunction(
+  provider: ModelProviderName,
+  author: AuthorName,
+): (usage: ModelUsage, field: CostBreakdownField) => number {
   switch (provider) {
     case "vertex":
       return (usage: ModelUsage, field: CostBreakdownField) => {
@@ -142,10 +159,7 @@ function getThresholdValueFunction(provider: ModelProviderName): (usage: ModelUs
         switch (field) {
           case "inputCost":
           case "outputCost":
-            return usage.input + 
-              (usage.cacheDetails?.cachedInput ?? 0) + 
-              (usage.cacheDetails?.write5m ?? 0) + 
-              (usage.cacheDetails?.write1h ?? 0);
+            return anthropicPromptLength(usage);
           default:
             return 0;
         }
@@ -156,13 +170,38 @@ function getThresholdValueFunction(provider: ModelProviderName): (usage: ModelUs
           case "inputCost":
           case "outputCost":
           case "cachedInputCost":
-            return usage.input + (usage.cacheDetails?.cachedInput ?? 0);
+            return promptLength(usage);
           default:
             return 0;
         }
       }
     default:
-      return () => 0;
+      // Everything else (openai, azure, openrouter, helicone, bedrock, ...) tiers on
+      // the request's prompt length. These providers resell models from several
+      // authors, so an Anthropic-authored model keeps the Anthropic rule wherever it
+      // is served from. Providers whose models declare a single tier are unaffected:
+      // the only tier has threshold 0, so any value selects it.
+      if (author === "anthropic") {
+        return (usage: ModelUsage, field: CostBreakdownField) => {
+          switch (field) {
+            case "inputCost":
+            case "outputCost":
+              return anthropicPromptLength(usage);
+            default:
+              return 0;
+          }
+        };
+      }
+      return (usage: ModelUsage, field: CostBreakdownField) => {
+        switch (field) {
+          case "inputCost":
+          case "outputCost":
+          case "cachedInputCost":
+            return promptLength(usage);
+          default:
+            return 0;
+        }
+      };
   }
 }
 
@@ -186,7 +225,7 @@ export function calculateModelCostBreakdown(params: {
   // e.g Anthropic's inputCost and output cost is higher if PROMPT >= X tokens
   // e.g Vertex's inputCost is higher if INPUT >= X tokens, but cachedInputCost is higher if CACHED_INPUT >= X tokens
   // getThresholdValue is a function that will return the value to compare to X
-  const getThresholdValue = getThresholdValueFunction(provider);
+  const getThresholdValue = getThresholdValueFunction(provider, config.author);
   const sortedPricing = [...config.pricing].sort((a, b) => a.threshold - b.threshold);
   // Preprocess pricing tiers once upfront to fill missing fields from previous tiers
   const preprocessedPricing = preprocessPricingTiers(sortedPricing);


### PR DESCRIPTION
Fixes #5690

## The bug

`getThresholdValueFunction` in `packages/cost/models/calculate-cost.ts` only had cases for `vertex`, `google-ai-studio`, `anthropic` and `xai`. Every other provider fell through to `default: return () => 0`. Since `getPricingTier` picks the highest tier whose `threshold` is `<=` the value it is given, a constant `0` always selects the cheapest tier, so any higher tier on those providers was unreachable and large-context requests were under-charged.

The example from the issue, `gpt-5.4` on `openai` with `input: 300000, output: 50000`:

| | input | output | total |
|---|---|---|---|
| charged (base tier) | 300000 x $2.50/M = $0.75 | 50000 x $15/M = $0.75 | **$1.50** |
| correct (>272K tier) | 300000 x $5/M = $1.50 | 50000 x $22.50/M = $1.125 | **$2.625** |

43% under.

I scanned every endpoint config in `packages/cost/models/authors/` for `pricing.length > 1` to size it. 40 endpoints declare more than one tier; 24 of them sit on a provider the switch did not handle:

```
handled     anthropic 3, google-ai-studio 3, vertex 7, xai 3
unreachable azure 2, bedrock 3, helicone 10, openai 2, openrouter 7
```

`bedrock` is in that list too, which the issue did not mention: the three `claude-sonnet-4*` Bedrock endpoints each declare a 200000 tier that was never selected.

## The fix

The `default` branch now returns the request's prompt length instead of `0`.

For `openai`, `azure`, `openrouter` and `helicone` serving OpenAI-authored models that is `usage.input + (usage.cacheDetails?.cachedInput ?? 0)`, exactly what the issue proposed and what the `xai` handler already does.

`bedrock`, `openrouter` and `helicone` also resell Anthropic models, and Anthropic bills cache writes as part of the prompt, which is why the existing `anthropic` case adds `write5m` and `write1h`. Keying the threshold basis purely off the serving provider would silently under-count the prompt for Claude on Bedrock, so the default branch checks the model's `author` and applies the Anthropic rule wherever an Anthropic-authored model is served from. The `promptLength` / `anthropicPromptLength` helpers exist so the two rules are written once.

Models with a single pricing tier are unaffected: their only tier has `threshold: 0`, so any value selects it. The four existing provider cases are untouched, `vertex` in particular, which tiers `cachedInputCost` off the cached-token count alone rather than the prompt.

## Tests

Nine cases added to the `threshold-based pricing` block in `packages/__tests__/cost/modelCostFromRegistry.test.ts`: gpt-5.4 above and below the 272K threshold on `openai`, cached input counting toward that threshold, the higher tier on `azure` / `helicone` / `openrouter` (the OpenRouter rates carry that provider's 1.055 markup), Claude Sonnet 4 on `bedrock` above the threshold only once cache writes are counted and below it otherwise, and a guard that a single-tier model (`gpt-4o`) still prices the same.

Reverting only `packages/cost/models/calculate-cost.ts` and keeping the tests:

```
$ npx jest __tests__/cost/modelCostFromRegistry.test.ts

  ● threshold-based pricing › should use higher tier pricing for OpenAI GPT-5.4 over 272K tokens
    expect(received).toBe(expected) // Object.is equality
    Expected: 1.5
    Received: 0.75

  ● threshold-based pricing › should count cached input toward the GPT-5.4 threshold
    expect(received).toBe(expected) // Object.is equality
    Expected: 1
    Received: 0.5

  ● threshold-based pricing › should use higher tier pricing for GPT-5.4 on azure over 272K tokens
    expect(received).toBeCloseTo(expected, precision)
    Expected: 1.5000000000000002
    Received: 0.7500000000000001

  ● threshold-based pricing › should use higher tier pricing for GPT-5.4 on helicone over 272K tokens
    expect(received).toBeCloseTo(expected, precision)
    Expected: 1.5000000000000002
    Received: 0.7500000000000001

  ● threshold-based pricing › should use higher tier pricing for GPT-5.4 on openrouter over 272K tokens
    expect(received).toBeCloseTo(expected, precision)
    Expected: 1.5825
    Received: 0.79125

  ● threshold-based pricing › should apply the Anthropic threshold rule to Claude Sonnet 4 on Bedrock
    expect(received).toBe(expected) // Object.is equality
    Expected: 0.9
    Received: 0.45

Tests:       6 failed, 21 passed, 27 total
```

With the fix in place, the whole `packages` suite:

```
$ npx jest __tests__/
Test Suites: 1 skipped, 41 passed, 41 of 42 total
Tests:       3 skipped, 587 passed, 590 total
Snapshots:   8 passed, 8 total
```

`npx tsc --noEmit` reports nothing on either changed file.

One note on how I ran these: `packages/package.json` and `packages/yarn.lock` are not in the repo, so the `yarn install --frozen-lockfile` step in `.github/workflows/packages-test.yml` has nothing to install from. I ran the suite against a local jest/ts-jest setup with `@helicone-package/*` mapped to `packages/*`, which is what the imports resolve to anyway. Nothing from that setup is in this branch.
