### PR TITLE
fix(nebius): refresh Token Factory integration

### DIFF
--- a/docs/getting-started/integration-method/nebius.mdx
+++ b/docs/getting-started/integration-method/nebius.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Nebius Token Factory Integration"
 sidebarTitle: "Nebius Token Factory"
-description: "Connect Helicone with Nebius Token Factory, a platform that provides powerful AI models including text and multimodal models, embeddings and guardrails, and text-to-image models."
+description: "Send supported Nebius Token Factory API requests through Helicone's legacy provider gateway for observability."
 "twitter:title": "Nebius Token Factory AI Integration - Helicone OSS LLM Observability"
 ---
 
@@ -34,25 +34,35 @@ Replace the following Nebius Token Factory URL with the Helicone Gateway URL:
 
 `https://api.tokenfactory.nebius.com` -> `https://nebius.helicone.ai`
 
-and then add the following authentication headers:
+and then add the provider and Helicone authentication headers:
 
 ```javascript
-Authorization: Bearer <your API key>
+Authorization: Bearer <your Nebius API key>
+Helicone-Auth: Bearer <your Helicone API key>
 ```
 
 </Step>
 </Steps>
 
-Now you can access all the models on Nebius Token Factory with a simple fetch call:
+The legacy provider gateway preserves the path you send and forwards it to Nebius Token Factory. Check the [Token Factory model catalog](https://tokenfactory.nebius.com/) before choosing a model because availability changes over time.
+
+<Note>
+  Helicone's AI Gateway Nebius provider routes model requests to Chat
+  Completions. Helicone's `/v1/responses` support may translate a request to
+  Chat Completions; it does not provide direct access to the Token Factory
+  Responses API. This legacy integration documents Chat Completions and Image
+  Generations only.
+</Note>
 
 ## Example - Text Completion
 
 ```bash
 curl \
   --header "Authorization: Bearer $NEBIUS_API_KEY" \
+  --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
   --header "Content-Type: application/json" \
   --data '{
-    "model": "deepseek-ai/DeepSeek-R1",
+    "model": "meta-llama/Llama-3.3-70B-Instruct",
     "messages": [
       {
         "role": "user",
@@ -65,12 +75,15 @@ curl \
 
 ## Example - Image Generation
 
+Use a currently available Token Factory image model ID. The placeholder below is intentional so this example does not pin a model that may have been retired.
+
 ```bash
 curl \
   --header "Authorization: Bearer $NEBIUS_API_KEY" \
+  --header "Helicone-Auth: Bearer $HELICONE_API_KEY" \
   --header "Content-Type: application/json" \
   --data '{
-    "model": "black-forest-labs/flux-schnell",
+    "model": "<current-image-model-id>",
     "prompt": "A beautiful sunset over a mountain landscape"
 }' \
   --url https://nebius.helicone.ai/v1/images/generations

