### PR TITLE
fix(worker): anchor cacheSettings s-maxage/max-age regex to skip vendor extensions

### DIFF
--- a/worker/src/lib/util/cache/cacheSettings.ts
+++ b/worker/src/lib/util/cache/cacheSettings.ts
@@ -15,8 +15,8 @@ export interface CacheSettings {
 }
 
 function buildCacheControl(cacheControl: string): string {
-  const sMaxAge = cacheControl.match(/s-maxage=(\d+)/)?.[1];
-  const maxAge = cacheControl.match(/max-age=(\d+)/)?.[1];
+  const sMaxAge = cacheControl.match(/(?:^|[\s,;])s-maxage=(\d+)/)?.[1];
+  const maxAge = cacheControl.match(/(?:^|[\s,;])max-age=(\d+)/)?.[1];
 
   if (sMaxAge || maxAge) {
     let sMaxAgeInSeconds = 0;

--- a/worker/test/routers/cacheSettingsRegexWordBoundary.spec.ts
+++ b/worker/test/routers/cacheSettingsRegexWordBoundary.spec.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+// File audited in https://github.com/Helicone/helicone/issues/5780.
+// The regex patterns for s-maxage and max-age in buildCacheControl had
+// no word boundary, so vendor extensions like `x-s-maxage=3600` were
+// matched as `s-maxage=3600`. The fix adds a non-capturing separator
+// group `(?:^|[\s,;])` before the directive name.
+const TARGET = "worker/src/lib/util/cache/cacheSettings.ts";
+
+describe("cacheSettings regex word-boundary regression (worker)", () => {
+  const src = readFileSync(
+    join(import.meta.dirname, "..", "..", "..", TARGET),
+    "utf8"
+  );
+
+  it("s-maxage regex has a separator/anchor before the directive name", () => {
+    // The unanchored form `/s-maxage=(\d+)/` matches anywhere in the
+    // input (including in `x-s-maxage=3600`). The anchored form is
+    // `/(?:^|[\s,;])s-maxage=(\d+)/` — the substring
+    // "(?:^|[\\s,;])s-maxage=" must appear in the source.
+    expect(
+      src,
+      "s-maxage regex has no separator/anchor — `x-s-maxage` would be misidentified as `s-maxage`"
+    ).toContain("(?:^|[\\s,;])s-maxage=");
+  });
+
+  it("max-age regex has a separator/anchor before the directive name", () => {
+    expect(
+      src,
+      "max-age regex has no separator/anchor — `x-max-age` would be misidentified as `max-age`"
+    ).toContain("(?:^|[\\s,;])max-age=");
+  });
+
+  it("the `(\\d+)` capture group is preserved (not preceded by a separator capture)", () => {
+    // The fix uses a non-capturing group `(?:^|[\\s,;])` for the
+    // separator, so the capture group is still `(\\d+)` — the seconds
+    // value. We assert the literal substring `=(\\d+)` appears in both
+    // regexes (i.e. the capture group is directly after the `=`).
+    expect(
+      src,
+      "s-maxage capture group is missing or not capturing digits"
+    ).toContain("s-maxage=(\\d+)");
+    expect(
+      src,
+      "max-age capture group is missing or not capturing digits"
+    ).toContain("max-age=(\\d+)");
+  });
+
+  it("the old unanchored `/s-maxage=(\\d+)/` and `/max-age=(\\d+)/` patterns are gone", () => {
+    // The full literal regex literals: `/s-maxage=(\d+)/` and
+    // `/max-age=(\d+)/`. After the fix, both are inside
+    // `/(?:^|[\s,;]).../`, so these exact substrings should NOT
+    // appear in the source.
+    expect(
+      src,
+      "old unanchored `/s-maxage=(\\d+)/` pattern still in source"
+    ).not.toContain("/s-maxage=(\\d+)/");
+    expect(
+      src,
+      "old unanchored `/max-age=(\\d+)/` pattern still in source"
+    ).not.toContain("/max-age=(\\d+)/");
+  });
+});

--- a/worker/test/routers/vitest.config.mts
+++ b/worker/test/routers/vitest.config.mts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    setupFiles: [],
+  },
+  resolve: {
+    alias: {
+      "@worker": new URL("../../src", import.meta.url).pathname,
+      "@helicone-package/cost": new URL(
+        "../../../packages/cost",
+        import.meta.url
+      ).pathname,
+    },
+  },
+});

--- a/worker/vitest.config.mts
+++ b/worker/vitest.config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
       "./test/alerts/vitest.config.mts",
       "./test/token-limit-exception/vitest.config.mts",
       "./test/rate-limit/vitest.config.mts",
+      "./test/routers/vitest.config.mts",
     ],
   },
 });


### PR DESCRIPTION
## Summary

`worker/src/lib/util/cache/cacheSettings.ts:18-19` uses two regex patterns with no word boundary or separator check:

```ts
/s-maxage=(\d+)/
/max-age=(\d+)/
```

