### PR TITLE
fix(worker): add radix and NaN-safe default to walletRouter pagination parseInt

### DIFF
--- a/worker/src/routers/api/walletRouter.ts
+++ b/worker/src/routers/api/walletRouter.ts
@@ -175,9 +175,15 @@ export function getWalletRouter(
 
       try {
         // Parse pagination parameters
-        const pageNum = Math.max(0, page ? parseInt(page as string) : 0);
+        const pageNum = Math.max(
+          0,
+          page ? parseInt(page as string, 10) || 0 : 0
+        );
         const pageSizeNum = Math.min(
-          Math.max(1, pageSize ? parseInt(pageSize as string) : 50),
+          Math.max(
+            1,
+            pageSize ? parseInt(pageSize as string, 10) || 50 : 50
+          ),
           1000
         );
 

--- a/worker/test/routers/vitest.config.mts
+++ b/worker/test/routers/vitest.config.mts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: [],
+  },
+  resolve: {
+    alias: {
+      "@worker": new URL("../../src", import.meta.url).pathname,
+      "@helicone-package/cost": new URL(
+        "../../../packages/cost",
+        import.meta.url
+      ).pathname,
+      "@helicone-package/secrets": new URL(
+        "../../../packages/secrets",
+        import.meta.url
+      ).pathname,
+    },
+  },
+});

--- a/worker/test/routers/walletPagination.spec.ts
+++ b/worker/test/routers/walletPagination.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const WALLET_ROUTER_PATH = resolve(
+  __dirname,
+  "../../src/routers/api/walletRouter.ts"
+);
+
+function readWalletRouterSource(): string {
+  return readFileSync(WALLET_ROUTER_PATH, "utf-8");
+}
+
+describe("walletRouter pagination parseInt uses radix and NaN-safe default", () => {
+  it("page parameter is parsed with a radix of 10", () => {
+    const source = readWalletRouterSource();
+    // The fix is the line: `page ? parseInt(page as string, 10) || 0 : 0`
+    expect(source).toMatch(
+      /page\s*\?\s*parseInt\(\s*page\s+as\s+string\s*,\s*10\s*\)\s*\|\|\s*0/
+    );
+  });
+
+  it("pageSize parameter is parsed with a radix of 10", () => {
+    const source = readWalletRouterSource();
+    expect(source).toMatch(
+      /pageSize\s*\?\s*parseInt\(\s*pageSize\s+as\s+string\s*,\s*10\s*\)\s*\|\|\s*50/
+    );
+  });
+
+  it("does not use parseInt without a radix anywhere in walletRouter.ts", () => {
+    const source = readWalletRouterSource();
+    // Look for `parseInt(` followed by a string and `)` without a radix
+    // in the pagination context. The new code uses `, 10)`, so a `parseInt(...)`
+    // call without a radix would be `parseInt(<string>)` with no second arg.
+    const matches = source.match(/parseInt\([^)]*\)/g) ?? [];
+    const noRadix = matches.filter(
+      (m) => !m.includes(", 10") && !m.includes(",10")
+    );
+    expect(noRadix).toEqual([]);
+  });
+});

--- a/worker/vitest.config.mts
+++ b/worker/vitest.config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
       "./test/alerts/vitest.config.mts",
       "./test/token-limit-exception/vitest.config.mts",
       "./test/rate-limit/vitest.config.mts",
+      "./test/routers/vitest.config.mts",
     ],
   },
 });


### PR DESCRIPTION
Fixes #5751.

## Summary

`worker/src/routers/api/walletRouter.ts:178, 180` parses the `page` and `pageSize` query-string parameters with `parseInt` but no radix, and the result is fed straight into `Math.max` / `Math.min` without any `NaN` check. A request with `?page=abc&pageSize=xyz` computes `pageNum = NaN` and `pageSizeNum = NaN`, both of which are then passed to `walletStub.getTableData(tableName, pageNum, pageSizeNum)`. The wallet DO's behavior with `NaN` arguments is undefined. This PR adds the radix and a `NaN`-safe default so bad query params fall back to the documented defaults instead of reaching the DO as `NaN`.

## What changed

