### PR TITLE
fix(cost): tier Anthropic cached-input reads by the long-context threshold

### DIFF
--- a/packages/__tests__/cost/anthropic-cache-tier.test.ts
+++ b/packages/__tests__/cost/anthropic-cache-tier.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "@jest/globals";
+import { calculateModelCostBreakdown } from "../../cost/models/calculate-cost";
+
+// claude-4.5-sonnet:anthropic has two pricing tiers:
+//   threshold 0:      input 0.000003, cacheMultipliers.cachedInput 0.1
+//   threshold 200000: input 0.000006  (cacheMultipliers inherited from the base tier)
+//
+// Above 200k prompt tokens the input rate doubles, and a cached read is priced as a
+// multiple of the input rate, so it should double too. This pins that cached reads pick
+// the same long-context tier as input and output do.
+describe("Anthropic long-context cache pricing", () => {
+  const providerModelId = "claude-sonnet-4-5-20250929";
+
+  it("prices cached reads at the >200k tier, like input and output", () => {
+    const breakdown = calculateModelCostBreakdown({
+      modelUsage: {
+        input: 250_000, // above the 200k threshold on its own
+        output: 1_000,
+        cacheDetails: { cachedInput: 100_000 },
+      },
+      providerModelId,
+      provider: "anthropic",
+    });
+
+    expect(breakdown).not.toBeNull();
+    // input:  250_000 * 0.000006             = 1.5
+    // cached: 100_000 * 0.000006 * 0.1       = 0.06  (base tier would give 0.03)
+    expect(breakdown?.inputCost).toBeCloseTo(1.5, 10);
+    expect(breakdown?.cachedInputCost).toBeCloseTo(0.06, 10);
+  });
+
+  it("prices cached reads at the base tier below the threshold", () => {
+    const breakdown = calculateModelCostBreakdown({
+      modelUsage: {
+        input: 10_000,
+        output: 1_000,
+        cacheDetails: { cachedInput: 5_000 },
+      },
+      providerModelId,
+      provider: "anthropic",
+    });
+
+    expect(breakdown).not.toBeNull();
+    // Base tier: cached 5_000 * 0.000003 * 0.1 = 0.0015
+    expect(breakdown?.cachedInputCost).toBeCloseTo(0.0015, 10);
+  });
+});

--- a/packages/cost/models/calculate-cost.ts
+++ b/packages/cost/models/calculate-cost.ts
@@ -142,9 +142,14 @@ function getThresholdValueFunction(provider: ModelProviderName): (usage: ModelUs
         switch (field) {
           case "inputCost":
           case "outputCost":
-            return usage.input + 
-              (usage.cacheDetails?.cachedInput ?? 0) + 
-              (usage.cacheDetails?.write5m ?? 0) + 
+          // Cached reads are tiered by the same long-context threshold as input/output:
+          // above 200k prompt tokens Anthropic charges the higher input rate, and the
+          // cached-read price is a multiple of that rate. Without this case the field fell
+          // through to 0 and cached reads were always priced at the base tier.
+          case "cachedInputCost":
+            return usage.input +
+              (usage.cacheDetails?.cachedInput ?? 0) +
+              (usage.cacheDetails?.write5m ?? 0) +
               (usage.cacheDetails?.write1h ?? 0);
           default:
             return 0;


### PR DESCRIPTION
## Problem

`getThresholdValueFunction` returns, per provider, the token count used to pick which pricing tier applies to a given cost field. The `anthropic` branch handles `inputCost` and `outputCost` but has no `cachedInputCost` case, so that field falls through to `default: return 0`. Every other provider that tiers (`vertex`, `xai`, `google-ai-studio`) has a `cachedInputCost` case.

Because the threshold value is always 0 for Anthropic cached reads, `getPricingTier` always returns the base tier for them, even on a request past the long-context threshold.

Concretely, `claude-4.5-sonnet:anthropic` prices:

```
threshold 0:      input 0.000003, cacheMultipliers.cachedInput 0.1
threshold 200000: input 0.000006  (cacheMultipliers inherited)
```

A cached read is priced as `cachedInput * tier.input * cacheMultipliers.cachedInput`. Above 200k prompt tokens the input rate doubles, so the cached-read price should double too (0.1 * 0.000006). Instead it stays at the base tier (0.1 * 0.000003), so cached reads on long-context Anthropic requests are billed at half the intended rate. Input and output already tier correctly, so within one request the cached-read rate is inconsistent with the input rate it is derived from.

## Fix

Add the `cachedInputCost` case to the `anthropic` threshold function, returning the same total-prompt value as `inputCost`/`outputCost`. Cached reads now select the same tier as input and output.

## Tests

`packages/__tests__/cost/anthropic-cache-tier.test.ts` checks that a >200k request prices cached reads at the tier-1 rate (0.06 for 100k cached tokens, where the base tier would give 0.03), and that a sub-threshold request still uses the base tier.
