### PR TITLE
fix(worker): propagate parseModelString errors from AttemptBuilder.buildAttempts (TODO flagged in source)

### DIFF
--- a/worker/src/lib/ai-gateway/AttemptBuilder.ts
+++ b/worker/src/lib/ai-gateway/AttemptBuilder.ts
@@ -14,7 +14,7 @@ import {
 } from "@helicone-package/cost/models/types";
 import { parseModelString } from "@helicone-package/cost/models/provider-helpers";
 import { ProviderKeysManager } from "../managers/ProviderKeysManager";
-import { isErr } from "../util/results";
+import { isErr, Result, ok, err } from "../util/results";
 import { Attempt } from "./types";
 import { ProviderKey } from "../db/ProviderKeysStore";
 import { PluginHandler } from "./PluginHandler";
@@ -42,17 +42,15 @@ export class AttemptBuilder {
     bodyMapping: BodyMappingType = "OPENAI",
     plugins?: Plugin[],
     globalIgnoreProviders?: Set<ModelProviderName>
-  ): Promise<Attempt[]> {
+  ): Promise<Result<Attempt[], string>> {
     const allAttempts: Attempt[] = [];
 
     for (const modelString of modelStrings) {
       const modelSpec = parseModelString(modelString);
 
-      // Skip invalid model specs
-      // TODO: Return error
       if (isErr(modelSpec)) {
-        console.error(`Skipping invalid model: ${modelSpec.error}`);
-        continue;
+        console.error(`Invalid model string: ${modelSpec.error}`);
+        return err(modelSpec.error);
       }
 
       if (modelSpec.data.provider) {
@@ -80,12 +78,14 @@ export class AttemptBuilder {
 
     // Filter explicit provider routing attempts (not filtered in buildAttemptsForAllProviders)
     if (globalIgnoreProviders && globalIgnoreProviders.size > 0) {
-      return allAttempts.filter(
-        (attempt) => !globalIgnoreProviders.has(attempt.endpoint.provider)
+      return ok(
+        allAttempts.filter(
+          (attempt) => !globalIgnoreProviders.has(attempt.endpoint.provider)
+        )
       );
     }
 
-    return allAttempts;
+    return ok(allAttempts);
   }
 
   private async buildAttemptsForAllProviders(

--- a/worker/src/lib/ai-gateway/SimpleAIGateway.ts
+++ b/worker/src/lib/ai-gateway/SimpleAIGateway.ts
@@ -173,7 +173,7 @@ export class SimpleAIGateway {
           this.traceContext
         )
       : null;
-    let attempts = await this.attemptBuilder.buildAttempts(
+    const attemptsResult = await this.attemptBuilder.buildAttempts(
       modelStrings,
       this.orgId,
       bodyMapping,
@@ -181,6 +181,18 @@ export class SimpleAIGateway {
       globalIgnoreProviders
     );
     this.tracer.finishSpan(buildSpan);
+
+    if (isErr(attemptsResult)) {
+      errors.push({
+        source: "Invalid model",
+        type: "request_failed",
+        message: attemptsResult.error,
+        statusCode: 400,
+      });
+      return this.createErrorResponse(errors);
+    }
+
+    let attempts = attemptsResult.data;
 
     // Filter out helicone provider attempts when x-stripe-customer-id is present
     // to ensure Stripe meter events are only sent for actual external provider usage

--- a/worker/test/routers/attemptBuilderErrorPropagation.spec.ts
+++ b/worker/test/routers/attemptBuilderErrorPropagation.spec.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+// Files audited in https://github.com/Helicone/helicone/issues/5759.
+// The fix converts `AttemptBuilder.buildAttempts` from
+//   Promise<Attempt[]>
+// to
+//   Promise<Result<Attempt[], string>>
+// and propagates the error to the caller in SimpleAIGateway so a typo
+// in a model string produces a 400 with the parser's message instead
+// of being silently dropped from the fallback list.
+const ATTEMPT_BUILDER = "worker/src/lib/ai-gateway/AttemptBuilder.ts";
+const SIMPLE_GATEWAY = "worker/src/lib/ai-gateway/SimpleAIGateway.ts";
+
+describe("AttemptBuilder error propagation regression (worker)", () => {
+  const builderSrc = readFileSync(
+    join(import.meta.dirname, "..", "..", "..", ATTEMPT_BUILDER),
+    "utf8"
+  );
+  const gatewaySrc = readFileSync(
+    join(import.meta.dirname, "..", "..", "..", SIMPLE_GATEWAY),
+    "utf8"
+  );
+
+  it("buildAttempts return type is Result<Attempt[], string> (not bare Attempt[])", () => {
+    // The public buildAttempts signature must declare
+    //   ): Promise<Result<Attempt[], string>> {
+    // Use a literal substring check (avoiding regex on nested generics).
+    // The string "Promise<Result<Attempt[], string>>" must appear
+    // between the `async buildAttempts(` opener and the first closing `}`.
+    const opener = builderSrc.indexOf("async buildAttempts(");
+    expect(opener, "buildAttempts opener not found").toBeGreaterThanOrEqual(0);
+    // Search from the opener; the signature should be near the start.
+    const tail = builderSrc.slice(opener);
+    expect(
+      tail,
+      "buildAttempts does not return Result<Attempt[], string>"
+    ).toContain("Promise<Result<Attempt[], string>>");
+    // Negative control: the public buildAttempts must NOT have the old return
+    // type. The private buildAttemptsForAllProviders (which returns Attempt[])
+    // exists later in the file; ensure the public one is not the match by
+    // checking the substring "Promise<Attempt[]>" does not appear within
+    // ~600 chars of the public opener (i.e. inside the public signature).
+    const publicTail = tail.slice(0, 600);
+    expect(
+      publicTail,
+      "public buildAttempts still returns bare Attempt[]"
+    ).not.toContain("Promise<Attempt[]>");
+  });
+
+  it("the maintainer TODO and silent-skip log are removed from the error branch", () => {
+    // The old code had:
+    //   // TODO: Return error
+    //   if (isErr(modelSpec)) {
+    //     console.error(`Skipping invalid model: ${modelSpec.error}`);
+    //     continue;
+    //   }
+    expect(builderSrc, "maintainer TODO still in source").not.toMatch(
+      /\/\/\s*TODO:\s*Return\s+error/i
+    );
+    expect(
+      builderSrc,
+      "old silent-skip log still in source"
+    ).not.toMatch(/Skipping\s+invalid\s+model/);
+  });
+
+  it("the isErr(modelSpec) branch returns err(...) instead of continuing", () => {
+    // The old code had:
+    //   if (isErr(modelSpec)) {
+    //     console.error(`Skipping invalid model: ${modelSpec.error}`);
+    //     continue;
+    //   }
+    // The new code must call `return err(modelSpec.error)` (literal
+    // substring) and must not use `continue` inside the block.
+    // We use a substring check rather than a block-boundary regex because
+    // the block body contains a template literal whose `${...}` braces
+    // confuse non-greedy `[\s\S]*?\}` matching.
+    const isErrIdx = builderSrc.indexOf("if (isErr(modelSpec))");
+    expect(isErrIdx, "isErr(modelSpec) guard not found").toBeGreaterThanOrEqual(0);
+    // Window the next 400 chars after the guard opener; the block body
+    // fits comfortably in this window.
+    const window = builderSrc.slice(isErrIdx, isErrIdx + 400);
+    expect(window, "isErr branch does not return err(modelSpec.error)").toContain(
+      "return err(modelSpec.error)"
+    );
+    // The old silent-skip pattern: `continue;` as a bare statement at the
+    // start of a line inside the block. We assert it is gone in the same
+    // window.
+    expect(
+      window,
+      "isErr branch still uses bare `continue;` to skip the bad model"
+    ).not.toMatch(/^\s*continue\s*;?\s*$/m);
+  });
+
+  it("SimpleAIGateway checks isErr(attemptsResult) before using attempts", () => {
+    // After the buildAttempts call there must be a `isErr(attemptsResult)`
+    // check that pushes a 400 error and returns. We assert the source and
+    // statusCode are set so the user-facing 400 message names the bad model.
+    const openerIdx = gatewaySrc.indexOf("isErr(attemptsResult)");
+    expect(openerIdx, "isErr(attemptsResult) guard not found").toBeGreaterThanOrEqual(
+      0
+    );
+    // Window the next 400 chars; the handler body fits in this range.
+    const window = gatewaySrc.slice(openerIdx, openerIdx + 400);
+    expect(window, "handler missing `source: \"Invalid model\"`").toContain(
+      'source: "Invalid model"'
+    );
+    expect(window, "handler missing statusCode: 400").toContain("statusCode: 400");
+  });
+});

--- a/worker/test/routers/vitest.config.mts
+++ b/worker/test/routers/vitest.config.mts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: [],
+  },
+  resolve: {
+    alias: {
+      "@worker": new URL("../../src", import.meta.url).pathname,
+      "@helicone-package/cost": new URL(
+        "../../../packages/cost",
+        import.meta.url
+      ).pathname,
+    },
+  },
+});

--- a/worker/vitest.config.mts
+++ b/worker/vitest.config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
       "./test/alerts/vitest.config.mts",
       "./test/token-limit-exception/vitest.config.mts",
       "./test/rate-limit/vitest.config.mts",
+      "./test/routers/vitest.config.mts",
     ],
   },
 });