`String.prototype.match` with these patterns matches the **substring** `s-maxage=` (resp. `max-age=`) anywhere in the input — including vendor extensions like `x-s-maxage=3600`, `proxy-s-maxage=3600`, or `x-max-age=1800`. The HTTP spec (RFC 9111 § 5.2.2) lists only the standard cache directives and says vendor extensions starting with `x-` are implementation-defined and should be ignored by standard parsers.

A user who sends `Cache-Control: x-s-maxage=3600, max-age=1800` (a vendor extension that should be ignored) gets the vendor extension incorrectly interpreted as a 1-hour `s-maxage` cache TTL. The `buildCacheControl` function then returns `public, max-age=3600` based on the misinterpreted value, when the user's intent was `max-age=1800`.

Fix: add a non-capturing separator group `(?:^|[\s,;])` before the directive name, requiring the match to be at the start of the string OR preceded by whitespace, a comma, or a semicolon. The character class `[\s,;]` covers all valid HTTP cache-control separators. The non-capturing group `(?:` preserves the original `(\d+)` capture group for the seconds value.

## Files changed

- `worker/src/lib/util/cache/cacheSettings.ts` — 2 regex pattern edits (+2/-2)
- `worker/test/routers/cacheSettingsRegexWordBoundary.spec.ts` — new structural regression test
- `worker/test/routers/vitest.config.mts` — node-env test project
- `worker/vitest.config.mts` — register the new project

## Why

The bug is a real input-parsing defensiveness issue. A vendor extension should be ignored by the standard parser, but the current code is happy to match a vendor extension as the standard directive it happens to contain. The fix is small (2 regex anchors) and the regression test is structural (4 assertions on the regex source). Same category as the prior parseInt work (#5751, #5752, #5755, #5756) — input-parsing defensiveness — but different shape (regex anchoring vs. parseInt argument).

I noted this in `~/.oss-memory/README.md` as "documented as future work" during cycles 11-14 but never filed it. This PR is the follow-up.

## Testing performed

- `npx tsc --noEmit -p worker/tsconfig.json` — clean
- `npx vitest run test/routers/cacheSettingsRegexWordBoundary.spec.ts` — 4/4 pass
- Verified the regression test **fails** when both regexes are restored to the unanchored form (3 of 4 tests fail with clear messages — the two separator/anchor checks and the unanchored-pattern check), then re-applied → 4/4 pass

The new test reads the source and asserts four structural properties (using `src.includes()` for substring checks to avoid the regex-escaping pitfalls I hit on the first attempt):
1. The `s-maxage` regex has the separator/anchor prefix `(?:^|[\s,;])` before the directive name.
2. The `max-age` regex has the separator/anchor prefix before the directive name.
3. The `(\d+)` capture group is preserved (the seconds value, not the separator).
4. The old unanchored `/s-maxage=(\d+)/` and `/max-age=(\d+)/` patterns are gone.

Same node-env / file-read pattern as the prior PRs in this session (#5752, #5755, #5756, #5757, #5758, #5760, #5769, #5772, #5776).

## Backward compatibility

- **A user who was sending a vendor extension like `x-s-maxage=3600` and relying on it to set a 1-hour cache TTL** will now get the default 7-day cache (since neither `s-maxage` nor `max-age` is now matched). This is the correct HTTP-spec behavior — vendor extensions are implementation-defined and should be ignored. No known user relies on the misinterpreted behavior (the docs at `docs/features/advanced-usage/caching.mdx:127-316` only document the standard format).
- **A user who was sending the standard format** (`max-age=3600`, `s-maxage=3600, max-age=1800`, `no-cache, s-maxage=3600`) gets the same behavior as before. The separator-anchored regex matches the same strings the unanchored regex did, plus correctly excludes vendor extensions.

## Risks

- A user who is intentionally relying on the misinterpreted `x-s-maxage=3600` behavior to set a 1-hour cache will get a 7-day cache instead. This is a behavior change, but the previous behavior was a bug — the user should update to use the standard `s-maxage=3600` (without the `x-` prefix) for the documented 1-hour cache. The docs only document the standard format, so no documented user is relying on the vendor extension.

## Out of scope (documented in #5780)

- The fix is similar in spirit to the `#5751` / `#5752` / `#5755` / `#5756` parseInt radix work — a small defensive-coding fix that prevents a subtle misinterpretation. Different shape (regex anchoring vs. parseInt argument), same category (input-parsing defensiveness).
- The fix is in the same file as the cycle 9 parseInt work (`cacheSettings.ts`), but does not overlap with it — the cycle 9 fix touched lines 25, 27 (the `parseInt` calls inside `buildCacheControl`); this issue touches lines 18-19 (the regex anchors). The two fixes compose cleanly.
- The pre-existing worker test infrastructure issue (`Cannot find module '@helicone-package/cost/costCalc'` affecting 22 of 32 worker test files) is unrelated and out of scope.
- The pre-existing tiered-pricing billing bug #5690 (OpenAI long-context underbilling for gpt-5.4) and its siblings #5766, #5767 are unrelated and already filed.

Fixes #5780
