### PR TITLE
fix(cost): cover xai, perplexity, mistral, helicone, and self-canonical aliases in dbProviderToProvider

### DIFF
--- a/packages/__tests__/cost/provider-helpers-db.test.ts
+++ b/packages/__tests__/cost/provider-helpers-db.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "@jest/globals";
+import { dbProviderToProvider } from "../../cost/models/provider-helpers";
+import { providers, ModelProviderName } from "../../cost/models/providers";
+
+// The actual legacy human-readable variants accepted by
+// `dbProviderToProvider`. Several are special-cased (e.g. "AWS Bedrock",
+// "Google AI (Gemini)", "Vertex AI", "XAI", "OpenAI"), so we cannot derive
+// this from the canonical lowercase name by simple capitalisation.
+const LEGACY_ALIASES: Record<ModelProviderName, string[]> = {
+  baseten: ["baseten", "Baseten"],
+  anthropic: ["anthropic", "Anthropic"],
+  azure: ["azure", "Azure OpenAI"],
+  bedrock: ["bedrock", "AWS Bedrock", "aws"],
+  canopywave: ["canopywave", "Canopy Wave"],
+  cerebras: ["cerebras", "Cerebras"],
+  chutes: ["chutes", "Chutes"],
+  deepinfra: ["deepinfra", "DeepInfra"],
+  deepseek: ["deepseek", "DeepSeek"],
+  fireworks: ["fireworks", "Fireworks"],
+  "google-ai-studio": ["google", "google-ai-studio", "Google AI (Gemini)"],
+  groq: ["groq", "Groq"],
+  helicone: ["helicone", "Helicone"],
+  mistral: ["mistral", "Mistral"],
+  nebius: ["nebius", "Nebius"],
+  novita: ["novita", "Novita"],
+  openai: ["openai", "OpenAI"],
+  openrouter: ["openrouter", "OpenRouter"],
+  perplexity: ["perplexity", "Perplexity"],
+  vertex: ["vertex", "Vertex AI"],
+  xai: ["xai", "XAI"],
+};
+
+describe("dbProviderToProvider legacy-format adapter", () => {
+  it("exposes a legacy alias for every provider in the providers map", () => {
+    const canonicalNames = Object.keys(providers) as ModelProviderName[];
+    expect(canonicalNames.length).toBeGreaterThanOrEqual(21);
+    for (const name of canonicalNames) {
+      expect(LEGACY_ALIASES[name]).toBeDefined();
+      expect(LEGACY_ALIASES[name].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns the canonical name for the lowercase input for every provider", () => {
+    const canonicalNames = Object.keys(providers) as ModelProviderName[];
+    for (const name of canonicalNames) {
+      expect(dbProviderToProvider(name)).toBe(name);
+    }
+  });
+
+  it("returns the canonical name for every legacy alias in the table", () => {
+    const entries = Object.entries(LEGACY_ALIASES) as [
+      ModelProviderName,
+      string[],
+    ][];
+    for (const [canonical, aliases] of entries) {
+      for (const alias of aliases) {
+        expect(dbProviderToProvider(alias)).toBe(canonical);
+      }
+    }
+  });
+
+  // Spot-check the 4 providers that were silently dropped before this fix.
+  // Each row in `decrypted_provider_keys_v2` whose `provider_name` matched
+  // one of these caused `getDecryptedProviderKeys` to filter the row out
+  // without any log or error.
+  describe("previously-missing providers (regression for the silent drop)", () => {
+    it("maps xai / XAI to canonical xai", () => {
+      expect(dbProviderToProvider("xai")).toBe("xai");
+      expect(dbProviderToProvider("XAI")).toBe("xai");
+    });
+
+    it("maps perplexity / Perplexity to canonical perplexity", () => {
+      expect(dbProviderToProvider("perplexity")).toBe("perplexity");
+      expect(dbProviderToProvider("Perplexity")).toBe("perplexity");
+    });
+
+    it("maps mistral / Mistral to canonical mistral", () => {
+      expect(dbProviderToProvider("mistral")).toBe("mistral");
+      expect(dbProviderToProvider("Mistral")).toBe("mistral");
+    });
+
+    it("maps helicone / Helicone to canonical helicone", () => {
+      expect(dbProviderToProvider("helicone")).toBe("helicone");
+      expect(dbProviderToProvider("Helicone")).toBe("helicone");
+    });
+  });
+
+  it("returns null for unknown provider names", () => {
+    expect(dbProviderToProvider("foo")).toBeNull();
+    expect(dbProviderToProvider("OpenAI Extra")).toBeNull();
+    expect(dbProviderToProvider("")).toBeNull();
+  });
+
+  it("accepts the special-cased vertex alias 'Vertex AI' but not the naive 'Vertex'", () => {
+    // Documents the asymmetry: callers must use the exact legacy form for
+    // vertex. A naive capitalisation ("Vertex") does not match.
+    expect(dbProviderToProvider("vertex")).toBe("vertex");
+    expect(dbProviderToProvider("Vertex AI")).toBe("vertex");
+    expect(dbProviderToProvider("Vertex")).toBeNull();
+  });
+});

--- a/packages/cost/models/provider-helpers.ts
+++ b/packages/cost/models/provider-helpers.ts
@@ -123,10 +123,14 @@ export const dbProviderToProvider = (
   if (provider === "groq" || provider === "Groq") {
     return "groq";
   }
-  if (provider === "google" || provider === "Google AI (Gemini)") {
+  if (
+    provider === "google" ||
+    provider === "google-ai-studio" ||
+    provider === "Google AI (Gemini)"
+  ) {
     return "google-ai-studio";
   }
-  if (provider === "Azure OpenAI") {
+  if (provider === "azure" || provider === "Azure OpenAI") {
     return "azure";
   }
   if (provider === "deepseek" || provider === "DeepSeek") {
@@ -158,6 +162,18 @@ export const dbProviderToProvider = (
   }
   if (provider === "nebius" || provider === "Nebius") {
     return "nebius";
+  }
+  if (provider === "xai" || provider === "XAI") {
+    return "xai";
+  }
+  if (provider === "perplexity" || provider === "Perplexity") {
+    return "perplexity";
+  }
+  if (provider === "mistral" || provider === "Mistral") {
+    return "mistral";
+  }
+  if (provider === "helicone" || provider === "Helicone") {
+    return "helicone";
   }
   return null;
 };


### PR DESCRIPTION
## Summary

Fix `dbProviderToProvider` in `packages/cost/models/provider-helpers.ts` — the
legacy-format adapter for `provider_name` rows in `decrypted_provider_keys_v2`
and related tables. The adapter was incomplete in three ways, all of which
caused the calling code in `ProviderKeysStore.ts:46-61`, `KeyManager.ts:162, 679`,
and `apiKeyController.ts:80, 140` to filter the row out at
`if (!provider) return null;`, silently dropping the user's stored provider
key with no log or error.

### What was missing

1. **Four providers were completely missing from the adapter**: `xai` (with
   the legacy `XAI` alias), `perplexity`, `mistral`, and `helicone`. Any row
   whose `provider_name` matched one of these canonical names was dropped.
2. **`azure` only accepted the legacy `"Azure OpenAI"` alias.** A row whose
   `provider_name` is the canonical `"azure"` was dropped.
3. **`google-ai-studio` only accepted `"google"` and `"Google AI (Gemini)"`.**
   A row whose `provider_name` is the canonical `"google-ai-studio"` was
   dropped. The other 19 providers in the adapter accept their own canonical
   form; this was the one asymmetry.

After this change, all 21 providers in the `providers` map round trip through
the adapter: `dbProviderToProvider(canonical) === canonical` and
`dbProviderToProvider(legacy) === canonical`. Unknown names still return
`null`.

## Why this matters

Concrete consequence: a user who saves an xAI key (or Perplexity, or Mistral,
or the platform-managed Helicone provider key) into
`decrypted_provider_keys_v2` before the row gets migrated to the lowercase
canonical form will have the key silently disappear from
`getDecryptedProviderKeys` results. The AI gateway then falls back to PTB for
those providers even though the user's BYOK is present. There is no error,
no log, no surface signal — just a missing key.

## Test

New file: `packages/__tests__/cost/provider-helpers-db.test.ts` — 9 tests:

- Round trip for every provider in the `providers` map (lowercase input).
- Round trip for every legacy alias in a hand-coded table (covers the
  special-cased forms like `"AWS Bedrock"`, `"Vertex AI"`, `"Google AI (Gemini)"`,
  `"Azure OpenAI"`, `"XAI"`, `"Canopy Wave"`, `"DeepInfra"`).
- Direct regression checks for the four previously-missing providers.
- Negative cases (`null` for unknown names).
- Documents the vertex asymmetry: `"Vertex AI"` matches but `"Vertex"` does
  not.

The two asymmetry bugs (azure, google-ai-studio) were caught by the
round-trip test during development and fixed in the same change.

## Verification

```text
$ npx tsc --noEmit -p worker/tsconfig.json
EXIT=0
```

```text
$ npx tsc --noEmit -p packages/tsconfig.json
# 2 pre-existing test-file errors in helicone.test.ts and getMapperType.test.ts
# (out of scope; same set cycle 7 documented in PR #5749). My change adds 0 new
# errors.
EXIT=1
```

```text
$ cd packages && npx jest --config jest.config.ts
Test Suites: 1 skipped, 42 passed, 42 of 43 total
Tests:       3 skipped, 587 passed, 590 total
```

## Backward compatibility

Additive only. The function is a legacy-format adapter and the new
`ModelProviderName` values are exactly what the rest of the codebase already
uses. No public API change. Pre-existing rows that previously returned `null`
will now return the correct canonical name — this is the desired behaviour.

Fixes #5782
