### PR TITLE
fix(worker): split Helicone-Cache-Ignore-Keys on commas (was wrapped in JSON, breaking documented behavior)

### DIFF
--- a/worker/src/lib/models/HeliconeHeaders.ts
+++ b/worker/src/lib/models/HeliconeHeaders.ts
@@ -377,11 +377,14 @@ export class HeliconeHeaders implements IHeliconeHeaders {
           ? parseInt(this.headers.get("Helicone-Cache-Bucket-Max-Size") ?? "0")
           : null,
         cacheControl: this.headers.get("Helicone-Cache-Control") ?? null,
-        cacheIgnoreKeys: this.headers.get("Helicone-Cache-Ignore-Keys")
-          ? JSON.parse(
-            `[${this.headers.get("Helicone-Cache-Ignore-Keys") ?? ""}]`
-          )
-          : null,
+        cacheIgnoreKeys: (() => {
+          const raw = this.headers.get("Helicone-Cache-Ignore-Keys");
+          if (!raw) return null;
+          return raw
+            .split(",")
+            .map((key) => key.trim())
+            .filter((key) => key.length > 0);
+        })(),
       },
       promptName: this.headers.get("Helicone-Prompt-Name") ?? null,
       userId: this.headers.get("Helicone-User-Id") ?? null,

