### PR TITLE
fix(packages,worker): add VAPI to ProviderName union and drop as any cast

### DIFF
--- a/packages/cost/providers/mappings.ts
+++ b/packages/cost/providers/mappings.ts
@@ -132,6 +132,7 @@ export const providersNames = [
   "CEREBRAS",
   "BASETEN",
   "CANOPYWAVE",
+  "VAPI",
 ] as const;
 
 export type ProviderName = (typeof providersNames)[number];

--- a/worker/src/routers/vapiProxyRouter.ts
+++ b/worker/src/routers/vapiProxyRouter.ts
@@ -36,7 +36,7 @@ export const getVapiProxyRouter = (router: BaseRouter) => {
       env: Env,
       ctx: ExecutionContext
     ) => {
-      return await proxyForwarder(requestWrapper, env, ctx, "VAPI" as any);
+      return await proxyForwarder(requestWrapper, env, ctx, "VAPI");
     }
   );
 

--- a/worker/test/routers/vapiProviderName.spec.ts
+++ b/worker/test/routers/vapiProviderName.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const MAPPINGS_PATH = resolve(
+  __dirname,
+  "../../../packages/cost/providers/mappings.ts"
+);
+
+const VAPI_ROUTER_PATH = resolve(
+  __dirname,
+  "../../src/routers/vapiProxyRouter.ts"
+);
+
+function readMappingsSource(): string {
+  return readFileSync(MAPPINGS_PATH, "utf-8");
+}
+
+function readVapiRouterSource(): string {
+  return readFileSync(VAPI_ROUTER_PATH, "utf-8");
+}
+
+describe("VAPI ProviderName union coverage", () => {
+  it("adds 'VAPI' to the providersNames array", () => {
+    const source = readMappingsSource();
+    expect(source).toMatch(/["']VAPI["']/);
+  });
+
+  it("keeps the providersNames array shaped as a const tuple", () => {
+    const source = readMappingsSource();
+    expect(source).toMatch(
+      /export\s+const\s+providersNames\s*=\s*\[[\s\S]*\]\s+as\s+const/
+    );
+  });
+});
+
+describe("vapiProxyRouter no longer uses `as any` on the provider", () => {
+  it("calls proxyForwarder with 'VAPI' directly (no `as any` cast)", () => {
+    const source = readVapiRouterSource();
+    expect(source).not.toMatch(
+      /proxyForwarder\([^)]*["']VAPI["']\s+as\s+any/
+    );
+  });
+
+  it("still passes 'VAPI' to proxyForwarder", () => {
+    const source = readVapiRouterSource();
+    expect(source).toMatch(
+      /proxyForwarder\([^)]*["']VAPI["']\s*\)/
+    );
+  });
+
+  it("still exports getVapiProxyRouter (positive control)", () => {
+    const source = readVapiRouterSource();
+    expect(source).toMatch(/export\s+const\s+getVapiProxyRouter\s*=/);
+  });
+
+  it("still registers the /helicone/test route (positive control)", () => {
+    const source = readVapiRouterSource();
+    expect(source).toMatch(/router\.get\(\s*["']\/helicone\/test["']/);
+  });
+});

--- a/worker/test/routers/vitest.config.mts
+++ b/worker/test/routers/vitest.config.mts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: [],
+  },
+  resolve: {
+    alias: {
+      "@worker": new URL("../../src", import.meta.url).pathname,
+      "@helicone-package/cost": new URL(
+        "../../../packages/cost",
+        import.meta.url
+      ).pathname,
+      "@helicone-package/secrets": new URL(
+        "../../../packages/secrets",
+        import.meta.url
+      ).pathname,
+    },
+  },
+});

--- a/worker/vitest.config.mts
+++ b/worker/vitest.config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
       "./test/alerts/vitest.config.mts",
       "./test/token-limit-exception/vitest.config.mts",
       "./test/rate-limit/vitest.config.mts",
+      "./test/routers/vitest.config.mts",
     ],
   },
 });


### PR DESCRIPTION
Fixes #5744.

## Summary

