### PR TITLE
fix(jawn): surface evaluator errors from runExperimentEvaluators

### DIFF
--- a/valhalla/jawn/src/managers/evaluator/EvaluatorManager.ts
+++ b/valhalla/jawn/src/managers/evaluator/EvaluatorManager.ts
@@ -343,6 +343,9 @@ export class EvaluatorManager extends BaseManager {
     }
 
     const evaluators = await this.getEvaluatorsForExperiment(experimentId);
+    if (evaluators.error) {
+      return err(evaluators.error);
+    }
 
     const experimentData =
       await experimentManager.getExperimentOutputForScores(experimentId);
@@ -375,6 +378,11 @@ export class EvaluatorManager extends BaseManager {
         return Promise.all(evaluationPromises);
       }) ?? []
     );
+
+    const failedEvaluation = x.flat().find((result) => result.error);
+    if (failedEvaluation?.error) {
+      return err(failedEvaluation.error);
+    }
 
     return ok(null);
   }

--- a/valhalla/jawn/src/managers/evaluator/__tests__/EvaluatorManager.test.ts
+++ b/valhalla/jawn/src/managers/evaluator/__tests__/EvaluatorManager.test.ts
@@ -1,0 +1,99 @@
+import { EvaluatorManager } from "../EvaluatorManager";
+import { AuthParams } from "../../../packages/common/auth/types";
+import { err, ok } from "../../../packages/common/result";
+
+// pythonEvaluator builds a CodeSandbox pool at import time, which requires a
+// sandbox API key. This suite never reaches it.
+jest.mock("../pythonEvaluator", () => ({
+  pythonEvaluator: jest.fn(),
+}));
+
+jest.mock("../../experiment/ExperimentV2Manager", () => ({
+  ExperimentV2Manager: jest.fn().mockImplementation(() => ({
+    hasAccessToExperiment: async () => true,
+    getExperimentOutputForScores: async () => ({
+      data: [
+        {
+          request_id: "request-1",
+          input_record: { inputs: { prompt: "hello" }, autoInputs: {} },
+          scores: {},
+        },
+      ],
+      error: null,
+    }),
+  })),
+}));
+
+describe("EvaluatorManager.runExperimentEvaluators", () => {
+  const authParams: AuthParams = {
+    organizationId: "test-org-id",
+    userId: "test-user-id",
+    role: "admin",
+  };
+
+  const evaluator = {
+    id: "evaluator-1",
+    created_at: "2024-01-01T00:00:00.000Z",
+    scoring_type: "LLM-BOOLEAN",
+    llm_template: {},
+    organization_id: "test-org-id",
+    updated_at: "2024-01-01T00:00:00.000Z",
+    name: "Quality Gate",
+    code_template: null,
+    last_mile_config: null,
+  };
+
+  // The manager is typed with private members; the test stubs them directly.
+  const buildManager = () => new EvaluatorManager(authParams) as any;
+
+  const stubEvaluatorRun = (manager: any, evaluatorResult: unknown) => {
+    jest
+      .spyOn(manager, "getContent")
+      .mockResolvedValue(ok({ requestBody: "{}", responseBody: "{}" }));
+    return jest
+      .spyOn(manager, "runEvaluatorAndPostScore")
+      .mockResolvedValue(evaluatorResult);
+  };
+
+  it("returns success when every evaluator succeeds", async () => {
+    const manager = buildManager();
+    jest
+      .spyOn(manager, "getEvaluatorsForExperiment")
+      .mockResolvedValue(ok([evaluator]));
+    const runEvaluator = stubEvaluatorRun(manager, ok(null));
+
+    const result = await manager.runExperimentEvaluators("experiment-1");
+
+    expect(runEvaluator).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(ok(null));
+  });
+
+  it("returns the evaluator error instead of reporting success", async () => {
+    const manager = buildManager();
+    jest
+      .spyOn(manager, "getEvaluatorsForExperiment")
+      .mockResolvedValue(ok([evaluator]));
+    const runEvaluator = stubEvaluatorRun(
+      manager,
+      err("SyntheticEvaluatorError")
+    );
+
+    const result = await manager.runExperimentEvaluators("experiment-1");
+
+    expect(runEvaluator).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(err("SyntheticEvaluatorError"));
+  });
+
+  it("returns the evaluator list error before running any evaluator", async () => {
+    const manager = buildManager();
+    jest
+      .spyOn(manager, "getEvaluatorsForExperiment")
+      .mockResolvedValue(err("Unauthorized"));
+    const runEvaluator = stubEvaluatorRun(manager, ok(null));
+
+    const result = await manager.runExperimentEvaluators("experiment-1");
+
+    expect(runEvaluator).not.toHaveBeenCalled();
+    expect(result).toEqual(err("Unauthorized"));
+  });
+});


### PR DESCRIPTION
Closes #5746

## What

`EvaluatorManager.runExperimentEvaluators()` awaits the per-request evaluator
promises into `x`, but never inspects the resulting `Result` values, and it
does not check `getEvaluatorsForExperiment()`. Both paths fall through to
`ok(null)`.

Because `experimentV2Controller.runExperimentEvaluators` returns the manager
result verbatim with HTTP 200, `POST /v2/experiment/{experimentId}/evaluators/run`
answers `{"data":null,"error":null}` after an evaluator has failed. The older
`POST /v1/experiment/{experimentId}/evaluators/run`
(`experimentController.runExperimentEvaluatorsOld`) calls the same method and is
affected identically.

## Change

Two checks in `runExperimentEvaluators`, no behavior change on the success path:

- return the evaluator-list error before any evaluation starts; and
- return the first failed evaluation instead of unconditional `ok(null)`.

Concurrency, partial-success semantics, controller types, and the web mutation
are untouched.

## Test

Adds `valhalla/jawn/src/managers/evaluator/__tests__/EvaluatorManager.test.ts`
with three cases: passing control returns `ok(null)`; a failing evaluator is
returned by the outer run; an evaluator-list error short-circuits before any
evaluator runs.

The suite stubs `getEvaluatorsForExperiment`, `getContent`, and
`runEvaluatorAndPostScore`, and mocks `ExperimentV2Manager` and
`pythonEvaluator` — no ClickHouse, Supabase, model call, or API key.

```text
NODE_ENV=test yarn workspace helicone-api test:jawn --runInBand --forceExit \
  --runTestsByPath src/managers/evaluator/__tests__/EvaluatorManager.test.ts
# Tests: 3 passed, 3 total

yarn workspace helicone-api build
# Build success

npx tsc --noEmit -p valhalla/jawn/tsconfig.json
# 0 errors
```

Reverting only the `EvaluatorManager.ts` change fails 2 of the 3 tests, so the
regression pins the reported behavior rather than the implementation.

`--forceExit` is needed because importing `EvaluatorManager` reaches a
module-level `setInterval` in `KVCache`; that is pre-existing and untouched
here.
