### PR TITLE
fix(worker): match only real s-maxage and max-age Cache-Control directives

### DIFF
--- a/worker/src/lib/util/cache/cacheSettings.ts
+++ b/worker/src/lib/util/cache/cacheSettings.ts
@@ -15,8 +15,8 @@ export interface CacheSettings {
 }
 
 function buildCacheControl(cacheControl: string): string {
-  const sMaxAge = cacheControl.match(/s-maxage=(\d+)/)?.[1];
-  const maxAge = cacheControl.match(/max-age=(\d+)/)?.[1];
+  const sMaxAge = cacheControl.match(/(?:^|[,;\s])s-maxage=(\d+)/)?.[1];
+  const maxAge = cacheControl.match(/(?:^|[,;\s])max-age=(\d+)/)?.[1];
 
   if (sMaxAge || maxAge) {
     let sMaxAgeInSeconds = 0;

--- a/worker/test/cache/cacheSettings.spec.ts
+++ b/worker/test/cache/cacheSettings.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { getCacheSettings } from "../../src/lib/util/cache/cacheSettings";
+
+const DEFAULT_CACHE_AGE = 60 * 60 * 24 * 7; // 7 days, matches cacheSettings.ts
+
+function cacheControlFrom(cacheControlHeader: string): string | undefined {
+  const result = getCacheSettings(
+    new Headers({
+      "Cache-Control": cacheControlHeader,
+      "Helicone-Cache-Enabled": "true",
+    })
+  );
+  expect(result.error).toBeNull();
+  return result.data?.cacheControl;
+}
+
+describe("getCacheSettings Cache-Control directive matching", () => {
+  it("uses the real max-age when a vendor x-s-maxage prefix is also present", () => {
+    expect(cacheControlFrom("x-s-maxage=3600, max-age=1800")).toBe(
+      "public, max-age=1800"
+    );
+  });
+
+  it("does not invent an s-maxage TTL from x-s-maxage alone", () => {
+    const cacheControl = cacheControlFrom("x-s-maxage=3600");
+    expect(cacheControl).not.toBe("public, max-age=3600");
+    expect(cacheControl).toBe(`public, max-age=${DEFAULT_CACHE_AGE}`);
+  });
+
+  it("still honors a real s-maxage directive over max-age", () => {
+    expect(cacheControlFrom("s-maxage=3600, max-age=1800")).toBe(
+      "public, max-age=3600"
+    );
+  });
+
+  it("still honors a standalone max-age directive", () => {
+    expect(cacheControlFrom("max-age=1800")).toBe("public, max-age=1800");
+  });
+});


### PR DESCRIPTION
Unanchored `/s-maxage=` and `/max-age=` treated vendor extensions like `x-s-maxage` as the standard directive, so `Cache-Control: x-s-maxage=3600, max-age=1800` became `public, max-age=3600`.

Match only real tokens (start or after `,;` / whitespace). `x-s-maxage` no longer wins over `max-age`.

Fixes #5780