### PR TITLE
fix(jawn): repair empty tsoa operator models in routes.ts (prod filter validation regression)

### DIFF
--- a/valhalla/jawn/fix_swagger_operators.py
+++ b/valhalla/jawn/fix_swagger_operators.py
@@ -1,55 +1,106 @@
 """
-Repair empty filter-operator schemas in the tsoa-generated swagger files.
+Repair empty filter-operator models in the tsoa-generated artifacts.
 
-tsoa's type resolver intermittently fails to expand Partial<Record<..., string>>
-aliases from @helicone-package/filters (the result depends on the order in which
-the compiler happens to visit the referencing controllers), leaving schemas like
-Partial_TextOperators_ as an empty object. An empty schema type-checks as
-Record<string, never> downstream and breaks every filter body in the web client.
+tsoa's type resolver intermittently fails to expand the operator aliases from
+@helicone-package/filters (the result depends on the order in which the
+compiler happens to visit the referencing controllers), leaving models such as
+Partial_TextOperators_ as an empty object. That breaks two things:
+
+  * swagger.json -> the web client types every text filter body as
+    Record<string, never>, which fails the web build.
+  * routes.ts    -> TSOA's *runtime* validation (noImplicitAdditionalProperties
+    = throw-on-extras) rejects every filter that uses a text operator with
+    '"..." is an excess property', which broke request filtering in prod on
+    2026-08-31 when only swagger.json was being repaired.
 
 Until tsoa resolves these reliably (see https://github.com/lukeautry/tsoa/issues/911
-for the underlying Record-alias handling), patch the known operator schemas with
-their true expansions, which mirror packages/filters/filterDefs.ts.
+for the underlying alias handling), patch the known operator models in BOTH
+artifacts with their true expansions, which mirror packages/filters/filterDefs.ts,
+and fail the build if any of them is still empty afterwards.
 """
 
 import json
+import re
 import sys
 
