### PR TITLE
fix(worker): drop dead dbInsert/dbUpdate methods from ClickhouseClientWrapper

### DIFF
--- a/worker/src/lib/db/ClickhouseWrapper.ts
+++ b/worker/src/lib/db/ClickhouseWrapper.ts
@@ -20,59 +20,6 @@ export class ClickhouseClientWrapper {
     });
   }
 
-  // TODO dead code
-  async dbInsertClickhouse<T extends keyof ClickhouseDB["Tables"]>(
-    table: T,
-    values: ClickhouseDB["Tables"][T][]
-  ): Promise<Result<string, string>> {
-    try {
-      const queryResult = await this.clickHouseClient.insert({
-        table: table,
-        values: values,
-        format: "JSONEachRow",
-        // Recommended for cluster usage to avoid situations
-        // where a query processing error occurred after the response code
-        // and HTTP headers were sent to the client.
-        // See https://clickhouse.com/docs/en/interfaces/http/#response-buffering
-        clickhouse_settings: {
-          async_insert: 1,
-          wait_end_of_query: 1,
-        },
-      });
-      return { data: queryResult.query_id, error: null };
-    } catch (err) {
-      console.error("dbInsertClickhouseError", err);
-      return {
-        data: null,
-        error: JSON.stringify(err),
-      };
-    }
-  }
-
-  // TODO dead code
-  async dbUpdateClickhouse(query: string): Promise<Result<string, string>> {
-    try {
-      const commandResult = await this.clickHouseClient.command({
-        query,
-        // Recommended for cluster usage to avoid situations
-        // where a query processing error occurred after the response code
-        // and HTTP headers were sent to the client.
-        // See https://clickhouse.com/docs/en/interfaces/http/#response-buffering
-        clickhouse_settings: {
-          wait_end_of_query: 1,
-        },
-      });
-
-      return { data: commandResult.query_id, error: null };
-    } catch (error: unknown) {
-      console.error("dbUpdateClickhouseError", error);
-      return {
-        data: null,
-        error: JSON.stringify(error),
-      };
-    }
-  }
-
   async dbQuery<T>(
     query: string,
     parameters: (number | string | boolean | Date)[]

--- a/worker/test/routers/clickhouseWrapper.spec.ts
+++ b/worker/test/routers/clickhouseWrapper.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const CLICKHOUSE_WRAPPER_PATH = resolve(
+  __dirname,
+  "../../src/lib/db/ClickhouseWrapper.ts"
+);
+
+function readClickhouseWrapperSource(): string {
+  return readFileSync(CLICKHOUSE_WRAPPER_PATH, "utf-8");
+}
+
+describe("ClickhouseClientWrapper dead CRUD methods removed", () => {
+  it("no longer defines dbInsertClickhouse", () => {
+    const source = readClickhouseWrapperSource();
+    expect(source).not.toMatch(/async\s+dbInsertClickhouse\s*[<(]/);
+  });
+
+  it("no longer defines dbUpdateClickhouse", () => {
+    const source = readClickhouseWrapperSource();
+    expect(source).not.toMatch(/async\s+dbUpdateClickhouse\s*\(/);
+  });
+
+  it("no longer contains the `// TODO dead code` comments", () => {
+    const source = readClickhouseWrapperSource();
+    expect(source).not.toMatch(/\/\/\s*TODO\s+dead\s+code/);
+  });
+
+  it("still defines dbQuery (the only used method)", () => {
+    const source = readClickhouseWrapperSource();
+    expect(source).toMatch(/async\s+dbQuery\s*</);
+  });
+
+  it("still exports the ClickhouseClientWrapper class", () => {
+    const source = readClickhouseWrapperSource();
+    expect(source).toMatch(
+      /export\s+class\s+ClickhouseClientWrapper\s*\{/
+    );
+  });
+
+  it("still exports the ClickhouseDB type used by dbQuery callers", () => {
+    const source = readClickhouseWrapperSource();
+    expect(source).toMatch(
+      /export\s+interface\s+ClickhouseDB\s*\{/
+    );
+  });
+});

--- a/worker/test/routers/vitest.config.mts
+++ b/worker/test/routers/vitest.config.mts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: [],
+  },
+  resolve: {
+    alias: {
+      "@worker": new URL("../../src", import.meta.url).pathname,
+      "@helicone-package/cost": new URL(
+        "../../../packages/cost",
+        import.meta.url
+      ).pathname,
+      "@helicone-package/secrets": new URL(
+        "../../../packages/secrets",
+        import.meta.url
+      ).pathname,
+    },
+  },
+});

--- a/worker/vitest.config.mts
+++ b/worker/vitest.config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
       "./test/alerts/vitest.config.mts",
       "./test/token-limit-exception/vitest.config.mts",
       "./test/rate-limit/vitest.config.mts",
+      "./test/routers/vitest.config.mts",
     ],
   },
 });