--- a/packages/__tests__/cost/providers/nebius.test.ts
+++ b/packages/__tests__/cost/providers/nebius.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "@jest/globals";
+import { registry } from "../../../cost/models/registry";
+import {
+  buildEndpointUrl,
+  buildRequestBody,
+} from "../../../cost/models/provider-helpers";
+import { NebiusProvider } from "../../../cost/models/providers/nebius";
+
+describe("Nebius Token Factory provider", () => {
+  const provider = new NebiusProvider();
+
+  it("routes AI Gateway requests to Chat Completions", () => {
+    const config = registry.getModelProviderConfig(
+      "llama-3.3-70b-instruct",
+      "nebius",
+    );
+    expect(config.data).toBeDefined();
+
+    const endpoint = registry.buildEndpoint(config.data!, {});
+    expect(endpoint.data).toBeDefined();
+
+    const result = buildEndpointUrl(endpoint.data!, {
+      bodyMapping: "OPENAI",
+    });
+
+    expect(result.data).toBe(
+      "https://api.tokenfactory.nebius.com/v1/chat/completions",
+    );
+  });
+
+  it("uses the current Token Factory model ID and public pricing", async () => {
+    const config = registry.getModelProviderConfig(
+      "llama-3.3-70b-instruct",
+      "nebius",
+    );
+    expect(config.data).toBeDefined();
+    expect(config.data?.providerModelId).toBe(
+      "meta-llama/Llama-3.3-70B-Instruct",
+    );
+    expect(config.data?.pricing).toEqual([
+      {
+        threshold: 0,
+        input: 0.00000013,
+        output: 0.0000004,
+      },
+    ]);
+
+    const endpoint = registry.buildEndpoint(config.data!, {});
+    expect(endpoint.data).toBeDefined();
+
+    const result = await buildRequestBody(endpoint.data!, {
+      parsedBody: {
+        model: "llama-3.3-70b-instruct/nebius",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+      bodyMapping: "OPENAI",
+      toAnthropic: (body: any) => body,
+      toChatCompletions: (body: any) => body,
+    });
+
+    expect(result.error).toBeNull();
+    expect(JSON.parse(result.data!)).toMatchObject({
+      model: "meta-llama/Llama-3.3-70B-Instruct",
+      messages: [{ role: "user", content: "Hello" }],
+    });
+  });
+
+  it("returns a Token Factory detail error", async () => {
+    const result = await provider.buildErrorMessage(
+      new Response(JSON.stringify({ detail: "Invalid API key" }), {
+        status: 401,
+      }),
+    );
+
+    expect(result.message).toBe("Invalid API key");
+  });
+
+  it("returns an OpenAI-compatible nested error", async () => {
+    const result = await provider.buildErrorMessage(
+      new Response(
+        JSON.stringify({ error: { message: "Model is not available" } }),
+        { status: 404 },
+      ),
+    );
+
+    expect(result.message).toBe("Model is not available");
+  });
+
+  it("falls back to the HTTP status for a malformed error", async () => {
+    const result = await provider.buildErrorMessage(
+      new Response("not-json", { status: 502 }),
+    );
+
+    expect(result.message).toBe("Request failed with status 502");
+  });
+});

--- a/packages/cost/models/providers/nebius.ts
+++ b/packages/cost/models/providers/nebius.ts
@@ -22,7 +22,10 @@ export class NebiusProvider extends BaseProvider {
     try {
       const respJson = (await response.json()) as any;
       return {
-        message: respJson.detail || `Request failed with status ${response.status}`
+        message:
+          respJson.detail ||
+          respJson.error?.message ||
+          `Request failed with status ${response.status}`,
       };
     } catch (error) {
       return { message: `Request failed with status ${response.status}` };

--- a/worker/test/gateway/nebius-routes.spec.ts
+++ b/worker/test/gateway/nebius-routes.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildTargetUrl } from "../../src/lib/clients/ProviderClient";
+
+describe("Nebius Token Factory legacy gateway routes", () => {
+  const tokenFactoryBaseUrl = "https://api.tokenfactory.nebius.com";
+
+  it.each(["/v1/chat/completions", "/v1/images/generations"])(
+    "preserves the %s route",
+    (pathname) => {
+      const gatewayUrl = new URL(`https://nebius.helicone.ai${pathname}`);
+
+      expect(buildTargetUrl(gatewayUrl, tokenFactoryBaseUrl).href).toBe(
+        `${tokenFactoryBaseUrl}${pathname}`
+      );
+    }
+  );
+
+  it("preserves query parameters", () => {
+    const gatewayUrl = new URL(
+      "https://nebius.helicone.ai/v1/chat/completions?region=eu-north1"
+    );
+
+    expect(buildTargetUrl(gatewayUrl, tokenFactoryBaseUrl).href).toBe(
+      `${tokenFactoryBaseUrl}/v1/chat/completions?region=eu-north1`
+    );
+  });
+});

--- a/worker/test/gateway/vitest.config.mts
+++ b/worker/test/gateway/vitest.config.mts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@worker": new URL("../../src", import.meta.url).pathname,
+      "@helicone-package/cost": new URL(
+        "../../../packages/cost",
+        import.meta.url
+      ).pathname,
+      "@helicone-package/llm-mapper": new URL(
+        "../../../packages/llm-mapper",
+        import.meta.url
+      ).pathname,
+    },
+  },
+});

--- a/worker/vitest.config.mts
+++ b/worker/vitest.config.mts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     projects: [
       "./test/ai-gateway/vitest.config.mts",
+      "./test/gateway/vitest.config.mts",
       "./test/cache/vitest.config.mts",
       "./test/alerts/vitest.config.mts",
       "./test/token-limit-exception/vitest.config.mts",


### PR DESCRIPTION
## Ticket

N/A — this refreshes the existing Nebius Token Factory integration; it does not add a new provider.

## Component/Service

- [ ] Web (Frontend)
- [ ] Jawn (Backend)
- [x] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [x] AI Gateway
- [x] Packages
- [ ] Infrastructure/Docker
- [x] Documentation

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes

- [x] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos

Not applicable (docs and provider behavior only).

## Extra Notes

- The existing `llama-3.3-70b-instruct:nebius` model ID and $0.13/$0.40 per-million-token pricing were re-verified against the [public Token Factory catalog](https://tokenfactory.nebius.com/api/public/models_info) on 2026-08-13, so this PR adds regression coverage instead of changing correct registry data.
- The Image Generations example now uses an explicit current-model placeholder because no image-generation model is present in the public catalog at the time of this update. The route remains covered as transparent legacy-proxy behavior.
- This does not claim direct Token Factory Responses API support. Helicone's AI Gateway Nebius provider targets Chat Completions; Helicone may translate Responses-format input to that endpoint.

## Context

The existing integration page used retired model examples, omitted the required `Helicone-Auth` header from both runnable requests, and did not distinguish the transparent legacy proxy from the chat-only AI Gateway provider mapping. The Nebius provider also ignored standard OpenAI-compatible `{ "error": { "message": ... } }` error bodies.

This change:

- updates the chat example to the currently active `meta-llama/Llama-3.3-70B-Instruct` model;
- removes the retired hard-coded image model while preserving the documented image route;
- adds the missing Helicone authentication header;
- documents the Chat Completions / Responses boundary;
- accepts both Token Factory `detail` errors and OpenAI-compatible nested errors;
- adds request, pricing, error, and chat/image path-preservation regression tests.

## Tests

- `yarn jest --config packages/jest.config.ts --runInBand packages/__tests__/cost/providers/nebius.test.ts` (5 passed)
- `yarn workspace helicone-worker test:run --config test/gateway/vitest.config.mts test/gateway/nebius-routes.spec.ts` (3 passed)
- `yarn workspace helicone-worker lint` (passed; existing warnings only)
- `yarn prettier --check docs/getting-started/integration-method/nebius.mdx packages/cost/models/providers/nebius.ts packages/__tests__/cost/providers/nebius.test.ts worker/test/gateway/nebius-routes.spec.ts worker/test/gateway/vitest.config.mts worker/vitest.config.mts`