### PR DESCRIPTION
## Summary

`AttemptBuilder.buildAttempts` in `worker/src/lib/ai-gateway/AttemptBuilder.ts:39` returned `Promise<Attempt[]>` and silently dropped any model string that failed `parseModelString` (typo, deprecated id, unknown model). The maintainer flagged this in source with a `// TODO: Return error` comment and a `console.error(...Skipping invalid model...)` log.

A user request with `modelStrings: ["gpt-4o", "gpt-4o-min"]` (typo on the second) currently degrades to a 200 with the typo'd entry silently removed from the fallback list. The user gets no signal that one of their model ids was rejected — they just don't see the fallback they expected. The empty-array check at `SimpleAIGateway.ts:193` then fires a generic "No available providers" 400 that blames the provider configuration rather than the typo.

This change converts `buildAttempts` to `Promise<Result<Attempt[], string>>` and returns `err(modelSpec.error)` on the first invalid model. The caller in `SimpleAIGateway.ts` checks `isErr(attemptsResult)` and builds a 400 with `source: "Invalid model"` and the parser's message, mirroring the existing empty-array 400 path.

The `console.error` log is preserved (renamed to `Invalid model string` to match the new return-error semantics) so operators still see the bad input in logs.

## Files changed

- `worker/src/lib/ai-gateway/AttemptBuilder.ts` — return type + 2-line body change + final-return wrap (18 lines)
- `worker/src/lib/ai-gateway/SimpleAIGateway.ts` — 1 Result check, 1 error push, 1 return (14 lines)
- `worker/test/routers/attemptBuilderErrorPropagation.spec.ts` — new structural regression test
- `worker/test/routers/vitest.config.mts` — node-env test project
- `worker/vitest.config.mts` — register the new project