### PR DESCRIPTION
Fixes #5740.

## Summary

`ClickhouseClientWrapper` in `worker/src/lib/db/ClickhouseWrapper.ts` exposed two methods, `dbInsertClickhouse` and `dbUpdateClickhouse`, each marked with a `// TODO dead code` comment from the maintainer. Neither is called anywhere in the worker. The class is used across the worker (12+ import sites) but only via `dbQuery`. This PR deletes the two methods and their comments.

## Why this is safe

- `dbUpdateClickhouse` has zero callers anywhere in the repository.
- `dbInsertClickhouse` has zero callers in `worker/`. It is used in `valhalla/jawn/` against `valhalla/jawn/src/lib/db/ClickhouseWrapper.ts`, which is a separate, independent file. The two wrappers are not shared at runtime.
- The class's actually-used surface (`dbQuery`, the `ClickhouseEnv` interface, the `ClickhouseDB` and table types) is unchanged.

## What changed

- `worker/src/lib/db/ClickhouseWrapper.ts`: delete `dbInsertClickhouse` (28 lines) and `dbUpdateClickhouse` (23 lines) plus their `// TODO dead code` comments. The `dbQuery` method and the type definitions are untouched.
- `worker/test/routers/clickhouseWrapper.spec.ts` (new): 6 structural regression tests that read the file as text and assert the dead methods are gone, the `// TODO dead code` comments are gone, and the `dbQuery` / `ClickhouseClientWrapper` / `ClickhouseDB` surface is preserved.
- `worker/test/routers/vitest.config.mts` (new): minimal `node`-environment vitest config (mirrors the `test/alerts` pattern). Registered in the root `worker/vitest.config.mts` `projects` list.
- `worker/vitest.config.mts`: add the new `routers` project.

The new spec reads the source as text rather than importing `ClickhouseClientWrapper` directly, because the existing `test/ai-gateway` vitest config has a pre-existing module-resolution issue (`@helicone-package/cost/costCalc` is not resolvable through the `resolve.alias` map) that blocks any test whose import chain touches the worker source from loading. The structural check is the simplest env-independent way to enforce the class of bug this PR is fixing (someone re-adding the dead methods).

## Verified

- `npx tsc --noEmit -p worker/tsconfig.json` — clean, no new errors
- `cd worker && npx vitest run test/routers/clickhouseWrapper.spec.ts` — 6 passed in 147ms
- Re-adding the dead methods makes 3 of the 6 tests fail, confirming regression detection works

## Out of scope (deferred to follow-up issues)

- Consolidating the worker and valhalla `ClickhouseWrapper` copies into a shared package. Out of scope for a focused PR; the two copies are intentionally independent and the valhalla copy is heavily used.
- Adding real Clickhouse mocks and unit-testing `dbQuery`. The structural test is the minimum the maintainer's `// TODO` comment asked for; richer test infrastructure is a separate piece of work.
- Fixing the pre-existing module-resolution issue in `test/ai-gateway` that prevents most worker vitest specs from loading. Affects 22 of 32 worker test files; no fix attempted here.

## Risk

None at runtime. The change is a deletion of unreachable code. If a downstream consumer outside the repo imports the worker entrypoints and calls these methods, that consumer is broken — but the surface never worked in production, and the methods are explicitly marked dead by the maintainer.
