### PR TITLE
fix(worker): wire VAPI_PROXY to its existing router

### DIFF
--- a/worker/src/routers/routerFactory.ts
+++ b/worker/src/routers/routerFactory.ts
@@ -8,6 +8,7 @@ import { RequestWrapper } from "../lib/RequestWrapper";
 import { getAnthropicProxyRouter } from "./anthropicProxyRouter";
 import { getAPIRouter } from "./api/apiRouter";
 import { getOpenAIProxyRouter } from "./openaiProxyRouter";
+import { getVapiProxyRouter } from "./vapiProxyRouter";
 import { handleFeedback } from "../lib/managers/FeedbackManager";
 import { getGatewayAPIRouter } from "./gatewayRouter";
 import { getGenerateRouter } from "./generateRouter";
@@ -26,9 +27,7 @@ export type BaseOpenAPIRouter = OpenAPIRouterType<
 const WORKER_MAP = {
   ANTHROPIC_PROXY: getAnthropicProxyRouter,
   OPENAI_PROXY: getOpenAIProxyRouter,
-  VAPI_PROXY: () => {
-    throw new Error("VAPI_PROXY not implemented");
-  },
+  VAPI_PROXY: getVapiProxyRouter,
   HELICONE_API: getAPIRouter,
   GATEWAY_API: getGatewayAPIRouter,
   GENERATE_API: getGenerateRouter,

--- a/worker/test/routers/routerFactory.spec.ts
+++ b/worker/test/routers/routerFactory.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const ROUTER_FACTORY_PATH = resolve(
+  __dirname,
+  "../../src/routers/routerFactory.ts"
+);
+
+function readRouterFactorySource(): string {
+  return readFileSync(ROUTER_FACTORY_PATH, "utf-8");
+}
+
+describe("routerFactory VAPI_PROXY wiring", () => {
+  it("imports getVapiProxyRouter from ./vapiProxyRouter", () => {
+    const source = readRouterFactorySource();
+    expect(source).toMatch(
+      /import\s*\{\s*getVapiProxyRouter\s*\}\s*from\s*["']\.\/vapiProxyRouter["']/
+    );
+  });
+
+  it("wires VAPI_PROXY to getVapiProxyRouter in WORKER_MAP", () => {
+    const source = readRouterFactorySource();
+    expect(source).toMatch(/VAPI_PROXY:\s*getVapiProxyRouter\s*,/);
+  });
+
+  it("does not leave the throwing placeholder in WORKER_MAP", () => {
+    const source = readRouterFactorySource();
+    expect(source).not.toMatch(
+      /VAPI_PROXY:\s*\(\s*\)\s*=>\s*\{\s*throw\s+new\s+Error\(["']VAPI_PROXY not implemented["']\)/
+    );
+  });
+});

--- a/worker/test/routers/vitest.config.mts
+++ b/worker/test/routers/vitest.config.mts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: [],
+  },
+  resolve: {
+    alias: {
+      "@worker": new URL("../../src", import.meta.url).pathname,
+      "@helicone-package/cost": new URL(
+        "../../../packages/cost",
+        import.meta.url
+      ).pathname,
+      "@helicone-package/secrets": new URL(
+        "../../../packages/secrets",
+        import.meta.url
+      ).pathname,
+    },
+  },
+});

--- a/worker/vitest.config.mts
+++ b/worker/vitest.config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
       "./test/alerts/vitest.config.mts",
       "./test/token-limit-exception/vitest.config.mts",
       "./test/rate-limit/vitest.config.mts",
+      "./test/routers/vitest.config.mts",
     ],
   },
 });


### PR DESCRIPTION
Fixes #5738.

## Summary

`WORKER_MAP.VAPI_PROXY` in `worker/src/routers/routerFactory.ts` was a placeholder that threw `Error: VAPI_PROXY not implemented` at call time, even though `worker/src/routers/vapiProxyRouter.ts` is a complete, working router with `getVapiProxyRouter` exported and structured identically to its siblings. This PR wires the existing router into the map.

## What changed

- `worker/src/routers/routerFactory.ts`: import `getVapiProxyRouter` from `./vapiProxyRouter` and replace the throwing arrow with the function reference. The router file itself is unchanged.
- `worker/test/routers/routerFactory.spec.ts` (new): regression test that asserts the import is present, `VAPI_PROXY` is wired to `getVapiProxyRouter`, and the throwing placeholder is gone.
- `worker/test/routers/vitest.config.mts` (new): minimal `node`-environment vitest config that mirrors the existing `test/alerts` pattern. Registered in the root `worker/vitest.config.mts` `projects` list.
- `worker/vitest.config.mts`: add the new routers project to the `projects` list.

The new test reads `routerFactory.ts` as text rather than importing the module, because the existing `test/ai-gateway` vitest config has a pre-existing module-resolution issue (`@helicone-package/cost/costCalc` is not resolvable through the `resolve.alias` map) that blocks any test importing the full `routerFactory` module from loading locally. A structural check is the simplest env-independent way to catch this regression class.

## Verified

- `npx tsc --noEmit -p worker/tsconfig.json` — clean, no new errors
- `cd worker && npx vitest run test/routers/routerFactory.spec.ts` — 3 passed
- Reverting the source change makes 2 of the 3 new tests fail, confirming the regression test catches the original bug

## Out of scope (deferred to a follow-up)

- The `"VAPI" as any` cast in `vapiProxyRouter.ts:39` exists because `"VAPI"` is not in the `ProviderName` union in `packages/cost/providers/mappings.ts:107-137`. Adding it would remove the cast, but it is a wider change to the legacy cost system and is better tracked as a follow-up issue.
- `worker/src/index.ts` has no host-routing block for VAPI, so even after this fix, requests on a `vapi.<helicone-domain>` host will still fall through to `throw new Error("Could not determine worker type")` at line 388. The wiring fix is the prerequisite; the host-routing entry needs product input on which VAPI upstream to forward to and how per-customer auth should be handled.

## Risk

None at runtime. The change is a one-line value swap to a router that already exists and is structured the same as the working sibling routers.
