### PR TITLE
Move yarn install command after copying web files

### DIFF
--- a/docker/dockerfiles/dockerfile_web
+++ b/docker/dockerfiles/dockerfile_web
@@ -15,10 +15,10 @@ COPY bifrost/package.json ./bifrost/
 
 ENV NODE_OPTIONS="--dns-result-order=ipv4first"
 
-RUN yarn install --frozen-lockfile --network-timeout 300000
-
 COPY packages/ ./packages/
 COPY web/ ./web/
+
+RUN yarn install --frozen-lockfile --network-timeout 300000
 
 RUN cd web && yarn build
 


### PR DESCRIPTION
Replaced the yarn install command to run after copying web files.

## Ticket
Link to the ticket(s) this pull request addresses.

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [ ] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
|                      |                   |

## Extra Notes
Any additional context, considerations, or notes for reviewers.

## Context
Why are you making this change?

## Screenshots / Demos
