### PR TITLE
fix: preserve signed body association in Python export example

### DIFF
--- a/examples/export/python/export.py
+++ b/examples/export/python/export.py
@@ -148,15 +148,20 @@ async def fetch_signed_body_async(session: aiohttp.ClientSession, url: str) -> D
 
 async def fetch_all_signed_bodies(data: List[ResponseData]):
     async with aiohttp.ClientSession() as session:
-        tasks = [fetch_signed_body_async(
-            session, d.signed_body_url) for d in data]
-        for d, task in zip(data, asyncio.as_completed(tasks)):
+        async def fetch_for_response(d: ResponseData):
             try:
-                d.signed_body_content = await task
+                content = await fetch_signed_body_async(
+                    session, d.signed_body_url)
+                return d, content
             except Exception as e:
                 print(
                     f"Failed to fetch or decode signed_body_url for response_id {d.response_id}: {e}")
                 raise e
+
+        tasks = [fetch_for_response(d) for d in data]
+        for task in asyncio.as_completed(tasks):
+            d, content = await task
+            d.signed_body_content = content
 
 
 def write_data_to_csv(data: List[ResponseData], file_name: str):


### PR DESCRIPTION
## Ticket

Related pull request: #4382

## Component/Service

Python export example (`examples/export/python`)

## Type of Change
- [X] Bug fix

## Deployment Notes
- [X] No special deployment steps required

## Context

`fetch_all_signed_bodies()` pairs responses in source order with signed-body results in _completion_ order. When requests finish out of order, a body can be written to the wrong response's CSV row. A failed request can also be reported under the wrong response ID.

This change carries each response through its signed-body fetch. Each completed body is assigned to the response that supplied its URL, while fetching stays concurrent.

## Extra Notes
`examples/export/python` has no test configuration or adjacent test suite, so I verified the reverse-completion regression with a deterministic local harness.

- Forced the second request to finish before the first. The previous code swapped the bodies; this change retained the correct response-to-body mapping.
- Forced the second request to fail first. This change reported the correct response ID.
- Repeated both cases under Python 3.12 and 3.14.
- Compiled the complete example under Python 3.12 and 3.14.