-TEXT_OPERATOR_KEYS = ["not-equals", "equals", "like", "ilike", "contains", "not-contains"]
-VECTOR_OPERATOR_KEYS = ["contains"]
-
-REPAIRS = {
-    "Partial_TextOperators_": {
-        "properties": {key: {"type": "string"} for key in TEXT_OPERATOR_KEYS},
-        "type": "object",
-        "description": "Make all properties in T optional",
-    },
-    "Partial_VectorOperators_": {
-        "properties": {key: {"type": "string"} for key in VECTOR_OPERATOR_KEYS},
-        "type": "object",
-        "description": "Make all properties in T optional",
-    },
+# name -> (property keys, swagger type, tsoa dataType)
+OPERATORS = {
+    "Partial_TextOperators_": (
+        ["not-equals", "equals", "like", "ilike", "contains", "not-contains"],
+        "string",
+        "string",
+    ),
+    "Partial_VectorOperators_": (["contains"], "string", "string"),
+    "Partial_NumberOperators_": (
+        ["not-equals", "equals", "gte", "lte", "lt", "gt"],
+        "number",
+        "double",
+    ),
+    "Partial_BooleanOperators_": (["equals"], "boolean", "boolean"),
+    "Partial_TimestampOperators_": (
+        ["equals", "gte", "lte", "lt", "gt"],
+        "string",
+        "string",
+    ),
 }
 
 
-def repair(path: str) -> None:
+def repair_swagger(path: str) -> None:
     with open(path) as f:
         spec = json.load(f)
-
     schemas = spec.get("components", {}).get("schemas", {})
     repaired = []
-    for name, replacement in REPAIRS.items():
+    for name, (keys, swagger_type, _) in OPERATORS.items():
         schema = schemas.get(name)
         if schema is not None and not schema.get("properties"):
-            schemas[name] = replacement
+            schemas[name] = {
+                "properties": {k: {"type": swagger_type} for k in keys},
+                "type": "object",
+                "description": "Make all properties in T optional",
+            }
             repaired.append(name)
-
     if repaired:
         with open(path, "w") as f:
             json.dump(spec, f, indent="\t")
         print(f"{path}: repaired {', '.join(repaired)}")
 
 
+def repair_routes(path: str) -> None:
+    with open(path) as f:
+        src = f.read()
+    repaired = []
+    for name, (keys, _, tsoa_type) in OPERATORS.items():
+        # tsoa emits:  "Partial_X_": {\n  "dataType": "refAlias",\n  "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
+        pattern = re.compile(
+            r'("' + re.escape(name) + r'":\s*\{\s*"dataType":\s*"refAlias",\s*"type":\s*\{"dataType":"nestedObjectLiteral","nestedProperties":)\{\}'
+        )
+        props = json.dumps({k: {"dataType": tsoa_type} for k in keys}, separators=(",", ":"))
+        src, n = pattern.subn(lambda m: m.group(1) + props, src)
+        if n:
+            repaired.append(name)
+    if repaired:
+        with open(path, "w") as f:
+            f.write(src)
+        print(f"{path}: repaired {', '.join(repaired)}")
+    # Fail loudly if a known operator model is still empty.
+    still_empty = [
+        name
+        for name in OPERATORS
+        if re.search(
+            r'"' + re.escape(name) + r'":\s*\{\s*"dataType":\s*"refAlias",\s*"type":\s*\{"dataType":"nestedObjectLiteral","nestedProperties":\{\}',
+            src,
+        )
+    ]
+    if still_empty:
+        print(f"{path}: ERROR operator models still empty after repair: {', '.join(still_empty)}", file=sys.stderr)
+        sys.exit(1)
+
+
 if __name__ == "__main__":
-    for swagger_path in sys.argv[1:]:
-        repair(swagger_path)
+    for p in sys.argv[1:]:
+        if p.endswith(".json"):
+            repair_swagger(p)
+        elif p.endswith(".ts"):
+            repair_routes(p)
+        else:
+            print(f"skipping unknown artifact {p}", file=sys.stderr)

--- a/valhalla/jawn/src/tsoa-build/public/routes.ts
+++ b/valhalla/jawn/src/tsoa-build/public/routes.ts
@@ -610,7 +610,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Partial_TextOperators_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"not-equals":{"dataType":"string"},"equals":{"dataType":"string"},"like":{"dataType":"string"},"ilike":{"dataType":"string"},"contains":{"dataType":"string"},"not-contains":{"dataType":"string"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Partial_NumberOperators_": {

--- a/valhalla/jawn/tsoa_run.sh
+++ b/valhalla/jawn/tsoa_run.sh
@@ -3,5 +3,5 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 npx tsoa spec-and-routes -c tsoa-private.json
 npx tsoa spec-and-routes -c tsoa-public.json
-python3 "$SCRIPT_DIR/fix_swagger_operators.py" src/tsoa-build/public/swagger.json src/tsoa-build/private/swagger.json
+python3 "$SCRIPT_DIR/fix_swagger_operators.py" src/tsoa-build/public/swagger.json src/tsoa-build/private/swagger.json src/tsoa-build/public/routes.ts src/tsoa-build/private/routes.ts
 cp src/tsoa-build/public/swagger.json "$SCRIPT_DIR/../../docs/swagger.json"


### PR DESCRIPTION
**Production hotfix — needs 1 approval to merge, then run `jawn-deployment.yml`.**

Since the 04:37Z deploy of #5801, TSOA runtime validation rejects every request filter that uses a text operator (`equals`/`like`/`contains`/…):

`Caught Validation Error for /v1/request/query-clickhouse — Could not match the union against any of the items … requestBody.filter … is an excess property`

Cause: the experiment removal reshuffled tsoa's type-visit order and it emitted `Partial_TextOperators_` as an empty model. The existing `fix_swagger_operators.py` repaired `swagger.json` (client types) but not `routes.ts`, which is what TSOA validates against at runtime with `throw-on-extras`.

Fix: the repair step now also patches the operator models in `routes.ts` and fails the build if any remain empty; `public/routes.ts` regenerated (its `Partial_TextOperators_` shape is identical to the pre-regression artifact). Jawn `tsc` clean. Worker/web untouched. Mirror of Helicone/helicone-private#15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQcs9hwBaiE9z1k32zYimo