- `worker/src/routers/api/walletRouter.ts:178, 180` — change `parseInt(page as string)` to `parseInt(page as string, 10) || 0` and `parseInt(pageSize as string)` to `parseInt(pageSize as string, 10) || 50`. The radix argument matches the maintainer's pattern in other worker `parseInt` call sites (`rateLimitOptions.ts:27-28`, `StripeManager.ts:36`, `policyParser.ts:91`, `AlertManager.ts:331`, `HeliconeHeaders.ts:449, 451, 455`). The `|| 0` / `|| 50` defaults turn `NaN` into the documented fallback, matching how the rest of the worker handles `NaN`-prone numeric input.
- `worker/test/routers/walletPagination.spec.ts` (new): 3 structural regression tests that read the file as text and assert the two lines use a radix and that no `parseInt` call in `walletRouter.ts` is missing a radix. Mirrors the `node`-env structural test pattern from #5739, #5741, #5745, #5749.
- `worker/test/routers/vitest.config.mts` (new) + `worker/vitest.config.mts`: register the new test project (mirrors the `test/alerts` node-env pattern).

## Why the test is structural

The pre-existing worker test infrastructure issue (`Cannot find module '@helicone-package/cost/costCalc'`) blocks most `worker/test/ai-gateway` vitest specs from loading. The new test is in the `test/routers/` project (no miniflare, no AI gateway imports, only `readFileSync` and `JSON.parse`). The structural check is fast, deterministic, and runs in any environment.

## Behavior table

| Query              | Before (`pageNum` / `pageSizeNum`)         | After                              |
|--------------------|--------------------------------------------|-------------------------------------|
| (no params)        | `0` / `50`                                 | `0` / `50` (no change)              |
| `?page=2&pageSize=25` | `2` / `25`                              | `2` / `25` (no change)              |
| `?page=0&pageSize=1`  | `0` / `1` (the `page ?` ternary treats `"0"` as falsy → falls to `: 0`) | `0` / `1` (no change)              |
| `?page=abc`        | `NaN` (passed to the DO)                   | `0` (default)                       |
| `?pageSize=xyz`    | `NaN` (passed to the DO)                   | `50` (default)                      |
| `?page=0x10`       | `16` (no-radix `parseInt` treats `0x10` as hex) | `0` (radix 10, `0x` is not a decimal digit) |
| `?page=-1`         | `-1` (`Math.max(0, -1)` → `0`)             | `0` (`Math.max(0, NaN || 0)` → `0`, since `-1` parses to `-1` which is truthy, the `||` doesn't fire; `Math.max(0, -1)` still gives `0` — no change) |

The change is observable only for `NaN`-producing and hex-style input. The two defensive changes (radix + `NaN` default) are independent — adding just the radix would fix the hex case but not the `NaN` case; adding just the `NaN` default would fix `NaN` but not the hex case. Both are needed for the user-input safety story.

## Verified

- `npx tsc --noEmit -p worker/tsconfig.json` — clean, no new errors
- `cd worker && npx vitest run test/routers/walletPagination.spec.ts` — 3 passed in 141ms
- Reverting the source change makes all 3 tests fail, confirming regression detection works

## Out of scope (deferred to a follow-up)

- The same `parseInt`-without-radix pattern in `worker/src/routers/gatewayRouter.ts:39, 47` (KV-stored integer; no user input but the lint warning is real) and in `worker/src/lib/util/cache/cacheFunctions.ts:91` and `worker/src/lib/util/cache/cacheSettings.ts:25, 27, 57` (HTTP header parsing; non-numeric headers would currently return `NaN`). These are not user-input-driven in the same direct way; a focused follow-up can add the radix across the rest of the worker.
- The wallet DO's `getTableData` does not currently validate its own arguments. Even with this PR, the DO should ideally defend against `NaN` in its own code. That's a separate, deeper fix in the DO.
- The pre-existing worker test infrastructure issue where most of `worker/test/ai-gateway` vitest specs fail to load (`Cannot find module '@helicone-package/cost/costCalc'`). The `yarn add -D vite-tsconfig-paths` fix is documented in #5749 as a follow-up.
- The VAPI host-routing in `worker/src/index.ts` and the VAPI cost model in `packages/cost/models/registry.ts` are still out-of-scope product decisions (documented in #5744).

## Risk

Very low. The change is:

- 2 lines edited (in one file).
- 1 new test file (structural check, fast, deterministic).
- 2 vitest config lines (test project registration, mirrors prior PRs).

Worst case: the `|| 0` / `|| 50` defaults treat `0` as a falsy value and default it. The current code's `page ? parseInt(...) : 0` ternary does the same thing (the `page ?` ternary treats `"0"` as falsy and falls through to `0`). So the new code's `||` default is consistent with the existing falsy behavior, not a new one. The only observable change is for non-numeric input, which today silently reaches the wallet DO as `NaN`.
