### PR TITLE
fix(cost): warn on unpriced models; add Claude Opus 4.7/4.8/5, Sonnet 5, Fable 5/5.1 pricing

### DIFF
--- a/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
+++ b/packages/__tests__/cost/__snapshots__/registrySnapshots.test.ts.snap
@@ -1165,6 +1165,138 @@ exports[`Registry Snapshots endpoint configurations snapshot 1`] = `
       ],
     },
   },
+  "anthropic/claude-4.7-opus": {
+    "claude-4.7-opus:anthropic": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 128000,
+      "modelId": "claude-opus-4-7",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "anthropic",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+  },
+  "anthropic/claude-4.8-opus": {
+    "claude-4.8-opus:anthropic": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 128000,
+      "modelId": "claude-opus-4-8",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "anthropic",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+  },
+  "anthropic/claude-5-fable": {
+    "claude-5-fable:anthropic": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 128000,
+      "modelId": "claude-fable-5",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "anthropic",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+  },
+  "anthropic/claude-5-opus": {
+    "claude-5-opus:anthropic": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 128000,
+      "modelId": "claude-opus-5",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "anthropic",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+  },
+  "anthropic/claude-5-sonnet": {
+    "claude-5-sonnet:anthropic": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 128000,
+      "modelId": "claude-sonnet-5",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "anthropic",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+  },
+  "anthropic/claude-5.1-fable": {
+    "claude-5.1-fable:anthropic": {
+      "context": 1000000,
+      "crossRegion": false,
+      "maxTokens": 128000,
+      "modelId": "claude-fable-5-1",
+      "parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+      ],
+      "provider": "anthropic",
+      "ptbEnabled": true,
+      "regions": [
+        "*",
+      ],
+    },
+  },
   "anthropic/claude-haiku-4-5-20251001": {
     "claude-haiku-4-5-20251001:anthropic": {
       "context": 200000,
@@ -7372,6 +7504,24 @@ exports[`Registry Snapshots model coverage snapshot 1`] = `
     "helicone",
     "vertex",
   ],
