### PR TITLE
fix(worker): add radix to 8 parseInt calls in cache and gateway code

### DIFF
--- a/worker/src/lib/models/HeliconeHeaders.ts
+++ b/worker/src/lib/models/HeliconeHeaders.ts
@@ -371,10 +371,13 @@ export class HeliconeHeaders implements IHeliconeHeaders {
         cacheEnabled:
           this.headers.get("Helicone-Cache-Enabled") === "true" ? true : false,
         cacheSeed: this.headers.get("Helicone-Cache-Seed")
-          ? parseInt(this.headers.get("Helicone-Cache-Seed") ?? "0")
+          ? parseInt(this.headers.get("Helicone-Cache-Seed") ?? "0", 10)
           : null,
         cacheBucketMaxSize: this.headers.get("Helicone-Cache-Bucket-Max-Size")
-          ? parseInt(this.headers.get("Helicone-Cache-Bucket-Max-Size") ?? "0")
+          ? parseInt(
+              this.headers.get("Helicone-Cache-Bucket-Max-Size") ?? "0",
+              10
+            )
           : null,
         cacheControl: this.headers.get("Helicone-Cache-Control") ?? null,
         cacheIgnoreKeys: this.headers.get("Helicone-Cache-Ignore-Keys")

--- a/worker/src/lib/util/cache/cacheFunctions.ts
+++ b/worker/src/lib/util/cache/cacheFunctions.ts
@@ -88,7 +88,7 @@ async function trySaveToCache(options: SaveToCacheOptions): Promise<boolean> {
       cacheSeed,
     } = options;
     const expirationTtl = cacheControl.includes("max-age=")
-      ? parseInt(cacheControl.split("max-age=")[1])
+      ? parseInt(cacheControl.split("max-age=")[1], 10)
       : 0;
     const { freeIndexes } = await getMaxCachedResponses(
       request,

--- a/worker/src/lib/util/cache/cacheSettings.ts
+++ b/worker/src/lib/util/cache/cacheSettings.ts
@@ -22,9 +22,9 @@ function buildCacheControl(cacheControl: string): string {
     let sMaxAgeInSeconds = 0;
     try {
       sMaxAgeInSeconds = sMaxAge
-        ? parseInt(sMaxAge)
+        ? parseInt(sMaxAge, 10)
         : maxAge
-          ? parseInt(maxAge)
+          ? parseInt(maxAge, 10)
           : 0;
     } catch (e) {
       console.error("Error parsing s-maxage or max-age", e);
@@ -55,7 +55,8 @@ function getCacheState(headers: Headers): CacheHeaders {
     cacheRead:
       (headers.get("Helicone-Cache-Read") ?? "").toLowerCase() === "true",
     cacheBucketMaxSize: parseInt(
-      headers.get("Helicone-Cache-Bucket-Max-Size") ?? "1"
+      headers.get("Helicone-Cache-Bucket-Max-Size") ?? "1",
+      10
     ),
     cacheSeed: headers.get("Helicone-Cache-Seed"),
   };

--- a/worker/src/routers/gatewayRouter.ts
+++ b/worker/src/routers/gatewayRouter.ts
@@ -36,7 +36,7 @@ async function rateLimitUnapprovedDomains(
     const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
     const rlKey = `gateway-rl-${url}-${today}`;
     const count = await rateLimitKV.get(rlKey);
-    if (count && parseInt(count) > MAX_REQUESTS_PER_DAY) {
+    if (count && parseInt(count, 10) > MAX_REQUESTS_PER_DAY) {
       return {
         rateLimited: true,
       };
@@ -44,7 +44,7 @@ async function rateLimitUnapprovedDomains(
       await safePut({
         key: rateLimitKV,
         keyName: rlKey,
-        value: (parseInt(count) + 1).toString(),
+        value: (parseInt(count, 10) + 1).toString(),
       });
     } else {
       const gatewayRlList = await rateLimitKV.get(`gateway-rl-list`);

--- a/worker/test/routers/parseintRadix.spec.ts
+++ b/worker/test/routers/parseintRadix.spec.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+// The four files audited in https://github.com/Helicone/helicone/issues/5755.
+// Every parseInt(...) call in these files must pass 10 as the second argument.
+// Sibling files (e.g. walletRouter.ts:178,180) have separate fixes and are
+// intentionally not asserted here.
+const TARGETS = [
+  "worker/src/lib/util/cache/cacheFunctions.ts",
+  "worker/src/lib/util/cache/cacheSettings.ts",
+  "worker/src/lib/models/HeliconeHeaders.ts",
+  "worker/src/routers/gatewayRouter.ts",
+];
+
+// Walk the file looking for `parseInt(` calls. For each one, count parens
+// to find the matching close paren (handles multi-line calls and nested
+// expressions like `headers.get(...)`). If the matched argument list does
+// not contain any top-level comma, no radix was passed.
+function findRadixlessParseIntCalls(
+  text: string
+): Array<{ start: number; end: number; inner: string }> {
+  const out: Array<{ start: number; end: number; inner: string }> = [];
+  const re = /parseInt\(/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const callStart = m.index + "parseInt(".length;
+    let depth = 1;
+    let i = callStart;
+    while (i < text.length && depth > 0) {
+      const ch = text[i];
+      if (ch === "(") depth++;
+      else if (ch === ")") depth--;
+      i++;
+    }
+    if (depth !== 0) continue; // unmatched parseInt( — leave to tsc
+    const callEnd = i - 1; // position of matching ')'
+    const inner = text.slice(callStart, callEnd);
+    if (!inner.includes(",")) {
+      out.push({ start: m.index, end: i, inner: inner.trim() });
+    }
+  }
+  return out;
+}
+
+describe("parseInt radix regression (worker)", () => {
+  for (const rel of TARGETS) {
+    it(`${rel} has no parseInt calls without a radix argument`, () => {
+      const abs = join(import.meta.dirname, "..", "..", "..", rel);
+      const text = readFileSync(abs, "utf8");
+      const offenders = findRadixlessParseIntCalls(text);
+      if (offenders.length > 0) {
+        const snippets = offenders.map((o) => `parseInt(${o.inner})`).join(", ");
+        throw new Error(
+          `parseInt(...) calls without a radix argument in ${rel}: ` +
+            `${snippets}. Every parseInt in the worker must pass 10 ` +
+            `as the second argument (see issue #5755).`
+        );
+      }
+      expect(offenders).toHaveLength(0);
+    });
+  }
+});

--- a/worker/test/routers/vitest.config.mts
+++ b/worker/test/routers/vitest.config.mts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: [],
+  },
+  resolve: {
+    alias: {
+      "@worker": new URL("../../src", import.meta.url).pathname,
+      "@helicone-package/cost": new URL(
+        "../../../packages/cost",
+        import.meta.url
+      ).pathname,
+    },
+  },
+});

--- a/worker/vitest.config.mts
+++ b/worker/vitest.config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
       "./test/alerts/vitest.config.mts",
       "./test/token-limit-exception/vitest.config.mts",
       "./test/rate-limit/vitest.config.mts",
+      "./test/routers/vitest.config.mts",
     ],
   },
 });


### PR DESCRIPTION
## Summary

Adds the `10` radix argument to eight `parseInt` calls across four worker files. Same class of bug as #5751 / #5752, separated out so the walletRouter fix (which also needed a NaN-safe fallback) could land on its own. The eight calls in this PR don't need the NaN fallback — `NaN` already routes through the surrounding `Math.max` / bucket-size / `count` falsy branch.

## Files changed

- `worker/src/lib/util/cache/cacheFunctions.ts` — 1 call (line 91, `Cache-Control: max-age=…` header)
- `worker/src/lib/util/cache/cacheSettings.ts` — 3 calls (lines 25, 27, 57; `s-maxage`/`max-age` regex captures + `Helicone-Cache-Bucket-Max-Size` header)
- `worker/src/lib/models/HeliconeHeaders.ts` — 2 calls (lines 374, 377; `Helicone-Cache-Seed` + `Helicone-Cache-Bucket-Max-Size` headers)
- `worker/src/routers/gatewayRouter.ts` — 2 calls (lines 39, 47; `rateLimitKV` counter, decimal by construction)
- `worker/test/routers/parseintRadix.spec.ts` — new structural regression test
- `worker/test/routers/vitest.config.mts` — new node-env test project
- `worker/vitest.config.mts` — register the new project

## Why

The MDN / TC39 guidance on `parseInt(string, radix)` is explicit: always pass the radix, because the default is implementation-dependent. None of these eight call sites intentionally accept hex — they all parse either regex captures, decimal HTTP-header values, or KV stringified integers. The current behavior is also a latent correctness bug (e.g. `parseInt("0x10")` → `16` instead of `0`), not just a lint issue.

## Testing performed

- `npx tsc --noEmit -p worker/tsconfig.json` — clean
- `npx vitest run test/routers/parseintRadix.spec.ts` — 4/4 pass (one per file)
- Verified the regression test **fails** when one of the eight fixes is reverted, then re-applied the fix and re-ran the test → 4/4 pass

The new test walks each of the four files, finds every `parseInt(...)` call (handling multi-line and nested parens via paren counting), and asserts each call's argument list contains a comma — i.e. a radix was passed. Files outside the four in scope (e.g. `walletRouter.ts`, which has its own fix in #5752) are intentionally not asserted.

## Backward compatibility

None. All eight call sites currently produce the same result for any input that starts with a non-zero digit, and the only behavioral change is for inputs that start with `0x`/`0X` (no current input sources produce these), which now correctly parse as `NaN` instead of as hex.

## Risks

None material. The only risk is missing one of the eight call sites in a future PR — the new regression test is the mitigation.

Fixes #5755
