### PR TITLE
docs: fix internal links in prompts-legacy documentation

### DIFF
--- a/docs/features/prompts-legacy/editor.mdx
+++ b/docs/features/prompts-legacy/editor.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Editor"
 sidebarTitle: "UI Managed"
-description: "Design, version, and manage your prompts collaboratively, then [effortlessly deploy them across your app](/features/prompts/generate)."
+description: "Design, version, and manage your prompts collaboratively, then [effortlessly deploy them across your app](/features/prompts-legacy/generate)."
 "twitter:title": "Prompts | Helicone OSS LLM Observability"
 ---
 
@@ -124,7 +124,7 @@ We're excited to launch Auto-Improve, an intelligent prompt optimization tool th
 <Warning>
   **API Migration Notice:** We are actively working on a new Router project that
   will include an updated Generate API. While the previous [Generate API
-  (legacy)](/features/prompts/generate) is still functional (see the notice on
+  (legacy)](/features/prompts-legacy/generate) is still functional (see the notice on
   that page for deprecation timelines), here's a temporary way to import and use
   your UI-managed prompts directly in your code in the meantime:
 </Warning>

--- a/docs/features/prompts-legacy/generate.mdx
+++ b/docs/features/prompts-legacy/generate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Generate API"
 sidebarTitle: "Generate (legacy)"
-description: "Deploy your [Editor](/features/prompts/editor) prompts effortlessly with a light and modern package."
+description: "Deploy your [Editor](/features/prompts-legacy/editor) prompts effortlessly with a light and modern package."
 "twitter:title": "Generate API | Helicone OSS LLM Observability"
 ---
 
@@ -106,7 +106,7 @@ Generates a response using a Helicone prompt.
 #### Parameters
 
 - `input` (string | object): Either a prompt ID string or a parameters object:
-  - `promptId` (string): The ID of the prompt to use, created in the [Prompt Editor](/features/prompts/editor)
+  - `promptId` (string): The ID of the prompt to use, created in the [Prompt Editor](/features/prompts-legacy/editor)
   - `version` (number | "production", optional): The version of the prompt to use. Defaults to "production"
   - `inputs` (object, optional): Variable inputs to use in the prompt, if any
   - `chat` (string[], optional): Chat history for chat-based prompts

--- a/docs/features/prompts-legacy/import.mdx
+++ b/docs/features/prompts-legacy/import.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Import"
 sidebarTitle: "Code Managed"
-description: "Automatically version and manage your prompts from your codebase, or [create and edit them in the UI](/features/prompts/editor)."
+description: "Automatically version and manage your prompts from your codebase, or [create and edit them in the UI](/features/prompts-legacy/editor)."
 "twitter:title": "Prompts | Helicone OSS LLM Observability"
 ---
 
@@ -34,7 +34,7 @@ Once you set up prompts in Helicone, your incoming requests will be matched to a
 
 - version and track iterations of your prompt over time.
 - maintain a dataset of inputs and outputs for each prompt.
-- generate content using predefined prompts through our [Generate API](/features/prompts/generate).
+- generate content using predefined prompts through our [Generate API](/features/prompts-legacy/generate).
 
 ## Quick Start
 


### PR DESCRIPTION
- Update editor.mdx links from /features/prompts/ to /features/prompts-legacy/
- Update generate.mdx links from /features/prompts/ to /features/prompts-legacy/
- Update import.mdx links from /features/prompts/ to /features/prompts-legacy/
- Ensure all cross-references point to correct legacy documentation paths

## Ticket
Link to the ticket(s) this pull request addresses.

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend) 
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [ ] Packages
- [ ] Infrastructure/Docker
- [✅] Documentation

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [✅] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [✅] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
|                      |                   |

## Extra Notes
Any additional context, considerations, or notes for reviewers.

## Context
Why are you making this change?

## Screenshots / Demos
#5790 