`vapiProxyRouter` calls `proxyForwarder(requestWrapper, env, ctx, "VAPI" as any)` with an `as any` cast because `"VAPI"` is missing from the `ProviderName` union at `packages/cost/providers/mappings.ts:97-135`. This PR adds `"VAPI"` to the union and removes the cast. Runtime behavior is unchanged: VAPI requests still flow through `proxyForwarder`, and `heliconeProviderToModelProviderName` returns `null` for "VAPI" via its existing `default: return null;` clause (same as today).

This is the type-hygiene follow-up to #5739 (which wired `VAPI_PROXY` to `getVapiProxyRouter`).

## What changed

- `packages/cost/providers/mappings.ts`: add `"VAPI"` to the `providersNames` array, after `"CANOPYWAVE"`. One line. The `ProviderName` union now includes `"VAPI"`.
- `worker/src/routers/vapiProxyRouter.ts`: drop the `as any` cast on the `proxyForwarder` call. The literal `"VAPI"` is now assignable to `Provider = ProviderName | "CUSTOM" | ModelProviderName` (from `worker/src/index.ts:29`).
- `worker/test/routers/vapiProviderName.spec.ts` (new): 6 structural regression tests that read the two source files and assert `"VAPI"` is in the union, the `as any` cast is gone, and the router still has the `getVapiProxyRouter` export and `/helicone/test` route (positive controls).
- `worker/test/routers/vitest.config.mts` (new) + `worker/vitest.config.mts`: register the new test project (mirrors the existing `test/alerts` node-env pattern).

## Why the test is structural

The existing `worker/test/ai-gateway` vitest config has a pre-existing module-resolution error (`Cannot find module '@helicone-package/cost/costCalc'`) that blocks any test whose import chain touches the worker source from loading. A structural (file-read) check runs in any environment and directly enforces the class of bug this PR fixes (someone re-introducing the `as any` cast or removing `"VAPI"` from the union).

## Cascades verified

The only `switch` on `ProviderName` in the repo is `heliconeProviderToModelProviderName` in `packages/cost/models/provider-helpers.ts:25-86`. Its `default: return null;` clause handles any new union member without an explicit case. The other two `switch (provider)` statements in `packages/cost/` (`getUsageProcessor` at `usage/getUsageProcessor.ts:16` and `getThresholdValueFunction` at `models/calculate-cost.ts:115`) operate on `ModelProviderName` (lowercase), which is a separate type and is not affected.

For "VAPI" the natural mapping in `heliconeProviderToModelProviderName` is `null` (no cost calculation, same as the unhandled `default`). Runtime cost behavior is unchanged.

## Verified

- `npx tsc --noEmit -p worker/tsconfig.json` — clean, no new errors
- `npx tsc --noEmit -p packages/tsconfig.json` — same 3 pre-existing errors as on `upstream/main`; none introduced
- `cd worker && npx vitest run test/routers/vapiProviderName.spec.ts` — 6 passed in 143ms
- Reverting both source changes makes 3 of 6 tests fail, confirming regression detection works
- Full worker vitest: 32 test files, 10 pass (including the new `routers` project), 22 fail to load with the pre-existing `Cannot find module '@helicone-package/cost/costCalc'` error; 149 tests run, all pass

## Out of scope (deferred to follow-up issues)

- Adding a cost model for VAPI in `packages/cost/models/registry.ts` and the `providers` array in `packages/cost/providers/mappings.ts:141+`. Requires knowing the VAPI upstream URL, the model, and per-token pricing. This PR does not change cost behavior; VAPI requests still report `null` cost via the existing `default: return null;` clause.
- Adding a host-routing block in `worker/src/index.ts` so a `vapi.<helicone-domain>` host dispatches to `WORKER_TYPE: "VAPI_PROXY"`. Separate product decision.

## Risk

Very low. The change is:

- A new string in a `const` array.
- Removal of an `as any` cast on a single call site.
- A structural regression test.

Worst case: a switch without a `default` clause somewhere would now be non-exhaustive. The repo was searched for switches on `ProviderName` and `provider`; only the three documented above operate on these types, and all three either operate on a different type (`ModelProviderName`) or have a `default` clause.
