### PR TITLE
feat: add Crusoe as a provider

### DIFF
--- a/packages/cost/models/providers/crusoe.ts
+++ b/packages/cost/models/providers/crusoe.ts
@@ -1,0 +1,33 @@
+import { BaseProvider } from "./base";
+import type { Endpoint, RequestParams } from "../types";
+
+export class CrusoeProvider extends BaseProvider {
+  readonly displayName = "Crusoe";
+  readonly baseUrl = "https://api.inference.crusoecloud.com/v1/";
+  readonly auth = "api-key" as const;
+  readonly pricingPages = ["https://www.crusoe.ai/cloud/pricing"];
+  readonly modelPages = [
+    "https://docs.crusoecloud.com/managed-inference/overview",
+  ];
+
+  buildUrl(endpoint: Endpoint, requestParams: RequestParams): string {
+    return `${this.baseUrl}chat/completions`;
+  }
+
+  async buildErrorMessage(response: Response): Promise<{
+    message: string;
+    details?: any;
+  }> {
+    try {
+      const respJson = (await response.json()) as any;
+      return {
+        message:
+          respJson.error?.message ||
+          respJson.detail ||
+          `Request failed with status ${response.status}`,
+      };
+    } catch (error) {
+      return { message: `Request failed with status ${response.status}` };
+    }
+  }
+}

--- a/packages/cost/models/providers/index.ts
+++ b/packages/cost/models/providers/index.ts
@@ -12,6 +12,7 @@ import { GoogleProvider } from "./google";
 import { GroqProvider } from "./groq";
 import { HeliconeProvider } from "./helicone";
 import { MistralProvider } from "./mistral";
+import { CrusoeProvider } from "./crusoe";
 import { NebiusProvider } from "./nebius";
 import { NovitaProvider } from "./novita";
 import { OpenAIProvider } from "./openai";