## Why

The maintainer explicitly flagged this with a `// TODO: Return error` comment on the exact line where the silent skip happens. The bug pattern is the same shape as #5751 / #5752 / #5757 (silently-discarded `Result` that should propagate) but in a different function and a different layer of the AI-gateway stack.

The `console.error` log in the silent-skip path is also misleading — it says "Skipping" but the user's request is actually proceeding with the partial model set, so the operator's log indicates a no-op that didn't happen.

## Testing performed

- `npx tsc --noEmit -p worker/tsconfig.json` — clean
- `npx vitest run test/routers/attemptBuilderErrorPropagation.spec.ts` — 4/4 pass
- Verified the regression test **fails** when the `isErr` branch is reverted to `console.error(Skipping invalid model) + continue;` (2 of 4 tests fail with clear messages pointing at the restored TODO marker and the missing `return err(modelSpec.error)`), then re-applied → 4/4 pass

The new test reads both source files and asserts four structural properties:
1. The public `buildAttempts` signature declares `Promise<Result<Attempt[], string>>` and the literal `Promise<Attempt[]>` does not appear within 600 chars of the public opener (so the test specifically targets the public function and ignores the private `buildAttemptsForAllProviders` which correctly returns `Promise<Attempt[]>`).
2. The maintainer's `// TODO: Return error` comment and the `Skipping invalid model` log line are gone.
3. The `if (isErr(modelSpec))` block contains `return err(modelSpec.error)` and no bare `continue;` (uses a 400-char substring window after the guard opener to avoid being confused by the template literal's `${...}` braces).
4. The caller in `SimpleAIGateway` has an `if (isErr(attemptsResult))` handler with `source: "Invalid model"` and `statusCode: 400`.

Same node-env / file-read pattern as the prior PRs in this session (#5752, #5755, #5756, #5757, #5758).

## Backward compatibility

A user who relied on the silent-skip behavior (e.g. a caller passing a list that intentionally includes "may or may not exist" model ids and falling through to whichever does) will see a behavior change. This is the correct UX — the silent skip was a bug, not a feature — but it is a behavior change for that niche case. No known in-repo caller relies on it. The `console.error` log is preserved as a side effect of the error path.

## Risks

- A user with a long-standing script that includes a typo'd model id in a fallback list (and has been quietly working on the partial set) will start getting 400s. The error message points them to the typo (which they can fix) and to the supported-models page. This is the right resolution.

## Out of scope (documented in #5759)

- A wider change to collect *all* invalid model errors and return them together (one request with 3 typos → 3 error messages) is a clean follow-up, but a wider change to the response shape and the `errors` array. The first-error behavior matches the maintainer's TODO and is the minimum-scope fix.
- The `heliconeProviderToModelProviderName` switch in `provider-helpers.ts:18-86` has a parallel pattern (returns `null` for unknown provider names), but the call sites treat `null` as "no mapping" rather than as a hard error. That code path is out of scope.

Fixes #5759