--- a/worker/test/routers/cacheIgnoreKeys.spec.ts
+++ b/worker/test/routers/cacheIgnoreKeys.spec.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+// File audited in https://github.com/Helicone/helicone/issues/5768.
+// The Helicone-Cache-Ignore-Keys header is documented as a comma-separated
+// list of JSON keys. The original code wrapped the value in `[...]` and
+// called JSON.parse, producing a single-element array whose value contained
+// a comma — so the consumer's `delete json[key]` loop did nothing. The fix
+// replaces the wrap-and-parse with split-by-comma + trim + filter-empty.
+const TARGET = "worker/src/lib/models/HeliconeHeaders.ts";
+
+describe("Helicone-Cache-Ignore-Keys parsing regression (worker)", () => {
+  const src = readFileSync(
+    join(import.meta.dirname, "..", "..", "..", TARGET),
+    "utf8"
+  );
+
+  it("does not wrap the header value in `[...]` and call JSON.parse", () => {
+    // The old shape was:
+    //   cacheIgnoreKeys: this.headers.get("Helicone-Cache-Ignore-Keys")
+    //     ? JSON.parse(`[${this.headers.get("Helicone-Cache-Ignore-Keys") ?? ""}]`)
+    //     : null,
+    // We assert the wrap-and-parse pattern is gone.
+    expect(
+      src,
+      "old wrap-and-parse pattern still in source — see #5768"
+    ).not.toMatch(/JSON\.parse\(\s*`\s*\[\$\{/);
+    // Also assert the literal wrapping template `[${...}]` is gone.
+    expect(
+      src,
+      "literal `[${...}]` template still in cacheIgnoreKeys expression"
+    ).not.toMatch(/\[\$\{this\.headers\.get\("Helicone-Cache-Ignore-Keys"\)/);
+  });
+
+  it("splits the header value on commas", () => {
+    // The new shape must call .split(",") on the raw value, within a
+    // reasonable window of the header reference. We use a substring
+    // window (rather than a strict regex) because the source has an IIFE
+    // between the header read and the .split() call, and the regex
+    // would have to span parentheses that belong to that IIFE.
+    const headerIdx = src.indexOf('"Helicone-Cache-Ignore-Keys"');
+    expect(headerIdx, "header reference not found").toBeGreaterThanOrEqual(0);
+    const window = src.slice(headerIdx, headerIdx + 400);
+    expect(
+      window,
+      "Helicone-Cache-Ignore-Keys is not split on commas"
+    ).toContain('.split(",")');
+  });
+
+  it("trims whitespace and drops empty entries", () => {
+    // After .split(",") the chain should .map(trim) and .filter(non-empty).
+    // We accept the chain order (split → map → filter) and look for the
+    // literal calls.
+    expect(src, ".trim() not called on split entries").toMatch(/\.trim\(\)/);
+    expect(src, "empty-entry filter not applied").toMatch(/\.filter\(/);
+  });
+});

--- a/worker/test/routers/vitest.config.mts
+++ b/worker/test/routers/vitest.config.mts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: [],
+  },
+  resolve: {
+    alias: {
+      "@worker": new URL("../../src", import.meta.url).pathname,
+      "@helicone-package/cost": new URL(
+        "../../../packages/cost",
+        import.meta.url
+      ).pathname,
+    },
+  },
+});

--- a/worker/vitest.config.mts
+++ b/worker/vitest.config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
       "./test/alerts/vitest.config.mts",
       "./test/token-limit-exception/vitest.config.mts",
       "./test/rate-limit/vitest.config.mts",
+      "./test/routers/vitest.config.mts",
     ],
   },
 });


### PR DESCRIPTION
## Summary

`worker/src/lib/models/HeliconeHeaders.ts:380-383` parsed the `Helicone-Cache-Ignore-Keys` header by wrapping the raw value in `[...]` and calling `JSON.parse`. The header is documented at `docs/features/advanced-usage/caching.mdx:149-153` as a **comma-separated** list of JSON keys (`"request_id,timestamp"`), so a user following the docs sent a comma-separated value and got back a single-element array `["request_id,timestamp"]`.

The consumer at `worker/src/lib/util/cache/cacheFunctions.ts:50-51` then iterates the array and calls `delete json[key]` — once, with the key `"request_id,timestamp"` (a single string with a comma), which is not a key in the request body. Net effect: a user who follows the docs and sets `Helicone-Cache-Ignore-Keys: request_id,timestamp` gets a silently non-functional cache-ignore, and two requests with different `request_id` values get different cache keys.

This change replaces the wrap-and-parse with `split(",")` + `map(trim)` + `filter(> 0)` so the documented behavior is restored. A user sending `request_id,timestamp` now gets `["request_id", "timestamp"]` and the consumer's loop removes both fields from the cache-key body hash.

## Files changed

- `worker/src/lib/models/HeliconeHeaders.ts` — 8-line change to the `cacheIgnoreKeys` expression (+8/-5)
- `worker/test/routers/cacheIgnoreKeys.spec.ts` — new structural regression test
- `worker/test/routers/vitest.config.mts` — node-env test project
- `worker/vitest.config.mts` — register the new project

## Why

The bug is shape-identical to cycles 8-9 (parseInt radix pass): a documented user-facing string format is parsed in a way that produces the wrong shape. The `Helicone-Cache-Ignore-Keys` feature is opt-in (header-only), so the blast radius is limited to users who actively set the header — but for those users, the feature has been silently broken since it was introduced. The existing test fixtures at `worker/test/cache/cacheFunctions.spec.ts:66, 184` already exercise the consumer with a pre-parsed `["request_id", "timestamp"]` array, so once the parsing is fixed the end-to-end behavior matches the docs and the test fixtures.

## Testing performed

- `npx tsc --noEmit -p worker/tsconfig.json` — clean
- `npx vitest run test/routers/cacheIgnoreKeys.spec.ts` — 3/3 pass
- Verified the regression test **fails** when the wrap-and-parse pattern is restored (2 of 3 tests fail with clear messages — the wrap-and-parse detection test and the `.split(",")` detection test), then re-applied → 3/3 pass

The new test reads the source and asserts three structural properties:
1. The `JSON.parse(\`[${...}]\`)` pattern is gone (the literal template-string wrap).
2. A `.split(",")` call appears within a 400-char window of the `Helicone-Cache-Ignore-Keys` reference (substring-window approach to avoid the IIFE's parentheses confusing a strict regex).
3. `.trim()` and `.filter(` are called on the split entries.

Same node-env / file-read pattern as the prior PRs in this session (#5752, #5755, #5756, #5757, #5758, #5760).

## Backward compatibility

- **A user who was sending a comma-separated value** (the documented format): the user-facing behavior changes from "ignored_keys silently doesn't work" to "ignored_keys works". This is the intended fix.
- **A user who was sending a single key** (e.g. `prompt_cache_key`): identical behavior before and after the fix.
- **A user who was unintentionally sending a JSON-encoded array** (e.g. `["a","b"]`) and getting the nested-array behavior: still broken, in a different way (the keys would now contain the literal `["` prefix and `"]` suffix). This is a noise-only change — no cache key was correctly computed either way, and no doc or test supports the JSON-array format.

The only behavior change that affects a non-broken case is the documented one (comma-separated now splits correctly).

## Risks

- A user who was unintentionally sending a JSON-encoded array and relying on the no-op semantics (i.e. the cache key includes all fields) might notice a behavior change. After the fix, the broken JSON-array input is still broken but the keys contain extra characters. This is a noise-only change — no cache key was correctly computed either way, and a real-world user would have noticed their cache misses long ago.

## Out of scope (documented in #5768)

- The unrelated `cacheSettings.ts` regex bug (where `x-s-maxage=3600` is incorrectly matched as `s-maxage=3600` because the regex has no word boundary) is a separate issue with a narrower blast radius.
- A future improvement to also support a JSON-encoded array format (in addition to comma-separated) would be a wider change to the response shape and the docs.

Fixes #5768
