### PR TITLE
fix(cost): Gemini 2.5 cache reads are 10% of input, not 25% (2.5x overcharge)

### DIFF
--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -8871,7 +8871,7 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
           "input": 0.000001,
         },
         "cacheMultipliers": {
-          "cachedInput": 0.25,
+          "cachedInput": 0.1,
           "write5m": 1,
         },
         "cacheStoragePerHour": 0.000001,
@@ -8901,7 +8901,7 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
           "input": 0.000001,
         },
         "cacheMultipliers": {
-          "cachedInput": 0.25,
+          "cachedInput": 0.1,
           "write5m": 1,
         },
         "cacheStoragePerHour": 0.000001,
@@ -8915,11 +8915,11 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
     "google-ai-studio": [
       {
         "audio": {
-          "cachedInputMultiplier": 0.0833333,
+          "cachedInputMultiplier": 0.1,
           "input": 3e-7,
         },
         "cacheMultipliers": {
-          "cachedInput": 0.25,
+          "cachedInput": 0.1,
           "write5m": 1,
         },
         "cacheStoragePerHour": 0.000001,
@@ -8938,11 +8938,11 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
     "vertex": [
       {
         "audio": {
-          "cachedInputMultiplier": 0.0833333,
+          "cachedInputMultiplier": 0.1,
           "input": 3e-7,
         },
         "cacheMultipliers": {
-          "cachedInput": 0.25,
+          "cachedInput": 0.1,
           "write5m": 1,
         },
         "cacheStoragePerHour": 0.000001,
@@ -8956,7 +8956,7 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
     "google-ai-studio": [
       {
         "cacheMultipliers": {
-          "cachedInput": 0.25,
+          "cachedInput": 0.1,
           "write5m": 1,
         },
         "cacheStoragePerHour": 0.0000045,
@@ -8980,7 +8980,7 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
     "vertex": [
       {
         "cacheMultipliers": {
-          "cachedInput": 0.25,
+          "cachedInput": 0.1,
           "write5m": 1,
         },
         "cacheStoragePerHour": 0.0000045,

--- a/packages/cost/models/authors/google/gemini-2.5-flash-lite/endpoints.ts
+++ b/packages/cost/models/authors/google/gemini-2.5-flash-lite/endpoints.ts
@@ -14,10 +14,10 @@ export const endpoints = {
         output: 0.0000004,
         audio: {
           input: 0.0000003, // $0.30/1M audio input tokens
-          cachedInputMultiplier: 0.0833333, // $0.025/1M cached audio (8.33% of input)
+          cachedInputMultiplier: 0.1, // $0.03/1M cached audio (10% of input)
         },
         cacheMultipliers: {
-          cachedInput: 0.25,
+          cachedInput: 0.1, // $0.01/1M = 10% of input
           write5m: 1.0,
         },
         cacheStoragePerHour: 0.000001,
@@ -60,10 +60,10 @@ export const endpoints = {
         output: 0.0000004,
         audio: {
           input: 0.0000003, // $0.30/1M audio input tokens
-          cachedInputMultiplier: 0.0833333, // $0.025/1M cached audio (8.33% of input)
+          cachedInputMultiplier: 0.1, // $0.03/1M cached audio (10% of input)
         },
         cacheMultipliers: {
-          cachedInput: 0.25,
+          cachedInput: 0.1, // $0.01/1M = 10% of input
           write5m: 1.0,
         },
         cacheStoragePerHour: 0.000001,

--- a/packages/cost/models/authors/google/gemini-2.5-flash/endpoints.ts
+++ b/packages/cost/models/authors/google/gemini-2.5-flash/endpoints.ts
@@ -17,7 +17,7 @@ export const endpoints = {
           cachedInputMultiplier: 0.1, // $0.1/1M cached audio (10% of input)
         },
         cacheMultipliers: {
-          cachedInput: 0.25,
+          cachedInput: 0.1, // $0.03/1M = 10% of input
           write5m: 1.0,
         },
         cacheStoragePerHour: 0.000001,
@@ -63,7 +63,7 @@ export const endpoints = {
           cachedInputMultiplier: 0.1, // $0.1/1M cached audio (10% of input)
         },
         cacheMultipliers: {
-          cachedInput: 0.25,
+          cachedInput: 0.1, // $0.03/1M = 10% of input
           write5m: 1.0,
         },
         cacheStoragePerHour: 0.000001,

--- a/packages/cost/models/authors/google/gemini-2.5-pro/endpoints.ts
+++ b/packages/cost/models/authors/google/gemini-2.5-pro/endpoints.ts
@@ -13,7 +13,7 @@ export const endpoints = {
         input: 0.00000125,
         output: 0.00001,
         cacheMultipliers: {
-          cachedInput: 0.25,
+          cachedInput: 0.1, // $0.125/1M = 10% of input
           write5m: 1.0,
         },
         cacheStoragePerHour: 0.0000045,
@@ -60,7 +60,7 @@ export const endpoints = {
         input: 0.00000125,
         output: 0.00001,
         cacheMultipliers: {
-          cachedInput: 0.25,
+          cachedInput: 0.1, // $0.125/1M = 10% of input
           write5m: 1.0,
         },
         cacheStoragePerHour: 0.0000045,


### PR DESCRIPTION
## Ticket

None — found while diffing this registry against Google's published rates.

## Component/Service

- [x] Packages

## Type of Change

- [x] Bug fix

## Deployment Notes

- [x] No special deployment steps required

## Context

All three Gemini 2.5 models price a cache read at **25% of input**. Google publishes **10%** for
every one of them, so cached input is billed at **2.5x**.

25% is not an arbitrary number — it is the ratio for **Gemini 2.0 Flash** ($0.10/M in,
$0.025/M cached). 2.0 Flash was shut down on 2026-06-01. The 2.5 rows are still carrying its
multiplier.

Google's current rates ([ai.google.dev/gemini-api/docs/pricing](https://ai.google.dev/gemini-api/docs/pricing)):

| model | input | context-caching | ratio | this repo |
|---|---|---|---|---|
| `gemini-2.5-pro` | $1.25/M (≤200k) | $0.125/M | 10% | `0.25` |
| `gemini-2.5-pro` | $2.50/M (>200k) | $0.25/M | 10% | — |
| `gemini-2.5-flash` | $0.30/M | $0.03/M | 10% | `0.25` |
| `gemini-2.5-flash-lite` | $0.10/M | $0.01/M | 10% | `0.25` |
| `gemini-2.5-flash-lite` (audio) | $0.30/M | $0.03/M | 10% | `0.0833333` |
| `gemini-2.0-flash` *(deprecated)* | $0.10/M | $0.025/M | **25%** | — |

**The repo already disagrees with itself in two places.** All four Gemini 3.x models use `0.1`:

```
gemini-3/endpoints.ts:16                     cachedInput: 0.1, // $0.2/1M = 10% of input
gemini-3-flash-preview/endpoints.ts:16       cachedInput: 0.1, // $0.05/1M = 10% of input
gemini-3.1-pro-preview/endpoints.ts:17       cachedInput: 0.1, // $0.20/1M = 10% of input
gemini-3.1-flash-lite-preview/endpoints.ts:16 cachedInput: 0.1, // $0.025/1M = 10% of input
```

And inside `gemini-2.5-flash/endpoints.ts` the audio line one block above already reads 10% while
the `cacheMultipliers` block below it reads 25%:

```ts
audio: {
  input: 0.000001,
  cachedInputMultiplier: 0.1,   // $0.1/1M cached audio (10% of input)   <- 10%
},
cacheMultipliers: {
  cachedInput: 0.25,                                                     // <- 25%
```

## What this costs a user

Cache reads dominate agent traffic, so the error lands almost entirely on the token type that
carries the bill. Per 1M cache-read tokens:

| model | billed today | should be |
|---|---|---|
| `gemini-2.5-pro` | $0.3125 | $0.1250 |
| `gemini-2.5-flash` | $0.0750 | $0.0300 |
| `gemini-2.5-flash-lite` | $0.0250 | $0.0100 |

Blended at a coding agent's measured token mix (95.6% cache read / 4.1% cache miss / 0.3%
output, over 8.04B tokens), the reported cost per 1M tokens is **90% / 89% / 97%** too high for
Pro / Flash / Flash-Lite respectively — the bill roughly doubles.

## Changes

Six `cachedInput` values and two `cachedInputMultiplier` values, `google-ai-studio` and `vertex`
blocks in each file:

```
gemini-2.5-pro/endpoints.ts:16,63          cachedInput 0.25 -> 0.1
gemini-2.5-flash/endpoints.ts:20,66        cachedInput 0.25 -> 0.1
gemini-2.5-flash-lite/endpoints.ts:20,66   cachedInput 0.25 -> 0.1
gemini-2.5-flash-lite/endpoints.ts:16,62   cachedInputMultiplier 0.0833333 -> 0.1
```

Snapshot regenerated with `npx jest __tests__/cost/registrySnapshots.test.ts -u`.
`npx jest __tests__/cost` passes: **13 suites, 190 tests, 8 snapshots**.

## Extra Notes

**`cachedInput: 0.25` elsewhere is correct and is not touched.** It appears 29 more times under
`openai/gpt-4.1`, `openai/o3`, `openai/o4`, `openai/gpt-5.1` and `xai/` — OpenAI and xAI really do
discount cached input to 25%. That is exactly why a stale 25% on a Gemini row does not look wrong
on inspection.

**What I verified and what I did not.** I verified the four rates above against the Gemini API
pricing page. I could not get the Vertex AI pricing page to render its tables, so the three
`vertex` lines rest on this repo's own convention — every Gemini 3.x model here carries identical
`cachedInput` on the `google-ai-studio` and `vertex` blocks. If Vertex actually differs, the
`vertex` half of this diff should be dropped and the studio half kept.

**One thing I left alone.** `gemini-2.5-pro`'s `threshold: 200000` tier has `input: 0.0000025` but
no `cacheMultipliers` block at all, so there is no cached-input rate for prompts over 200k. Google
charges $0.25/M there (10% of $2.50). Adding the block would change behaviour for that tier rather
than correct a wrong number, so I did not fold it into this PR — flagging it in case you want it.