@@ -36,6 +37,7 @@ export const providers = {
   groq: new GroqProvider(),
   helicone: new HeliconeProvider(),
   mistral: new MistralProvider(),
+  crusoe: new CrusoeProvider(),
   nebius: new NebiusProvider(),
   novita: new NovitaProvider(),
   openai: new OpenAIProvider(),
@@ -80,6 +82,7 @@ export const ResponsesAPIEnabledProviders: ModelProviderName[] = [
   "cerebras",
   "groq",
   "mistral",
+  "crusoe",
   "nebius",
   "novita",
   "openrouter",

--- a/packages/cost/models/providers/priorities.ts
+++ b/packages/cost/models/providers/priorities.ts
@@ -32,6 +32,7 @@ export const PROVIDER_PRIORITIES: Record<ModelProviderName, number> = {
   fireworks: 4,
   groq: 4,
   mistral: 4,
+  crusoe: 4,
   nebius: 4,
   novita: 4,
 

--- a/packages/cost/providers/crusoe/index.ts
+++ b/packages/cost/providers/crusoe/index.ts
@@ -14,6 +14,16 @@ export const costs: ModelRow[] = [
   {
     model: {
       operator: "equals",
+      value: "zai/GLM-5.1",
+    },
+    cost: {
+      prompt_token: 0.0000012,
+      completion_token: 0.0000044,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
       value: "openai/gpt-oss-120b",
     },
     cost: {
@@ -59,6 +69,76 @@ export const costs: ModelRow[] = [
     cost: {
       prompt_token: 0.0000005,
       completion_token: 0.0000015,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "deepseek-ai/DeepSeek-V4-Pro",
+    },
+    cost: {
+      prompt_token: 0.00000174,
+      completion_token: 0.00000348,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "deepseek-ai/Deepseek-V4-Flash",
+    },
+    cost: {
+      prompt_token: 0.00000014,
+      completion_token: 0.00000028,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "Qwen/Qwen3-235B-A22B-Instruct-2507",
+    },
+    cost: {
+      prompt_token: 0.00000022,
+      completion_token: 0.0000008,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
+    },
+    cost: {
+      prompt_token: 0.00000005,
+      completion_token: 0.0000002,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B",
+    },
+    cost: {
+      prompt_token: 0.0000003,
+      completion_token: 0.0000024,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "nvidia/Nemotron-3-Nano-Omni-Reasoning-30B-A3B",
+    },
+    cost: {
+      prompt_token: 0.0000003,
+      completion_token: 0.00000183,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "nvidia/Nemotron-3.5-Lightning-30B-A3B",
+    },
+    cost: {
+      prompt_token: 0.00000005,
+      completion_token: 0.00000003,
     },
   },
 ];

--- a/packages/cost/providers/crusoe/index.ts
+++ b/packages/cost/providers/crusoe/index.ts
@@ -136,9 +136,12 @@ export const costs: ModelRow[] = [
       operator: "equals",
       value: "nvidia/Nemotron-3.5-Lightning-30B-A3B",
     },
+    // The pricing page's output/cached columns are transposed for this row
+    // ($0.03 out / $0.20 cached as printed); the output rate is $0.20 per 1M,
+    // consistent with Nemotron 3 Nano, the other 30B-A3B in the catalog.
     cost: {
       prompt_token: 0.00000005,
-      completion_token: 0.00000003,
+      completion_token: 0.0000002,
     },
   },
 ];

--- a/packages/cost/providers/crusoe/index.ts
+++ b/packages/cost/providers/crusoe/index.ts
@@ -1,0 +1,64 @@
+import { ModelRow } from "../../interfaces/Cost";
+
+export const costs: ModelRow[] = [
+  {
+    model: {
+      operator: "equals",
+      value: "zai/GLM-5.2",
+    },
+    cost: {
+      prompt_token: 0.0000014,
+      completion_token: 0.0000044,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "openai/gpt-oss-120b",
+    },
+    cost: {
+      prompt_token: 0.00000005,
+      completion_token: 0.0000002,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "google/gemma-4-31b-it",
+    },
+    cost: {
+      prompt_token: 0.00000014,
+      completion_token: 0.0000004,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "moonshotai/Kimi-K2.6",
+    },
+    cost: {
+      prompt_token: 0.0000007,
+      completion_token: 0.0000035,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "meta-llama/Llama-3.3-70B-Instruct",
+    },
+    cost: {
+      prompt_token: 0.00000025,
+      completion_token: 0.00000075,
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "deepseek-ai/DeepSeek-V3-0324",
+    },
+    cost: {
+      prompt_token: 0.0000005,
+      completion_token: 0.0000015,
+    },
+  },
+];

--- a/packages/cost/providers/mappings.ts
+++ b/packages/cost/providers/mappings.ts
@@ -8,6 +8,7 @@ import { costs as llamaCosts } from "./llama";
 import { costs as nvidiaCosts } from "./nvidia";
 import { costs as cohereCosts } from "./cohere";
 import { costs as deepseekCosts } from "./deepseek";
+import { costs as crusoeCosts } from "./crusoe";
 import { costs as fireworksAICosts } from "./fireworks";
 import { costs as groqCosts } from "./groq";
 import { costs as mistralCosts } from "./mistral";
@@ -73,6 +74,9 @@ const deepseek = /^https:\/\/api\.deepseek\.com/;
 const x = /^https:\/\/api\.x\.ai/;
 const avianPattern = /^https:\/\/api\.avian\.io/;
 
+// https://api.inference.crusoecloud.com
+const crusoe = /^https:\/\/api\.inference\.crusoecloud\.com/;
+
 //https://api.tokenfactory.nebius.com
 const nebius = /^https:\/\/api\.tokenfactory\.nebius\.com/;
 
@@ -122,6 +126,7 @@ export const providersNames = [
   "DEEPSEEK",
   "X",
   "AVIAN",
+  "CRUSOE",
   "NEBIUS",
   "NOVITA",
   "OPENPIPE",
@@ -170,6 +175,11 @@ export const providers: {
     pattern: azurePattern,
     provider: "AZURE",
     costs: [...azureCosts, ...openAIProvider.costs],
+  },
+  {
+    pattern: crusoe,
+    provider: "CRUSOE",
+    costs: crusoeCosts,
   },
   {
     pattern: nebius,


### PR DESCRIPTION
## Summary

Adds [Crusoe](https://crusoe.ai) Managed Inference as a provider, mirroring the existing Nebius integration.

Crusoe provides an OpenAI-compatible API for open-weight models (GLM 5.2, DeepSeek V3, gpt-oss-120b, Gemma 4, Kimi K2.6, Llama 3.3) at `https://api.inference.crusoecloud.com/v1`. Crusoe is a supported provider in LiteLLM, Pydantic AI, Pipecat, aisuite, the Vercel AI SDK, and the models.dev registry.

### Changes

- `packages/cost/providers/crusoe/index.ts`: per-model costs for the 6 models with published pricing, from [crusoe.ai/cloud/pricing](https://www.crusoe.ai/cloud/pricing)
- `packages/cost/providers/mappings.ts`: endpoint pattern, `CRUSOE` provider name, and cost registration
- `packages/cost/models/providers/crusoe.ts`: provider class mirroring `NebiusProvider`
- `packages/cost/models/providers/index.ts` + `priorities.ts`: registration (priority 4, same tier as Nebius/Novita)

### Notes

- Model IDs match the live catalog exactly (verified against `GET /v1/models`); pricing figures were cross-checked against the public pricing page.
- I left out `web/data/providers.ts` since it references a logo asset. Happy to add that entry plus the logo file if you'd like it in this PR, and to add a docs page in whichever format you now prefer given the legacy-gateway warning on the per-provider pages.

I work at Crusoe and am happy to make any changes to fit how you structure providers.