+  "anthropic/claude-4.7-opus": [
+    "anthropic",
+  ],
+  "anthropic/claude-4.8-opus": [
+    "anthropic",
+  ],
+  "anthropic/claude-5-fable": [
+    "anthropic",
+  ],
+  "anthropic/claude-5-opus": [
+    "anthropic",
+  ],
+  "anthropic/claude-5-sonnet": [
+    "anthropic",
+  ],
+  "anthropic/claude-5.1-fable": [
+    "anthropic",
+  ],
   "anthropic/claude-haiku-4-5-20251001": [
     "anthropic",
     "bedrock",
@@ -8299,6 +8449,96 @@ exports[`Registry Snapshots pricing snapshot 1`] = `
         },
         "input": 0.000003,
         "output": 0.000015,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+  },
+  "anthropic/claude-4.7-opus": {
+    "anthropic": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write1h": 2,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+  },
+  "anthropic/claude-4.8-opus": {
+    "anthropic": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write1h": 2,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+  },
+  "anthropic/claude-5-fable": {
+    "anthropic": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write1h": 2,
+          "write5m": 1.25,
+        },
+        "input": 0.00001,
+        "output": 0.00005,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+  },
+  "anthropic/claude-5-opus": {
+    "anthropic": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write1h": 2,
+          "write5m": 1.25,
+        },
+        "input": 0.000005,
+        "output": 0.000025,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+  },
+  "anthropic/claude-5-sonnet": {
+    "anthropic": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.1,
+          "write1h": 2,
+          "write5m": 1.25,
+        },
+        "input": 0.000002,
+        "output": 0.00001,
+        "threshold": 0,
+        "web_search": 0.01,
+      },
+    ],
+  },
+  "anthropic/claude-5.1-fable": {
+    "anthropic": [
+      {
+        "cacheMultipliers": {
+          "cachedInput": 0.025,
+          "write1h": 2,
+          "write5m": 1.25,
+        },
+        "input": 0.00001,
+        "output": 0.00005,
         "threshold": 0,
         "web_search": 0.01,
       },
@@ -10054,6 +10294,42 @@ exports[`Registry Snapshots verify registry state 1`] = `
       ],
     },
     {
+      "model": "claude-4.7-opus",
+      "providers": [
+        "anthropic",
+      ],
+    },
+    {
+      "model": "claude-4.8-opus",
+      "providers": [
+        "anthropic",
+      ],
+    },
+    {
+      "model": "claude-5-fable",
+      "providers": [
+        "anthropic",
+      ],
+    },
+    {
+      "model": "claude-5-opus",
+      "providers": [
+        "anthropic",
+      ],
+    },
+    {
+      "model": "claude-5-sonnet",
+      "providers": [
+        "anthropic",
+      ],
+    },
+    {
+      "model": "claude-5.1-fable",
+      "providers": [
+        "anthropic",
+      ],
+    },
+    {
       "model": "claude-haiku-4-5-20251001",
       "providers": [
         "anthropic",
@@ -10846,7 +11122,7 @@ exports[`Registry Snapshots verify registry state 1`] = `
   ],
   "providerBreakdown": [
     {
-      "modelCount": 15,
+      "modelCount": 21,
       "provider": "anthropic",
     },
     {
@@ -10941,6 +11217,12 @@ exports[`Registry Snapshots verify registry state 1`] = `
     "claude-4.5-sonnet",
     "claude-4.6-opus",
     "claude-4.6-sonnet",
+    "claude-4.7-opus",
+    "claude-4.8-opus",
+    "claude-5-fable",
+    "claude-5-opus",
+    "claude-5-sonnet",
+    "claude-5.1-fable",
     "claude-haiku-4-5-20251001",
     "claude-opus-4",
     "claude-opus-4-1",
@@ -11049,9 +11331,9 @@ exports[`Registry Snapshots verify registry state 1`] = `
     "claude-3.5-haiku:anthropic:*",
   ],
   "totalArchivedConfigs": 0,
-  "totalEndpoints": 329,
-  "totalModelProviderConfigs": 329,
-  "totalModelsWithPtb": 108,
+  "totalEndpoints": 335,
+  "totalModelProviderConfigs": 335,
+  "totalModelsWithPtb": 114,
   "totalProviders": 21,
 }
 `;

--- a/packages/__tests__/cost/modelCostFromRegistry.test.ts
+++ b/packages/__tests__/cost/modelCostFromRegistry.test.ts
@@ -1,6 +1,6 @@
 import type { ModelUsage } from "../../cost/usage/types";
 import type { ModelProviderName } from "../../cost/models/providers";
-import { modelCostBreakdownFromRegistry } from "../../cost/costCalc";
+import { modelCost, modelCostBreakdownFromRegistry } from "../../cost/costCalc";
 
 describe("modelCostBreakdownFromRegistry", () => {
   it("should calculate cost for basic GPT-4o usage", () => {
@@ -435,5 +435,217 @@ describe("modelCostBreakdownFromRegistry", () => {
         expect(breakdown.cachedInputCost).toBe(30000 * 0.000002 * 0.1);
       }
     });
+  });
+});
+
+describe("unpriced model warning", () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  const legacyUsage = {
+    sum_prompt_tokens: 100,
+    prompt_cache_write_tokens: 0,
+    prompt_cache_read_tokens: 0,
+    prompt_audio_tokens: 0,
+    sum_completion_tokens: 50,
+    completion_audio_tokens: 0,
+    prompt_cache_write_5m: 0,
+    prompt_cache_write_1h: 0,
+  };
+
+  it("registry path warns with provider and model when no pricing exists", () => {
+    const breakdown = modelCostBreakdownFromRegistry({
+      modelUsage: { input: 100, output: 50 },
+      providerModelId: "not-a-real-model",
+      provider: "anthropic" as ModelProviderName,
+    });
+
+    expect(breakdown).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0][0]);
+    expect(message).toContain("not-a-real-model");
+    expect(message).toContain("anthropic");
+  });
+
+  it("registry path does not warn when pricing exists", () => {
+    const breakdown = modelCostBreakdownFromRegistry({
+      modelUsage: { input: 100, output: 50 },
+      providerModelId: "gpt-4o",
+      provider: "openai" as ModelProviderName,
+    });
+
+    expect(breakdown).not.toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("legacy modelCost warns and returns 0 when neither the legacy table nor the registry has pricing", () => {
+    const cost = modelCost({
+      provider: "ANTHROPIC",
+      model: "not-a-real-model",
+      ...legacyUsage,
+    });
+
+    expect(cost).toBe(0);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0][0]);
+    expect(message).toContain("not-a-real-model");
+    expect(message).toContain("ANTHROPIC");
+  });
+
+  it("legacy modelCost does not warn for a model the registry prices", () => {
+    // gpt-5.4 has a registry entry but no row in the legacy openai table.
+    // Callers prefer the registry result, so a legacy miss here is not a silent zero.
+    const cost = modelCost({
+      provider: "OPENAI",
+      model: "gpt-5.4",
+      ...legacyUsage,
+    });
+
+    expect(cost).toBe(0);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("legacy modelCost does not warn when the legacy table has pricing", () => {
+    const cost = modelCost({
+      provider: "ANTHROPIC",
+      model: "claude-sonnet-4-6",
+      ...legacyUsage,
+      sum_prompt_tokens: 1_000_000,
+      sum_completion_tokens: 0,
+    });
+
+    expect(cost).toBeCloseTo(3, 10);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("Claude Opus 4.7 / 4.8 / 5, Sonnet 5, Fable 5 / 5.1 pricing (anthropic)", () => {
+  // Rates per https://platform.claude.com/docs/en/about-claude/pricing (per MTok):
+  //   Opus 4.7 / 4.8 / 5: $5 in | $6.25 5m write | $10 1h write | $0.50 cache read | $25 out
+  //   Sonnet 5:           $2 in | $2.50 5m write | $4 1h write  | $0.20 cache read | $10 out
+  //   Fable 5:            $10 in | $12.50 5m write | $20 1h write | $1 cache read | $50 out
+  //   Fable 5.1:          $10 in | $12.50 5m write | $20 1h write | $0.25 cache read (0.025x) | $50 out
+
+  const oneMillionOfEverything: ModelUsage = {
+    input: 1_000_000,
+    output: 1_000_000,
+    cacheDetails: {
+      cachedInput: 1_000_000,
+      write5m: 1_000_000,
+      write1h: 1_000_000,
+    },
+  };
+
+  it("prices the pricing page worked example (50,000 in + 15,000 out at $5/$25) at $0.625 on Opus 4.7, 4.8 and 5", () => {
+    for (const providerModelId of ["claude-opus-4-7", "claude-opus-4-8", "claude-opus-5"]) {
+      const breakdown = modelCostBreakdownFromRegistry({
+        modelUsage: { input: 50_000, output: 15_000 },
+        providerModelId,
+        provider: "anthropic" as ModelProviderName,
+      });
+
+      expect(breakdown).not.toBeNull();
+      expect(breakdown!.inputCost).toBeCloseTo(0.25, 10);
+      expect(breakdown!.outputCost).toBeCloseTo(0.375, 10);
+      expect(breakdown!.totalCost).toBeCloseTo(0.625, 10);
+    }
+  });
+
+  it("applies $6.25 / $10 / $0.50 cache rates on Opus 4.8", () => {
+    const breakdown = modelCostBreakdownFromRegistry({
+      modelUsage: oneMillionOfEverything,
+      providerModelId: "claude-opus-4-8",
+      provider: "anthropic" as ModelProviderName,
+    });
+
+    expect(breakdown).not.toBeNull();
+    expect(breakdown!.inputCost).toBeCloseTo(5, 10);
+    expect(breakdown!.outputCost).toBeCloseTo(25, 10);
+    expect(breakdown!.cacheWrite5mCost).toBeCloseTo(6.25, 10);
+    expect(breakdown!.cacheWrite1hCost).toBeCloseTo(10, 10);
+    expect(breakdown!.cachedInputCost).toBeCloseTo(0.5, 10);
+  });
+
+  it("prices Sonnet 5 at $2 / $10 with $2.50 / $4 / $0.20 cache rates", () => {
+    const breakdown = modelCostBreakdownFromRegistry({
+      modelUsage: oneMillionOfEverything,
+      providerModelId: "claude-sonnet-5",
+      provider: "anthropic" as ModelProviderName,
+    });
+
+    expect(breakdown).not.toBeNull();
+    expect(breakdown!.inputCost).toBeCloseTo(2, 10);
+    expect(breakdown!.outputCost).toBeCloseTo(10, 10);
+    expect(breakdown!.cacheWrite5mCost).toBeCloseTo(2.5, 10);
+    expect(breakdown!.cacheWrite1hCost).toBeCloseTo(4, 10);
+    expect(breakdown!.cachedInputCost).toBeCloseTo(0.2, 10);
+  });
+
+  it("prices Fable 5 at $10 / $50 with a $1 cache read (0.1x)", () => {
+    const breakdown = modelCostBreakdownFromRegistry({
+      modelUsage: oneMillionOfEverything,
+      providerModelId: "claude-fable-5",
+      provider: "anthropic" as ModelProviderName,
+    });
+
+    expect(breakdown).not.toBeNull();
+    expect(breakdown!.inputCost).toBeCloseTo(10, 10);
+    expect(breakdown!.outputCost).toBeCloseTo(50, 10);
+    expect(breakdown!.cacheWrite5mCost).toBeCloseTo(12.5, 10);
+    expect(breakdown!.cacheWrite1hCost).toBeCloseTo(20, 10);
+    expect(breakdown!.cachedInputCost).toBeCloseTo(1, 10);
+  });
+
+  it("prices Fable 5.1 cache reads at $0.25 per MTok (0.025x), not the 0.1x default", () => {
+    const breakdown = modelCostBreakdownFromRegistry({
+      modelUsage: oneMillionOfEverything,
+      providerModelId: "claude-fable-5-1",
+      provider: "anthropic" as ModelProviderName,
+    });
+
+    expect(breakdown).not.toBeNull();
+    expect(breakdown!.inputCost).toBeCloseTo(10, 10);
+    expect(breakdown!.outputCost).toBeCloseTo(50, 10);
+    expect(breakdown!.cacheWrite5mCost).toBeCloseTo(12.5, 10);
+    expect(breakdown!.cacheWrite1hCost).toBeCloseTo(20, 10);
+    expect(breakdown!.cachedInputCost).toBeCloseTo(0.25, 10);
+  });
+
+  it("legacy table prices claude-opus-4-8 and the Fable 5.1 cache rates as well", () => {
+    const opus = modelCost({
+      provider: "ANTHROPIC",
+      model: "claude-opus-4-8",
+      sum_prompt_tokens: 50_000,
+      prompt_cache_write_tokens: 0,
+      prompt_cache_read_tokens: 0,
+      prompt_audio_tokens: 0,
+      sum_completion_tokens: 15_000,
+      completion_audio_tokens: 0,
+      prompt_cache_write_5m: 0,
+      prompt_cache_write_1h: 0,
+    });
+    expect(opus).toBeCloseTo(0.625, 10);
+
+    const fable51 = modelCost({
+      provider: "ANTHROPIC",
+      model: "claude-fable-5-1",
+      sum_prompt_tokens: 0,
+      prompt_cache_write_tokens: 2_000_000,
+      prompt_cache_read_tokens: 1_000_000,
+      prompt_audio_tokens: 0,
+      sum_completion_tokens: 0,
+      completion_audio_tokens: 0,
+      prompt_cache_write_5m: 1_000_000,
+      prompt_cache_write_1h: 1_000_000,
+    });
+    // $0.25 cache read + $12.50 5m write + $20 1h write
+    expect(fable51).toBeCloseTo(32.75, 10);
   });
 });

--- a/packages/cost/costCalc.ts
+++ b/packages/cost/costCalc.ts
@@ -2,6 +2,9 @@ import { costOfPrompt } from "./index";
 import type { ModelUsage } from "./usage/types";
 import type { ModelProviderName } from "./models/providers";
 import { calculateModelCostBreakdown, CostBreakdown } from "./models/calculate-cost";
+import { registry } from "./models/registry";
+import { heliconeProviderToModelProviderName } from "./models/provider-helpers";
+import type { Provider } from "@helicone-package/llm-mapper/types";
 
 // since costs in clickhouse are multiplied by the multiplier
 // divide to get real cost in USD in dollars
@@ -29,22 +32,50 @@ export function modelCost(
     multiple?: number;
   },
 ): number {
-  return (
-    costOfPrompt({
-      provider: params.provider,
-      model: params.model,
-      promptTokens: params.sum_prompt_tokens,
-      promptCacheWriteTokens: params.prompt_cache_write_tokens,
-      promptCacheReadTokens: params.prompt_cache_read_tokens,
-      promptAudioTokens: params.prompt_audio_tokens,
-      completionTokens: params.sum_completion_tokens,
-      completionAudioTokens: params.completion_audio_tokens,
-      promptCacheWrite5m: params.prompt_cache_write_5m,
-      promptCacheWrite1h: params.prompt_cache_write_1h,
-      perCall: params.per_call,
-      images: params.per_image,
-      multiple: params.multiple,
-    }) ?? 0
+  const cost = costOfPrompt({
+    provider: params.provider,
+    model: params.model,
+    promptTokens: params.sum_prompt_tokens,
+    promptCacheWriteTokens: params.prompt_cache_write_tokens,
+    promptCacheReadTokens: params.prompt_cache_read_tokens,
+    promptAudioTokens: params.prompt_audio_tokens,
+    completionTokens: params.sum_completion_tokens,
+    completionAudioTokens: params.completion_audio_tokens,
+    promptCacheWrite5m: params.prompt_cache_write_5m,
+    promptCacheWrite1h: params.prompt_cache_write_1h,
+    perCall: params.per_call,
+    images: params.per_image,
+    multiple: params.multiple,
+  });
+
+  if (cost === null) {
+    warnIfUnpriced(params.provider, params.model);
+    return 0;
+  }
+
+  return cost;
+}
+
+/**
+ * Warn when a model has no pricing in the legacy cost table and none in the
+ * model registry either. Callers prefer the registry result over the legacy
+ * one, so a legacy miss on a model the registry prices is expected and stays
+ * quiet; a miss in both is a request that will be recorded at $0.
+ */
+function warnIfUnpriced(provider: string, model: string): void {
+  const modelProvider = heliconeProviderToModelProviderName(provider as Provider);
+  if (modelProvider) {
+    const registryResult = registry.getModelProviderConfigByProviderModelId(
+      model,
+      modelProvider
+    );
+    if (registryResult.data) {
+      return;
+    }
+  }
+
+  console.warn(
+    `No pricing found for model "${model}" (provider "${provider}") in the legacy cost table or the model registry; recording cost as 0`
   );
 }
 

--- a/packages/cost/models/authors/anthropic/claude-4.7-opus/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-4.7-opus/endpoints.ts
@@ -1,0 +1,43 @@
+import { ModelProviderName } from "../../../providers";
+import type { ModelProviderConfig } from "../../../types";
+import { ClaudeOpus47ModelName } from "./model";
+
+export const endpoints = {
+  "claude-4.7-opus:anthropic": {
+    providerModelId: "claude-opus-4-7",
+    provider: "anthropic",
+    author: "anthropic",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+          write1h: 2.0, // $10 / MTok (200% of $5)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    supportedPlugins: ["web"],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+} satisfies Partial<
+  Record<`${ClaudeOpus47ModelName}:${ModelProviderName}`, ModelProviderConfig>
+>;

--- a/packages/cost/models/authors/anthropic/claude-4.7-opus/model.ts
+++ b/packages/cost/models/authors/anthropic/claude-4.7-opus/model.ts
@@ -1,0 +1,17 @@
+import type { ModelConfig } from "../../../types";
+
+export const models = {
+  "claude-4.7-opus": {
+    name: "Anthropic: Claude Opus 4.7",
+    author: "anthropic",
+    description:
+      "Claude Opus 4.7 is Anthropic's Opus-tier model released April 2026, now a legacy model succeeded by Claude Opus 5. Features a 1M context window, 128K max output, adaptive thinking, and text and image input. API model name: claude-opus-4-7",
+    contextLength: 1000000,
+    maxOutputTokens: 128000,
+    created: "2026-04-16T00:00:00.000Z",
+    modality: { inputs: ["text", "image"], outputs: ["text"] },
+    tokenizer: "Claude",
+  },
+} satisfies Record<string, ModelConfig>;
+
+export type ClaudeOpus47ModelName = keyof typeof models;

--- a/packages/cost/models/authors/anthropic/claude-4.8-opus/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-4.8-opus/endpoints.ts
@@ -1,0 +1,43 @@
+import { ModelProviderName } from "../../../providers";
+import type { ModelProviderConfig } from "../../../types";
+import { ClaudeOpus48ModelName } from "./model";
+
+export const endpoints = {
+  "claude-4.8-opus:anthropic": {
+    providerModelId: "claude-opus-4-8",
+    provider: "anthropic",
+    author: "anthropic",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+          write1h: 2.0, // $10 / MTok (200% of $5)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    supportedPlugins: ["web"],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+} satisfies Partial<
+  Record<`${ClaudeOpus48ModelName}:${ModelProviderName}`, ModelProviderConfig>
+>;

--- a/packages/cost/models/authors/anthropic/claude-4.8-opus/model.ts
+++ b/packages/cost/models/authors/anthropic/claude-4.8-opus/model.ts
@@ -1,0 +1,17 @@
+import type { ModelConfig } from "../../../types";
+
+export const models = {
+  "claude-4.8-opus": {
+    name: "Anthropic: Claude Opus 4.8",
+    author: "anthropic",
+    description:
+      "Claude Opus 4.8 is Anthropic's Opus-tier model released May 2026, now a legacy model succeeded by Claude Opus 5. Features a 1M context window, 128K max output, adaptive thinking, and text and image input. API model name: claude-opus-4-8",
+    contextLength: 1000000,
+    maxOutputTokens: 128000,
+    created: "2026-05-28T00:00:00.000Z",
+    modality: { inputs: ["text", "image"], outputs: ["text"] },
+    tokenizer: "Claude",
+  },
+} satisfies Record<string, ModelConfig>;
+
+export type ClaudeOpus48ModelName = keyof typeof models;

--- a/packages/cost/models/authors/anthropic/claude-5-fable/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-5-fable/endpoints.ts
@@ -1,0 +1,43 @@
+import { ModelProviderName } from "../../../providers";
+import type { ModelProviderConfig } from "../../../types";
+import { ClaudeFable5ModelName } from "./model";
+
+export const endpoints = {
+  "claude-5-fable:anthropic": {
+    providerModelId: "claude-fable-5",
+    provider: "anthropic",
+    author: "anthropic",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.00001, // $10 / MTok
+        output: 0.00005, // $50 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $1 / MTok (10% of $10)
+          write5m: 1.25, // $12.50 / MTok (125% of $10)
+          write1h: 2.0, // $20 / MTok (200% of $10)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    supportedPlugins: ["web"],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+} satisfies Partial<
+  Record<`${ClaudeFable5ModelName}:${ModelProviderName}`, ModelProviderConfig>
+>;

--- a/packages/cost/models/authors/anthropic/claude-5-fable/model.ts
+++ b/packages/cost/models/authors/anthropic/claude-5-fable/model.ts
@@ -1,0 +1,17 @@
+import type { ModelConfig } from "../../../types";
+
+export const models = {
+  "claude-5-fable": {
+    name: "Anthropic: Claude Fable 5",
+    author: "anthropic",
+    description:
+      "Claude Fable 5 is Anthropic's Fable-tier model released June 2026 for demanding reasoning and long-horizon agentic work, now a legacy model succeeded by Claude Fable 5.1. Features a 1M context window, 128K max output, adaptive thinking (always on), and text and image input. API model name: claude-fable-5",
+    contextLength: 1000000,
+    maxOutputTokens: 128000,
+    created: "2026-06-09T00:00:00.000Z",
+    modality: { inputs: ["text", "image"], outputs: ["text"] },
+    tokenizer: "Claude",
+  },
+} satisfies Record<string, ModelConfig>;
+
+export type ClaudeFable5ModelName = keyof typeof models;

--- a/packages/cost/models/authors/anthropic/claude-5-opus/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-5-opus/endpoints.ts
@@ -1,0 +1,43 @@
+import { ModelProviderName } from "../../../providers";
+import type { ModelProviderConfig } from "../../../types";
+import { ClaudeOpus5ModelName } from "./model";
+
+export const endpoints = {
+  "claude-5-opus:anthropic": {
+    providerModelId: "claude-opus-5",
+    provider: "anthropic",
+    author: "anthropic",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000005, // $5 / MTok
+        output: 0.000025, // $25 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.50 / MTok (10% of $5)
+          write5m: 1.25, // $6.25 / MTok (125% of $5)
+          write1h: 2.0, // $10 / MTok (200% of $5)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    supportedPlugins: ["web"],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+} satisfies Partial<
+  Record<`${ClaudeOpus5ModelName}:${ModelProviderName}`, ModelProviderConfig>
+>;

--- a/packages/cost/models/authors/anthropic/claude-5-opus/model.ts
+++ b/packages/cost/models/authors/anthropic/claude-5-opus/model.ts
@@ -1,0 +1,17 @@
+import type { ModelConfig } from "../../../types";
+
+export const models = {
+  "claude-5-opus": {
+    name: "Anthropic: Claude Opus 5",
+    author: "anthropic",
+    description:
+      "Claude Opus 5 is Anthropic's current Opus model, released July 2026, for complex agentic coding and enterprise work. Features a 1M context window, 128K max output, adaptive thinking on by default, and text and image input. API model name: claude-opus-5",
+    contextLength: 1000000,
+    maxOutputTokens: 128000,
+    created: "2026-07-24T00:00:00.000Z",
+    modality: { inputs: ["text", "image"], outputs: ["text"] },
+    tokenizer: "Claude",
+  },
+} satisfies Record<string, ModelConfig>;
+
+export type ClaudeOpus5ModelName = keyof typeof models;

--- a/packages/cost/models/authors/anthropic/claude-5-sonnet/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-5-sonnet/endpoints.ts
@@ -1,0 +1,43 @@
+import { ModelProviderName } from "../../../providers";
+import type { ModelProviderConfig } from "../../../types";
+import { ClaudeSonnet5ModelName } from "./model";
+
+export const endpoints = {
+  "claude-5-sonnet:anthropic": {
+    providerModelId: "claude-sonnet-5",
+    provider: "anthropic",
+    author: "anthropic",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.000002, // $2 / MTok
+        output: 0.00001, // $10 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.1, // $0.20 / MTok (10% of $2)
+          write5m: 1.25, // $2.50 / MTok (125% of $2)
+          write1h: 2.0, // $4 / MTok (200% of $2)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    supportedPlugins: ["web"],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+} satisfies Partial<
+  Record<`${ClaudeSonnet5ModelName}:${ModelProviderName}`, ModelProviderConfig>
+>;

--- a/packages/cost/models/authors/anthropic/claude-5-sonnet/model.ts
+++ b/packages/cost/models/authors/anthropic/claude-5-sonnet/model.ts
@@ -1,0 +1,17 @@
+import type { ModelConfig } from "../../../types";
+
+export const models = {
+  "claude-5-sonnet": {
+    name: "Anthropic: Claude Sonnet 5",
+    author: "anthropic",
+    description:
+      "Claude Sonnet 5 is Anthropic's current Sonnet model, released June 2026, offering the best combination of speed and intelligence. Features a 1M context window, 128K max output, adaptive thinking on by default, and text and image input. API model name: claude-sonnet-5",
+    contextLength: 1000000,
+    maxOutputTokens: 128000,
+    created: "2026-06-30T00:00:00.000Z",
+    modality: { inputs: ["text", "image"], outputs: ["text"] },
+    tokenizer: "Claude",
+  },
+} satisfies Record<string, ModelConfig>;
+
+export type ClaudeSonnet5ModelName = keyof typeof models;

--- a/packages/cost/models/authors/anthropic/claude-5.1-fable/endpoints.ts
+++ b/packages/cost/models/authors/anthropic/claude-5.1-fable/endpoints.ts
@@ -1,0 +1,43 @@
+import { ModelProviderName } from "../../../providers";
+import type { ModelProviderConfig } from "../../../types";
+import { ClaudeFable51ModelName } from "./model";
+
+export const endpoints = {
+  "claude-5.1-fable:anthropic": {
+    providerModelId: "claude-fable-5-1",
+    provider: "anthropic",
+    author: "anthropic",
+    pricing: [
+      {
+        threshold: 0,
+        input: 0.00001, // $10 / MTok
+        output: 0.00005, // $50 / MTok
+        web_search: 0.01, // $10 per 1000 searches (1:1 USD; 10/1K)
+        cacheMultipliers: {
+          cachedInput: 0.025, // $0.25 / MTok (2.5% of $10; 0.025x on Fable 5.1, not the usual 0.1x)
+          write5m: 1.25, // $12.50 / MTok (125% of $10)
+          write1h: 2.0, // $20 / MTok (200% of $10)
+        },
+      },
+    ],
+    contextLength: 1000000,
+    maxCompletionTokens: 128000,
+    supportedParameters: [
+      "max_tokens",
+      "temperature",
+      "stop",
+      "reasoning",
+      "include_reasoning",
+      "tools",
+      "tool_choice",
+    ],
+    supportedPlugins: ["web"],
+    ptbEnabled: true,
+    responseFormat: "ANTHROPIC",
+    endpointConfigs: {
+      "*": {},
+    },
+  },
+} satisfies Partial<
+  Record<`${ClaudeFable51ModelName}:${ModelProviderName}`, ModelProviderConfig>
+>;

--- a/packages/cost/models/authors/anthropic/claude-5.1-fable/model.ts
+++ b/packages/cost/models/authors/anthropic/claude-5.1-fable/model.ts
@@ -1,0 +1,17 @@
+import type { ModelConfig } from "../../../types";
+
+export const models = {
+  "claude-5.1-fable": {
+    name: "Anthropic: Claude Fable 5.1",
+    author: "anthropic",
+    description:
+      "Claude Fable 5.1 is Anthropic's most capable widely released model, released September 2026, for demanding reasoning and long-horizon agentic work. Features a 1M context window, 128K max output, adaptive thinking (always on), text and image input, and cache reads priced at 0.025x the base input price. API model name: claude-fable-5-1",
+    contextLength: 1000000,
+    maxOutputTokens: 128000,
+    created: "2026-09-01T00:00:00.000Z",
+    modality: { inputs: ["text", "image"], outputs: ["text"] },
+    tokenizer: "Claude",
+  },
+} satisfies Record<string, ModelConfig>;
+
+export type ClaudeFable51ModelName = keyof typeof models;

--- a/packages/cost/models/authors/anthropic/index.ts
+++ b/packages/cost/models/authors/anthropic/index.ts
@@ -21,6 +21,12 @@ import { models as claudeOpus4120250805Models } from "./claude-opus-4-1-20250805
 import { models as claudeOpus45Models } from "./claude-4.5-opus/model";
 import { models as claudeOpus46Models } from "./claude-4.6-opus/model";
 import { models as claudeSonnet46Models } from "./claude-4.6-sonnet/model";
+import { models as claudeOpus47Models } from "./claude-4.7-opus/model";
+import { models as claudeOpus48Models } from "./claude-4.8-opus/model";
+import { models as claudeOpus5Models } from "./claude-5-opus/model";
+import { models as claudeSonnet5Models } from "./claude-5-sonnet/model";
+import { models as claudeFable5Models } from "./claude-5-fable/model";
+import { models as claudeFable51Models } from "./claude-5.1-fable/model";
 
 // Import endpoints
 import { endpoints as claudeOpus41Endpoints } from "./claude-opus-4-1/endpoints";
@@ -38,6 +44,12 @@ import { endpoints as claudeOpus4120250805Endpoints } from "./claude-opus-4-1-20
 import { endpoints as claudeOpus45Endpoints } from "./claude-4.5-opus/endpoints";
 import { endpoints as claudeOpus46Endpoints } from "./claude-4.6-opus/endpoints";
 import { endpoints as claudeSonnet46Endpoints } from "./claude-4.6-sonnet/endpoints";
+import { endpoints as claudeOpus47Endpoints } from "./claude-4.7-opus/endpoints";
+import { endpoints as claudeOpus48Endpoints } from "./claude-4.8-opus/endpoints";
+import { endpoints as claudeOpus5Endpoints } from "./claude-5-opus/endpoints";
+import { endpoints as claudeSonnet5Endpoints } from "./claude-5-sonnet/endpoints";
+import { endpoints as claudeFable5Endpoints } from "./claude-5-fable/endpoints";
+import { endpoints as claudeFable51Endpoints } from "./claude-5.1-fable/endpoints";
 
 // Aggregate models
 export const anthropicModels = {
@@ -56,6 +68,12 @@ export const anthropicModels = {
   ...claudeOpus45Models,
   ...claudeOpus46Models,
   ...claudeSonnet46Models,
+  ...claudeOpus47Models,
+  ...claudeOpus48Models,
+  ...claudeOpus5Models,
+  ...claudeSonnet5Models,
+  ...claudeFable5Models,
+  ...claudeFable51Models,
 } satisfies Record<string, ModelConfig>;
 
 // Aggregate endpoints
@@ -75,4 +93,10 @@ export const anthropicEndpointConfig = {
   ...claudeOpus45Endpoints,
   ...claudeOpus46Endpoints,
   ...claudeSonnet46Endpoints,
+  ...claudeOpus47Endpoints,
+  ...claudeOpus48Endpoints,
+  ...claudeOpus5Endpoints,
+  ...claudeSonnet5Endpoints,
+  ...claudeFable5Endpoints,
+  ...claudeFable51Endpoints,
 } satisfies Record<string, ModelProviderConfig>;

--- a/packages/cost/models/calculate-cost.ts
+++ b/packages/cost/models/calculate-cost.ts
@@ -178,7 +178,12 @@ export function calculateModelCostBreakdown(params: {
     providerModelId,
     provider,
   );
-  if (configResult.error || !configResult.data) return null;
+  if (configResult.error || !configResult.data) {
+    console.warn(
+      `No pricing found in the model registry for providerModelId "${providerModelId}" (provider "${provider}"); cost cannot be calculated`
+    );
+    return null;
+  }
 
   const config: ModelProviderConfig = configResult.data;
 

--- a/packages/cost/providers/anthropic/index.ts
+++ b/packages/cost/providers/anthropic/index.ts
@@ -288,6 +288,90 @@ export const costs: ModelRow[] = [
     },
     showInPlayground: true,
   },
+  {
+    model: {
+      operator: "equals",
+      value: "claude-opus-4-7",
+    },
+    cost: {
+      prompt_token: 0.000005, // $5 / MTok
+      completion_token: 0.000025, // $25 / MTok
+      prompt_cache_write_token: 0.00000625, // 5m cache write: $6.25 / MTok
+      prompt_cache_read_token: 0.0000005, // Cache hits/refreshes: $0.50 / MTok
+      prompt_cache_creation_5m: 0.00000625, // $6.25 / MTok
+      prompt_cache_creation_1h: 0.00001, // 1h cache write: $10 / MTok
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "claude-opus-4-8",
+    },
+    cost: {
+      prompt_token: 0.000005, // $5 / MTok
+      completion_token: 0.000025, // $25 / MTok
+      prompt_cache_write_token: 0.00000625, // 5m cache write: $6.25 / MTok
+      prompt_cache_read_token: 0.0000005, // Cache hits/refreshes: $0.50 / MTok
+      prompt_cache_creation_5m: 0.00000625, // $6.25 / MTok
+      prompt_cache_creation_1h: 0.00001, // 1h cache write: $10 / MTok
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "claude-opus-5",
+    },
+    cost: {
+      prompt_token: 0.000005, // $5 / MTok
+      completion_token: 0.000025, // $25 / MTok
+      prompt_cache_write_token: 0.00000625, // 5m cache write: $6.25 / MTok
+      prompt_cache_read_token: 0.0000005, // Cache hits/refreshes: $0.50 / MTok
+      prompt_cache_creation_5m: 0.00000625, // $6.25 / MTok
+      prompt_cache_creation_1h: 0.00001, // 1h cache write: $10 / MTok
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "claude-sonnet-5",
+    },
+    cost: {
+      prompt_token: 0.000002, // $2 / MTok
+      completion_token: 0.00001, // $10 / MTok
+      prompt_cache_write_token: 0.0000025, // 5m cache write: $2.50 / MTok
+      prompt_cache_read_token: 0.0000002, // Cache hits/refreshes: $0.20 / MTok
+      prompt_cache_creation_5m: 0.0000025, // $2.50 / MTok
+      prompt_cache_creation_1h: 0.000004, // 1h cache write: $4 / MTok
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "claude-fable-5",
+    },
+    cost: {
+      prompt_token: 0.00001, // $10 / MTok
+      completion_token: 0.00005, // $50 / MTok
+      prompt_cache_write_token: 0.0000125, // 5m cache write: $12.50 / MTok
+      prompt_cache_read_token: 0.000001, // Cache hits/refreshes: $1 / MTok
+      prompt_cache_creation_5m: 0.0000125, // $12.50 / MTok
+      prompt_cache_creation_1h: 0.00002, // 1h cache write: $20 / MTok
+    },
+  },
+  {
+    model: {
+      operator: "equals",
+      value: "claude-fable-5-1",
+    },
+    cost: {
+      prompt_token: 0.00001, // $10 / MTok
+      completion_token: 0.00005, // $50 / MTok
+      prompt_cache_write_token: 0.0000125, // 5m cache write: $12.50 / MTok
+      prompt_cache_read_token: 0.00000025, // Cache hits/refreshes: $0.25 / MTok (0.025x on Fable 5.1)
+      prompt_cache_creation_5m: 0.0000125, // $12.50 / MTok
+      prompt_cache_creation_1h: 0.00002, // 1h cache write: $20 / MTok
+    },
+  },
 ];
 
 export const modelDetails: ModelDetailsMap = {


### PR DESCRIPTION
## Ticket
None.

## Component/Service
What part of Helicone does this affect?
- [ ] Web (Frontend)
- [ ] Jawn (Backend)
- [ ] Worker (Proxy)
- [ ] Bifrost (Marketing)
- [ ] AI Gateway
- [x] Packages
- [ ] Infrastructure/Docker
- [ ] Documentation

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Deployment Notes
- [x] No special deployment steps required
- [ ] Database migrations need to run
- [ ] Environment variable changes required
- [ ] Coordination with other teams needed

## Screenshots / Demos
| **Before**   |  **After**  |
|-------------|-----------|
| `claude-opus-4-8`, 50,000 input + 15,000 output tokens: cost recorded as **$0.00**, token counts correct, nothing logged | Same request: **$0.625** (50,000 × $5/M + 15,000 × $25/M) |
| Any model absent from both pricing tables: `null` / `0`, silently | Still `null` / `0`, plus one `console.warn` naming the provider and model |

## Extra Notes

### Part 1: make an unpriced model loud

- `packages/cost/models/calculate-cost.ts`: on a registry miss, `console.warn` with the `providerModelId` and `provider` before returning `null` (the return type is unchanged).
- `packages/cost/costCalc.ts`: `modelCost` still returns `0` when `costOfPrompt` returns `null`, but now warns first. The warning is suppressed when the model registry has an entry for the same model and provider: Jawn calls `modelCost` on every non-gateway request before the registry path, and `LoggingHandler` prefers the registry result, so a legacy miss on a registry-priced model (for example `gpt-5.4`, which has no legacy row) is expected and would otherwise warn on every request.
- No persisted values, schemas, or return types change. `console.warn` matches the existing logging in this package (`unified/providers.ts`).
- One line per miss, not deduplicated; the fix for a noisy log is to add the missing pricing. The Worker's own legacy fallback (`ProxyForwarder.ts`, `costOfPrompt(...) ?? 0`) is not touched; it already goes through the registry warning first.

### Part 2: Claude models missing from the registry

Added `packages/cost/models/authors/anthropic/{claude-4.7-opus,claude-4.8-opus,claude-5-opus,claude-5-sonnet,claude-5-fable,claude-5.1-fable}` (each with `model.ts` and `endpoints.ts`, mirroring `claude-4.6-sonnet`), wired into `authors/anthropic/index.ts`, plus `equals` rows in the legacy table `packages/cost/providers/anthropic/index.ts`.

| Model | API id | Input | 5m write | 1h write | Cache read | Output |
|---|---|---|---|---|---|---|
| Claude Opus 4.7 | `claude-opus-4-7` | $5 | $6.25 | $10 | $0.50 | $25 |
| Claude Opus 4.8 | `claude-opus-4-8` | $5 | $6.25 | $10 | $0.50 | $25 |
| Claude Opus 5 | `claude-opus-5` | $5 | $6.25 | $10 | $0.50 | $25 |
| Claude Sonnet 5 | `claude-sonnet-5` | $2 | $2.50 | $4 | $0.20 | $10 |
| Claude Fable 5 | `claude-fable-5` | $10 | $12.50 | $20 | $1 | $50 |
| Claude Fable 5.1 | `claude-fable-5-1` | $10 | $12.50 | $20 | $0.25 | $50 |

All per MTok. Multipliers are the standard 1.25x / 2x / 0.1x, except the Fable 5.1 cache read, which is 0.025x and set explicitly because the engine has no default for it. Context 1M, max output 128K, `created` set to each model's release date, all from the model pages listed below.

Choices a reviewer may want to change:
- Only `:anthropic` endpoints are added. Bedrock, Vertex and OpenRouter rates are on other pages that I did not verify, and no `pa/` Helicone endpoint is assumed to exist.
- `ptbEnabled: true` matches every other `:anthropic` entry. Flip to `false` if pass-through billing should not be offered for these models yet.
- `supportedParameters` and `supportedPlugins` mirror the 4.6 entries. The Sonnet 5 model page notes that non-default `temperature`/`top_p`/`top_k` return a 400 on that model; I left the informational list unchanged rather than guess at gateway behaviour.
- Legacy rows use `equals` so that `claude-fable-5` cannot match `claude-fable-5-1`, which has a different cache read rate.

Deliberately left out:
- `gpt-5.5` and Gemini 3.5/3.6/3.7 Flash, which are also missing from the registry; this PR only adds models whose full rate row I verified on Anthropic's pricing page.
- Claude Mythos 5 / 5.1 (limited availability).
- `modelDetails` entries, `unified/models.ts` playground mappings and the Stripe meter list; none of them affect cost calculation.

### Tests

- `packages/__tests__/cost/modelCostFromRegistry.test.ts`: 11 new tests. Five cover the warning (registry miss warns with provider and model; registry hit does not; legacy miss on a model unknown to both tables warns and returns 0; legacy miss on a registry-priced model does not warn; legacy hit does not warn). Six cover the new models, including the pricing page's worked example (50,000 in + 15,000 out at $5/$25 = $0.625) on Opus 4.7/4.8/5, the cache rates on Sonnet 5 and Fable 5, the 0.025x Fable 5.1 cache read, and the legacy rows for Opus 4.8 and Fable 5.1.
- Before this change: 8 of the 11 new tests fail (the three "does not warn" cases pass trivially). After: all 11 pass.
- `packages/__tests__/cost`: 13 suites, 201 tests, 8 snapshots pass (190 tests before this change). `registrySnapshots.test.ts.snap` was updated with `-u`; the diff adds the six new entries and bumps `modelCount` 15 → 21, `totalEndpoints` / `totalModelProviderConfigs` 329 → 335, `totalModelsWithPtb` 108 → 114, nothing else.

### Sources (fetched 2026-09-02)

https://platform.claude.com/docs/en/about-claude/pricing, model pricing table rows as shown:

```
| Claude Fable 5.1 | $10 / MTok | $12.50 / MTok | $20 / MTok | $0.25 / MTok1 | $50 / MTok |
| Claude Fable 5   | $10 / MTok | $12.50 / MTok | $20 / MTok | $1 / MTok     | $50 / MTok |
| Claude Opus 5    | $5 / MTok  | $6.25 / MTok  | $10 / MTok | $0.50 / MTok  | $25 / MTok |
| Claude Opus 4.8  | $5 / MTok  | $6.25 / MTok  | $10 / MTok | $0.50 / MTok  | $25 / MTok |
| Claude Opus 4.7  | $5 / MTok  | $6.25 / MTok  | $10 / MTok | $0.50 / MTok  | $25 / MTok |
| Claude Sonnet 5  | $2 / MTok  | $2.50 / MTok  | $4 / MTok  | $0.20 / MTok  | $10 / MTok |
```
(columns: Base input tokens | 5m cache writes | 1h cache writes | Cache hits and refreshes | Output tokens)

> *1 Cache hits and refreshes on Claude Fable 5.1 and Claude Mythos 5.1 are priced at 0.025x the base input price. All other models use the standard 0.1x multiplier.*

> The $2/$10 per million input/output token pricing for Claude Sonnet 5, announced at launch as introductory pricing through August 31, 2026, is now the standard price.

> Web search is available on the Claude API for **$10 per 1,000 searches**

Worked example on the same page (Claude Opus 5): "Input tokens | 50,000 × $5 / 1,000,000 | $0.25" and "Output tokens | 15,000 × $25 / 1,000,000 | $0.375".

Model ids, release dates, context window and max output: https://platform.claude.com/docs/en/models/overview and the per-model pages `models/opus-4-7/overview`, `models/opus-4-8/overview`, `models/opus-5/overview`, `models/sonnet-5/overview`, `models/fable-5/overview`, `models/fable-5-1/overview` (each states "Model ID", "Released", "Context window: 1M tokens", "Max output: 128K tokens"). The overview page notes: "Every Claude model ID is a pinned snapshot, including the dateless IDs used from the 4.6 generation on."

## Context
Why are you making this change?

A registry lookup is an exact `${providerModelId}:${provider}` match (`registry.ts`). When it misses, `calculateModelCostBreakdown` returns `null` (`calculate-cost.ts`), Jawn skips the breakdown (`ResponseBodyHandler.ts`), the legacy `costOfPrompt` also returns `null`, `modelCost` turns that into `0` (`costCalc.ts`), and `LoggingHandler.ts` stores `atLeastZero(... ?? 0)`. Nothing on that path logs, so every request for a model that is not in the tables is recorded at $0.00 with correct token counts, and dashboard spend for a whole model family silently reads zero.

Today that covers every Anthropic model released after Claude 4.6. Anthropic's own worked example (50,000 input + 15,000 output tokens on Opus 5 at $5 / $25 per MTok) is billed at $0.625 and recorded by Helicone as $0.00; the same holds for `claude-opus-4-8`, which is priced identically. This PR makes the miss visible and adds the six Anthropic models whose full rate row is on the pricing page.

## Screenshots / Demos
See the table above.
