### PR TITLE
fix(worker): add `return` to 3 err() calls in gatewayRouter getProvider (silently bypasses unapproved-domain rate limit)

### DIFF
--- a/worker/src/routers/gatewayRouter.ts
+++ b/worker/src/routers/gatewayRouter.ts
@@ -98,7 +98,7 @@ async function getProvider(
     );
   }
   if (!validateURL(targetBaseUrl)) {
-    err(
+    return err(
       new Response(`Invalid target base url "${targetBaseUrl}"`, {
         status: 400,
       })
@@ -107,7 +107,7 @@ async function getProvider(
   const targetBaseUrlHost = new URL(targetBaseUrl).origin;
 
   if (targetBaseUrlHost !== targetBaseUrl) {
-    err(
+    return err(
       new Response(
         `Target base url "${targetBaseUrl}" must not contain a path, got "${targetBaseUrlHost}"`,
         {
@@ -121,7 +121,7 @@ async function getProvider(
     rateLimitKV
   );
   if (rateLimited) {
-    err(
+    return err(
       new Response(
         `Rate limited unapproved domain! To get your target-url on the list of approved domains to surpase the rate limit please reach out to us at engineering@helicone.ai`,
         {

--- a/worker/test/routers/gatewayRouterErrReturn.spec.ts
+++ b/worker/test/routers/gatewayRouterErrReturn.spec.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+// File audited in https://github.com/Helicone/helicone/issues/5757.
+// Every err(...) call inside getProvider must be preceded by `return`,
+// otherwise the constructed Result is discarded and the guard does nothing.
+const TARGET = "worker/src/routers/gatewayRouter.ts";
+
+describe("gatewayRouter err-return regression (worker)", () => {
+  it(`every err(...) call in getProvider (${TARGET}) is preceded by \`return\``, () => {
+    const text = readFileSync(
+      join(import.meta.dirname, "..", "..", "..", TARGET),
+      "utf8"
+    );
+
+    // Locate the getProvider function body. `function getProviderFromTargetUrl`
+    // is the next top-level declaration after getProvider; using `function ` as
+    // the boundary keeps the slice to exactly the function under test.
+    const startMatch = text.match(/async function getProvider\(/);
+    if (!startMatch || startMatch.index === undefined) {
+      throw new Error(`Could not find getProvider in ${TARGET}`);
+    }
+    const bodyStart = startMatch.index;
+    const tail = text.slice(bodyStart);
+    const endMatch = tail.match(/\n(?=function |export )/);
+    const bodyEnd = endMatch ? bodyStart + endMatch.index : text.length;
+    const body = text.slice(bodyStart, bodyEnd);
+
+    // Strip block + line comments so a comment that mentions `err(...)` is not
+    // mistaken for a real call site.
+    const stripped = body
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\/.*$/gm, "");
+
+    const offenders: number[] = [];
+    stripped.split("\n").forEach((line, i) => {
+      if (/\berr\s*\(/.test(line) && !/^\s*return\s+err\s*\(/.test(line)) {
+        offenders.push(i + 1);
+      }
+    });
+
+    if (offenders.length > 0) {
+      throw new Error(
+        `err(...) calls in getProvider without a leading \`return\` at ` +
+          `line(s) ${offenders.join(", ")} relative to the function start. ` +
+          `Calling err() without \`return\` discards the Result — see #5757.`
+      );
+    }
+    expect(offenders).toHaveLength(0);
+  });
+});

--- a/worker/test/routers/vitest.config.mts
+++ b/worker/test/routers/vitest.config.mts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: [],
+  },
+  resolve: {
+    alias: {
+      "@worker": new URL("../../src", import.meta.url).pathname,
+      "@helicone-package/cost": new URL(
+        "../../../packages/cost",
+        import.meta.url
+      ).pathname,
+    },
+  },
+});

--- a/worker/vitest.config.mts
+++ b/worker/vitest.config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
       "./test/alerts/vitest.config.mts",
       "./test/token-limit-exception/vitest.config.mts",
       "./test/rate-limit/vitest.config.mts",
+      "./test/routers/vitest.config.mts",
     ],
   },
 });


### PR DESCRIPTION
## Summary

Adds the missing `return` keyword in front of three `err(...)` calls in `worker/src/routers/gatewayRouter.ts:getProvider`. `err` is a pure constructor (see `worker/src/lib/util/results.ts:53-55`), so calling it as a statement silently discards the `Result` it returns. The three affected guards construct a `Response` and then continue to the happy path:

1. **`if (!validateURL(targetBaseUrl))`** (line 100) — invalid URL → the next-line `new URL()` throws → 500 instead of the intended 400.
2. **`if (targetBaseUrlHost !== targetBaseUrl)`** (line 109) — path-bearing `targetBaseUrl` is silently forwarded to the provider, bypassing the path-rejection invariant.
3. **`if (rateLimited)`** (line 123) — the 10,000/day unapproved-domain rate limit is silently bypassed. The 429 Response is constructed and discarded; `proxyForwarder` runs as if no rate limit had fired. **This is the most serious of the three** — a bad actor can DoS a non-approved upstream through the gateway with no throttling.

The `gatewayForwarder` caller is already wired to return the error when `getProvider` returns one; adding `return` in front of each `err(...)` is the minimum correct fix.

## Files changed

- `worker/src/routers/gatewayRouter.ts` — 3 `return` keywords added (+3/-3)
- `worker/test/routers/gatewayRouterErrReturn.spec.ts` — new structural regression test
- `worker/test/routers/vitest.config.mts` — node-env test project
- `worker/vitest.config.mts` — register the new project

## Why

Three missing `return` keywords have been in this file since 2023-11-20 (Justin Torre, via `git blame`). The third one — the silent rate-limit bypass — is exploitable today. The structural shape is a textbook "looks like a guard, but isn't" bug: the error message is correct, the status code is correct, the `err()` call is correct, the `Result` is correct — and yet none of it matters because the value is dropped on the floor.

## Testing performed

- `npx tsc --noEmit -p worker/tsconfig.json` — clean
- `npx vitest run test/routers/gatewayRouterErrReturn.spec.ts` — 1/1 pass
- Verified the regression test **fails** when any of the three `return`s is reverted (reverted the line-124 `return`, test failed with `err(...) calls in getProvider without a leading \`return\` at line(s) 45 relative to the function start`), then re-applied → 1/1 pass

The new test reads `gatewayRouter.ts`, locates the `getProvider` function body (via the `async function getProvider(` opener and the next `function ` / `export ` boundary), strips block + line comments so a comment mentioning `err(...)` is not mistaken for a call site, and asserts every `err(...)` call in the function body is preceded by `return` on the same line. Same node-env / file-read pattern as #5755 / #5756.

## Backward compatibility

- **Unapproved-domain rate limit**: behavior changes — the rate limit starts being enforced. This is a *bug fix*, not a breaking change: the limit was advertised (`// Only allow 10,000 requests per day per unapproved domain` at line 27) and intended; today it just doesn't fire. The 429 error message points customers to `engineering@helicone.ai` to get on the approved-domains list.
- **Invalid URL**: behavior changes from unhandled-500 to a clean 400 with a body. Strictly better.
- **Path-bearing URL**: behavior changes from "forwarded as-is" to "rejected with 400". The error message (`must not contain a path`) was always a stated invariant; the validation was just never enforced. No customer can have been relying on a silently-accepted path because the message itself documents the constraint.

## Risks

- A customer using an unapproved upstream with >10k requests/day will start getting 429s. The error body points them to the resolution path. This is the right resolution.
- The unhandled-exception case for invalid URLs (which today returns 500) will start returning 400. If anything in the worker logs the 500 and pages on it, that page will stop. This is the correct fix — the 500 was a bug, not a signal.

## Out of scope (documented in #5757)

- A wider refactor of `getProvider` to use early `throw` instead of the `Result` pattern. The `Result` shape is used throughout the file; changing it would be a much larger change.
- The pre-existing `worker/test/ai-gateway` `Cannot find module '@helicone-package/cost/costCalc'` failure that affects 22 of 32 worker test files. This PR is worker-only and does not touch that config.

Fixes #5757
